### PR TITLE
fix: scope auth roles to active hospital (#3)

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -75,6 +75,7 @@ describe('AuthService', () => {
         onboardingCompleted: true,
         userRoles: [
           {
+            hospitalId: 'hospital-1',
             role: {
               slug: 'hospital_admin',
               permissions: [{ slug: 'patients:read' }],
@@ -98,6 +99,73 @@ describe('AuthService', () => {
         permissions: ['patients:read'],
         onboardingCompleted: true,
       });
+    });
+  });
+
+  describe('toAuthenticatedUser', () => {
+    it('filters out roles from a different hospital', () => {
+      const result = service.toAuthenticatedUser({
+        id: 'user-1',
+        authId: 'auth-1',
+        email: 'doc@hospital.com',
+        fullName: 'Doc',
+        hospitalId: 'hospital-a',
+        isActive: true,
+        onboardingCompleted: true,
+        userRoles: [
+          {
+            hospitalId: 'hospital-a',
+            role: {
+              slug: 'nurse',
+              permissions: [{ slug: 'patients:read' }],
+            },
+          },
+          {
+            hospitalId: 'hospital-b',
+            role: {
+              slug: 'doctor',
+              permissions: [
+                { slug: 'patients:write' },
+                { slug: 'appointments:write' },
+              ],
+            },
+          },
+        ],
+      } as User);
+
+      expect(result.roles).toEqual(['nurse']);
+      expect(result.permissions).toEqual(['patients:read']);
+    });
+
+    it('keeps platform roles regardless of hospital scope', () => {
+      const result = service.toAuthenticatedUser({
+        id: 'user-1',
+        authId: 'auth-1',
+        email: 'admin@careconnect.com',
+        fullName: 'Super',
+        hospitalId: 'hospital-a',
+        isActive: true,
+        onboardingCompleted: true,
+        userRoles: [
+          {
+            hospitalId: undefined,
+            role: {
+              slug: 'super_admin',
+              permissions: [{ slug: 'hospitals:write' }],
+            },
+          },
+          {
+            hospitalId: 'hospital-b',
+            role: {
+              slug: 'doctor',
+              permissions: [{ slug: 'patients:write' }],
+            },
+          },
+        ],
+      } as User);
+
+      expect(result.roles).toEqual(['super_admin']);
+      expect(result.permissions).toEqual(['hospitals:write']);
     });
   });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -80,12 +80,25 @@ export class AuthService {
   }
 
   toAuthenticatedUser(user: User): AuthenticatedUser {
-    const roles = user.userRoles?.map((ur) => ur.role.slug) ?? [];
+    const activeHospitalId = user.hospitalId;
+    const PLATFORM_ROLE_SLUGS = new Set(['super_admin', 'patient']);
+
+    const scopedRoles =
+      user.userRoles?.filter((ur) => {
+        const slug = ur.role?.slug;
+        if (slug && PLATFORM_ROLE_SLUGS.has(slug)) return true;
+        // Global grants (no hospital on the assignment)
+        if (!ur.hospitalId) return true;
+        // Hospital-scoped grants only apply for the user's active hospital
+        return !!activeHospitalId && ur.hospitalId === activeHospitalId;
+      }) ?? [];
+
+    const roles = scopedRoles.map((ur) => ur.role.slug);
     const permissions = [
       ...new Set(
-        user.userRoles?.flatMap(
+        scopedRoles.flatMap(
           (ur) => ur.role.permissions?.map((p) => p.slug) ?? [],
-        ) ?? [],
+        ),
       ),
     ];
 


### PR DESCRIPTION
## Summary
- Filter `toAuthenticatedUser` roles/permissions by active `users.hospitalId`
- Keep platform roles (`super_admin`, `patient`) and unscoped grants
- Unit tests for multi-hospital role leakage

Closes #3

## Test plan
- [x] AuthService unit tests covering foreign-hospital role exclusion
- [ ] User with stale foreign `user_roles` row does not receive those permissions


Made with [Cursor](https://cursor.com)