### PR TITLE
fix: reject cross-hospital staff invites (#2)

### DIFF
--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -1,4 +1,8 @@
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
@@ -40,7 +44,10 @@ describe('StaffService', () => {
     create: jest.fn(),
     findOne: jest.fn(),
   };
-  const clerkAdmin = { isConfigured: jest.fn(), inviteStaffByEmail: jest.fn() };
+  const clerkAdmin = {
+    isConfigured: jest.fn().mockReturnValue(false),
+    inviteStaffByEmail: jest.fn(),
+  };
   const audit = { log: jest.fn() };
 
   beforeEach(async () => {
@@ -114,6 +121,34 @@ describe('StaffService', () => {
       expect(() =>
         service.resolveHospitalId({ ...hospitalAdmin, hospitalId: undefined }),
       ).toThrow(NotFoundException);
+    });
+  });
+
+  describe('create — cross-hospital invite', () => {
+    it('rejects inviting a user who already belongs to another hospital', async () => {
+      rolesRepo.findOne.mockResolvedValue({ id: 'role-doctor', slug: 'doctor' });
+      usersRepo.findOne.mockResolvedValue({
+        id: 'user-1',
+        email: 'doc@example.com',
+        hospitalId: 'hospital-b',
+        fullName: 'Existing Doc',
+        authId: 'auth-1',
+      });
+
+      await expect(
+        service.create(
+          'hospital-a',
+          {
+            email: 'doc@example.com',
+            fullName: 'Existing Doc',
+            roleSlug: 'doctor',
+          },
+          hospitalAdmin,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(userRolesRepo.save).not.toHaveBeenCalled();
+      expect(staffRepo.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -121,6 +121,13 @@ export class StaffService {
     let user: User;
     if (existingByEmail) {
       user = existingByEmail;
+      // Single-hospital policy: a user may belong to at most one hospital.
+      // Never attach foreign roles/staff profiles while hospitalId stays elsewhere.
+      if (user.hospitalId && user.hospitalId !== hospitalId) {
+        throw new BadRequestException(
+          'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
+        );
+      }
       if (!user.hospitalId) {
         await this.usersRepo.update(user.id, {
           hospitalId,
@@ -292,6 +299,16 @@ export class StaffService {
       ? await this.findById(invite.staffProfileId)
       : null;
     if (!staff) throw new NotFoundException('Staff profile missing for invite');
+
+    const invitee = await this.usersRepo.findOne({ where: { id: staff.userId } });
+    if (
+      invitee?.hospitalId &&
+      invitee.hospitalId !== invite.hospitalId
+    ) {
+      throw new BadRequestException(
+        'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
+      );
+    }
 
     await this.usersRepo.update(staff.userId, {
       authId,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,13 @@ CareConnect is a Turborepo monorepo for hospital and clinic operations.
 
 Authorization is enforced in Nest (not Postgres RLS). Migrations are Neon-compatible and do not depend on Supabase `auth.uid()`.
 
+### Multi-hospital / tenancy policy
+
+- Each user has at most one `users.hospital_id` (home hospital).
+- Staff invites **must not** attach roles or staff profiles for hospital B when the user already belongs to hospital A.
+- Platform roles (`super_admin`) and patient portal accounts may have a null hospital membership.
+- Role/permission grants on `user_roles` are hospital-scoped; effective permissions should only include the active hospital (plus platform roles).
+
 ## Modules
 
 Hospitals, users/RBAC, staff (+ invites), patients, facility, appointments, admissions, clinical, discharge/follow-ups, portal, billing, pharmacy, inventory, reports, uploads.


### PR DESCRIPTION
## Summary
- Reject staff create/invite when the email already belongs to another hospital
- Guard `acceptInvite` the same way for stale invites
- Document single-hospital tenancy policy in `docs/architecture.md`
- Add unit coverage for the cross-hospital reject path

Closes #2

## Test plan
- [x] StaffService unit tests (7 passing)
- [ ] Inviting an existing user from hospital B into A returns 400
- [ ] Inviting a new email or unassigned user still succeeds


Made with [Cursor](https://cursor.com)