### PR TITLE
fix: close upload download IDOR (#1)

### DIFF
--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -10,6 +10,7 @@ import {
   Res,
   BadRequestException,
   NotFoundException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { AuthGuard } from '@nestjs/passport';
@@ -18,6 +19,8 @@ import { createReadStream, existsSync, mkdirSync } from 'fs';
 import { extname, join, basename } from 'path';
 import { randomUUID } from 'crypto';
 import type { Request, Response } from 'express';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { UploadsService } from './uploads.service';
 
 const UPLOAD_DIR = join(process.cwd(), 'uploads');
 const ALLOWED_MIME = new Set([
@@ -31,9 +34,13 @@ const ALLOWED_MIME = new Set([
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 ]);
 
+type AuthedRequest = Request & { user?: AuthenticatedUser };
+
 @Controller('uploads')
 @UseGuards(AuthGuard('clerk-jwt'))
 export class UploadsController {
+  constructor(private readonly uploadsService: UploadsService) {}
+
   @Post('patient-documents')
   @UseInterceptors(
     FileInterceptor('file', {
@@ -63,8 +70,11 @@ export class UploadsController {
   )
   uploadPatientDocument(
     @UploadedFile() file: Express.Multer.File,
-    @Req() req: Request,
+    @Req() req: AuthedRequest,
   ) {
+    if (!req.user) throw new ForbiddenException('Authentication required');
+    this.uploadsService.assertCanUpload(req.user);
+
     if (!file) throw new BadRequestException('file is required');
     const base =
       process.env.API_PUBLIC_URL?.replace(/\/$/, '') ||
@@ -77,13 +87,25 @@ export class UploadsController {
     };
   }
 
-  /** Authenticated download — replaces public static serving of PHI. */
+  /**
+   * Authenticated, hospital/patient-scoped download.
+   * Replaces public static serving of PHI; requires a matching patient_documents row.
+   */
   @Get(':filename')
-  download(@Param('filename') filename: string, @Res() res: Response) {
+  async download(
+    @Param('filename') filename: string,
+    @Req() req: AuthedRequest,
+    @Res() res: Response,
+  ) {
+    if (!req.user) throw new ForbiddenException('Authentication required');
+
     const safe = basename(filename);
     if (safe !== filename || safe.includes('..')) {
       throw new BadRequestException('Invalid filename');
     }
+
+    await this.uploadsService.assertCanDownload(safe, req.user);
+
     const path = join(UPLOAD_DIR, safe);
     if (!existsSync(path)) throw new NotFoundException('File not found');
     res.setHeader('Content-Disposition', `inline; filename="${safe}"`);

--- a/apps/api/src/uploads/uploads.module.ts
+++ b/apps/api/src/uploads/uploads.module.ts
@@ -1,9 +1,17 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
+import { Patient, PatientDocument } from '../database/entities';
 import { UploadsController } from './uploads.controller';
+import { UploadsService } from './uploads.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [
+    AuthModule,
+    TypeOrmModule.forFeature([PatientDocument, Patient]),
+  ],
   controllers: [UploadsController],
+  providers: [UploadsService],
+  exports: [UploadsService],
 })
 export class UploadsModule {}

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -1,0 +1,165 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Patient, PatientDocument } from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { UploadsService } from './uploads.service';
+
+describe('UploadsService', () => {
+  let service: UploadsService;
+
+  const documentsRepo = {
+    findOne: jest.fn(),
+  };
+  const patientsRepo = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UploadsService,
+        {
+          provide: getRepositoryToken(PatientDocument),
+          useValue: documentsRepo,
+        },
+        { provide: getRepositoryToken(Patient), useValue: patientsRepo },
+      ],
+    }).compile();
+
+    service = module.get(UploadsService);
+  });
+
+  const staffUser: AuthenticatedUser = {
+    id: 'staff-1',
+    authId: 'auth-staff',
+    email: 'doctor@hospital-a.com',
+    fullName: 'Dr A',
+    hospitalId: 'hospital-a',
+    roles: ['doctor'],
+    permissions: ['patients:read', 'patients:write'],
+    onboardingCompleted: true,
+  };
+
+  const patientUser: AuthenticatedUser = {
+    id: 'user-patient-1',
+    authId: 'auth-patient',
+    email: 'patient@example.com',
+    fullName: 'Pat',
+    hospitalId: undefined,
+    roles: ['patient'],
+    permissions: [],
+    onboardingCompleted: true,
+  };
+
+  describe('assertCanUpload', () => {
+    it('allows staff with patients:write', () => {
+      expect(() => service.assertCanUpload(staffUser)).not.toThrow();
+    });
+
+    it('allows super_admin', () => {
+      expect(() =>
+        service.assertCanUpload({
+          ...staffUser,
+          roles: ['super_admin'],
+          permissions: [],
+        }),
+      ).not.toThrow();
+    });
+
+    it('denies patient role', () => {
+      expect(() => service.assertCanUpload(patientUser)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('denies staff without patients:write', () => {
+      expect(() =>
+        service.assertCanUpload({
+          ...staffUser,
+          permissions: ['patients:read'],
+        }),
+      ).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('assertCanDownload', () => {
+    const document = {
+      id: 'doc-1',
+      patientId: 'patient-1',
+      fileUrl: 'http://localhost:4000/uploads/abc.pdf',
+      name: 'lab.pdf',
+    };
+
+    const patient = {
+      id: 'patient-1',
+      hospitalId: 'hospital-a',
+      userId: 'user-patient-1',
+    };
+
+    it('throws NotFound when no document row matches', async () => {
+      documentsRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.assertCanDownload('missing.pdf', staffUser),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('allows same-hospital staff with patients:read', async () => {
+      documentsRepo.findOne.mockResolvedValue(document);
+      patientsRepo.findOne.mockResolvedValue(patient);
+
+      await expect(
+        service.assertCanDownload('abc.pdf', staffUser),
+      ).resolves.toEqual(document);
+    });
+
+    it('denies staff from another hospital', async () => {
+      documentsRepo.findOne.mockResolvedValue(document);
+      patientsRepo.findOne.mockResolvedValue(patient);
+
+      await expect(
+        service.assertCanDownload('abc.pdf', {
+          ...staffUser,
+          hospitalId: 'hospital-b',
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('allows linked patient for their own document', async () => {
+      documentsRepo.findOne.mockResolvedValue(document);
+      patientsRepo.findOne.mockResolvedValue(patient);
+
+      await expect(
+        service.assertCanDownload('abc.pdf', patientUser),
+      ).resolves.toEqual(document);
+    });
+
+    it('denies patient for another patient document', async () => {
+      documentsRepo.findOne.mockResolvedValue(document);
+      patientsRepo.findOne.mockResolvedValue({
+        ...patient,
+        userId: 'other-user',
+      });
+
+      await expect(
+        service.assertCanDownload('abc.pdf', patientUser),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('allows super_admin across hospitals', async () => {
+      documentsRepo.findOne.mockResolvedValue(document);
+      patientsRepo.findOne.mockResolvedValue(patient);
+
+      await expect(
+        service.assertCanDownload('abc.pdf', {
+          ...staffUser,
+          roles: ['super_admin'],
+          hospitalId: undefined,
+          permissions: [],
+        }),
+      ).resolves.toEqual(document);
+    });
+  });
+});

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -1,0 +1,89 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Like, Repository } from 'typeorm';
+import { PERMISSIONS } from '@careconnect/types';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { Patient, PatientDocument } from '../database/entities';
+
+@Injectable()
+export class UploadsService {
+  constructor(
+    @InjectRepository(PatientDocument)
+    private readonly documentsRepo: Repository<PatientDocument>,
+    @InjectRepository(Patient)
+    private readonly patientsRepo: Repository<Patient>,
+  ) {}
+
+  /**
+   * Authorize download of a stored file by resolving it to a patient_documents
+   * row and checking hospital membership / patient ownership.
+   */
+  async assertCanDownload(
+    filename: string,
+    user: AuthenticatedUser,
+  ): Promise<PatientDocument> {
+    const document = await this.findDocumentByFilename(filename);
+    if (!document) {
+      throw new NotFoundException('File not found');
+    }
+
+    const patient = await this.patientsRepo.findOne({
+      where: { id: document.patientId },
+    });
+    if (!patient) {
+      throw new NotFoundException('File not found');
+    }
+
+    if (user.roles.includes('super_admin')) {
+      return document;
+    }
+
+    // Linked patient portal user: only their own documents
+    if (user.roles.includes('patient')) {
+      if (patient.userId && patient.userId === user.id) {
+        return document;
+      }
+      throw new ForbiddenException('Access denied');
+    }
+
+    // Hospital staff: same hospital + patients:read (or write)
+    if (
+      user.hospitalId &&
+      user.hospitalId === patient.hospitalId &&
+      (user.permissions.includes(PERMISSIONS.PATIENTS_READ) ||
+        user.permissions.includes(PERMISSIONS.PATIENTS_WRITE))
+    ) {
+      return document;
+    }
+
+    throw new ForbiddenException('Access denied');
+  }
+
+  /** Staff with patients:write may upload PHI documents. */
+  assertCanUpload(user: AuthenticatedUser): void {
+    if (user.roles.includes('super_admin')) return;
+    if (user.permissions.includes(PERMISSIONS.PATIENTS_WRITE)) return;
+    throw new ForbiddenException(
+      'patients:write permission required to upload documents',
+    );
+  }
+
+  private async findDocumentByFilename(
+    filename: string,
+  ): Promise<PatientDocument | null> {
+    // fileUrl is stored as absolute URL ending in /uploads/<filename>
+    const bySuffix = await this.documentsRepo.findOne({
+      where: { fileUrl: Like(`%/uploads/${filename}`) },
+    });
+    if (bySuffix) return bySuffix;
+
+    // Fallback: exact filename match for relative paths
+    return this.documentsRepo.findOne({
+      where: { fileUrl: filename },
+    });
+  }
+}

--- a/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
@@ -59,16 +59,31 @@ export default function PatientDetailPage() {
 
   const patient = data?.patient;
 
+  const apiBase = (
+    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql'
+  ).replace(/\/graphql\/?$/, '');
+
+  const handleOpenDocument = async (fileUrl: string) => {
+    const token = await getToken();
+    const res = await fetch(fileUrl, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) {
+      setUploadError('Unable to open document');
+      return;
+    }
+    const blob = await res.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    window.open(objectUrl, '_blank', 'noopener,noreferrer');
+    // Revoke after the browser has a chance to load the tab
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+  };
+
   const handleUpload = async (file: File) => {
     setUploading(true);
     setUploadError('');
     try {
       const token = await getToken();
-      const apiBase =
-        (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql').replace(
-          /\/graphql\/?$/,
-          '',
-        );
       const form = new FormData();
       form.append('file', file);
       const uploadRes = await fetch(`${apiBase}/uploads/patient-documents`, {
@@ -286,15 +301,14 @@ export default function PatientDetailPage() {
                   key={d.id}
                   className="flex items-center gap-3 rounded-2xl bg-clay-primary-light/30 p-3"
                 >
-                  <a
-                    href={d.fileUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex min-w-0 flex-1 items-center gap-3 hover:opacity-80"
+                  <button
+                    type="button"
+                    onClick={() => handleOpenDocument(d.fileUrl)}
+                    className="flex min-w-0 flex-1 items-center gap-3 text-left hover:opacity-80"
                   >
                     <FileText className="h-5 w-5 shrink-0 text-clay-primary" />
                     <span className="truncate text-sm text-clay-text">{d.name}</span>
-                  </a>
+                  </button>
                   <ClayButton
                     size="sm"
                     variant="ghost"


### PR DESCRIPTION
## Summary
- Authorize `GET /uploads/:filename` against `patient_documents` + hospital membership (staff) or linked patient ownership
- Require `patients:write` for `POST /uploads/patient-documents`
- Open patient documents via authenticated fetch so the Bearer JWT is sent
- Add unit tests for upload/download authorization

Closes #1

## Test plan
- [x] Unit tests for `UploadsService` (10 passing)
- [ ] Unauthenticated download returns 401
- [ ] Staff from another hospital cannot download
- [ ] Linked patient can download only their documents
- [ ] Upload without `patients:write` returns 403


Made with [Cursor](https://cursor.com)