### PR TITLE
fix: block patient hospital-wide billing/appointments (#4)

### DIFF
--- a/apps/api/src/appointments/appointments.resolver.ts
+++ b/apps/api/src/appointments/appointments.resolver.ts
@@ -5,7 +5,9 @@ import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
+import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
+import { STAFF_ROLES } from '../rbac/staff-roles';
 import { AppointmentsService } from './appointments.service';
 import {
   AppointmentType,
@@ -19,6 +21,7 @@ export class AppointmentsResolver {
   constructor(private readonly appointmentsService: AppointmentsService) {}
 
   @Query(() => [AppointmentType])
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.APPOINTMENTS_READ)
   async appointments(
     @CurrentUser() user: AuthenticatedUser,
@@ -40,6 +43,7 @@ export class AppointmentsResolver {
   }
 
   @Mutation(() => AppointmentType)
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.APPOINTMENTS_WRITE)
   async createAppointment(
     @CurrentUser() user: AuthenticatedUser,
@@ -54,6 +58,7 @@ export class AppointmentsResolver {
   }
 
   @Mutation(() => AppointmentType)
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.APPOINTMENTS_WRITE)
   async updateAppointmentStatus(
     @CurrentUser() user: AuthenticatedUser,
@@ -74,6 +79,7 @@ export class AppointmentsResolver {
   }
 
   @Mutation(() => AppointmentType)
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.APPOINTMENTS_WRITE)
   async cancelAppointment(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/billing/billing.resolver.ts
+++ b/apps/api/src/billing/billing.resolver.ts
@@ -5,7 +5,9 @@ import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
+import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
+import { STAFF_ROLES } from '../rbac/staff-roles';
 import { BillingService } from './billing.service';
 import {
   CreateInvoiceInput,
@@ -19,6 +21,7 @@ export class BillingResolver {
   constructor(private readonly billingService: BillingService) {}
 
   @Query(() => [InvoiceType])
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.BILLING_READ)
   async invoices(
     @CurrentUser() user: AuthenticatedUser,
@@ -32,6 +35,7 @@ export class BillingResolver {
   }
 
   @Query(() => InvoiceType)
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.BILLING_READ)
   async invoice(
     @CurrentUser() user: AuthenticatedUser,
@@ -46,6 +50,7 @@ export class BillingResolver {
   }
 
   @Mutation(() => InvoiceType)
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.BILLING_WRITE)
   async createInvoice(
     @CurrentUser() user: AuthenticatedUser,
@@ -60,6 +65,7 @@ export class BillingResolver {
   }
 
   @Mutation(() => InvoiceType)
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.BILLING_WRITE)
   async recordPayment(
     @CurrentUser() user: AuthenticatedUser,
@@ -74,6 +80,7 @@ export class BillingResolver {
   }
 
   @Mutation(() => InvoiceType)
+  @Roles(...STAFF_ROLES)
   @Permissions(PERMISSIONS.BILLING_WRITE)
   async voidInvoice(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/rbac/roles.guard.spec.ts
+++ b/apps/api/src/rbac/roles.guard.spec.ts
@@ -119,4 +119,38 @@ describe('RolesGuard', () => {
     user.permissions.push('patients:write');
     expect(guard.canActivate(createContext(user))).toBe(true);
   });
+
+  it('denies patient role on staff-only hospital list endpoints', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockImplementation((key: string) => {
+        if (key === ROLES_KEY) {
+          return [
+            'hospital_admin',
+            'hospital_manager',
+            'doctor',
+            'nurse',
+            'receptionist',
+            'lab_technician',
+            'pharmacist',
+            'accountant',
+          ];
+        }
+        if (key === PERMISSIONS_KEY) return ['billing:read'];
+        return undefined;
+      });
+
+    const patient: AuthenticatedUser = {
+      id: '4',
+      authId: 'auth-4',
+      email: 'patient@example.com',
+      fullName: 'Patient',
+      hospitalId: 'h-1',
+      roles: ['patient'],
+      permissions: ['billing:read', 'appointments:read'],
+      onboardingCompleted: true,
+    };
+
+    expect(guard.canActivate(createContext(patient))).toBe(false);
+  });
 });

--- a/apps/api/src/rbac/staff-roles.ts
+++ b/apps/api/src/rbac/staff-roles.ts
@@ -1,0 +1,13 @@
+import { ROLES, type RoleSlug } from '@careconnect/types';
+
+/** Staff roles allowed on hospital-scoped operational GraphQL APIs. */
+export const STAFF_ROLES: RoleSlug[] = [
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+  ROLES.DOCTOR,
+  ROLES.NURSE,
+  ROLES.RECEPTIONIST,
+  ROLES.LAB_TECHNICIAN,
+  ROLES.PHARMACIST,
+  ROLES.ACCOUNTANT,
+];

--- a/supabase/migrations/20240609000002_seed_roles_permissions.sql
+++ b/supabase/migrations/20240609000002_seed_roles_permissions.sql
@@ -68,8 +68,6 @@ SELECT r.id, p.id FROM roles r, permissions p
 WHERE r.slug = 'receptionist'
   AND p.slug IN ('patients:read', 'patients:write', 'appointments:read', 'appointments:write');
 
--- Patient permissions
-INSERT INTO role_permissions (role_id, permission_id)
-SELECT r.id, p.id FROM roles r, permissions p
-WHERE r.slug = 'patient'
-  AND p.slug IN ('appointments:read', 'billing:read');
+-- Patient: no hospital-wide GraphQL permissions.
+-- Portal access is enforced via @Roles('patient') on portal resolvers.
+-- (intentionally no role_permissions rows for patient)

--- a/supabase/migrations/20240609000010_revoke_patient_hospital_perms.sql
+++ b/supabase/migrations/20240609000010_revoke_patient_hospital_perms.sql
@@ -1,0 +1,10 @@
+-- Revoke hospital-wide list permissions from the patient role.
+-- Patients must use the portal GraphQL API (role-gated + patient-scoped),
+-- not invoices/appointments hospital list queries.
+
+DELETE FROM role_permissions rp
+USING roles r, permissions p
+WHERE rp.role_id = r.id
+  AND rp.permission_id = p.id
+  AND r.slug = 'patient'
+  AND p.slug IN ('appointments:read', 'billing:read');


### PR DESCRIPTION
## Summary
- Revoke `appointments:read` / `billing:read` from the patient role (seed + migration)
- Require staff roles on hospital billing and appointments GraphQL APIs
- Portal remains `@Roles(patient)` and patient-scoped
- Unit test: patient denied on staff-only endpoints even with stale permissions

Closes #4

## Test plan
- [x] RolesGuard unit test for patient denial
- [ ] Patient JWT cannot query `invoices` / `appointments`
- [ ] Portal `portalPatientRecords` still works for patients


Made with [Cursor](https://cursor.com)