### PR TITLE
fix: prevent concurrent double bed admission (#5)

### DIFF
--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -1,0 +1,152 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Admission, Bed, Patient, Ward } from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from '../audit/audit.service';
+import { AdmissionsService } from './admissions.service';
+
+describe('AdmissionsService', () => {
+  let service: AdmissionsService;
+
+  const manager = {
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn((_entity, data) => data),
+  };
+
+  const admissionsRepo = {
+    manager: {
+      transaction: jest.fn(async (cb: (m: typeof manager) => unknown) =>
+        cb(manager),
+      ),
+    },
+    findOne: jest.fn(),
+    find: jest.fn(),
+    count: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+  };
+  const patientsRepo = { findOne: jest.fn(), save: jest.fn() };
+  const wardsRepo = { findOne: jest.fn(), find: jest.fn() };
+  const bedsRepo = { findOne: jest.fn(), find: jest.fn(), save: jest.fn() };
+  const audit = { log: jest.fn() };
+
+  const actor: AuthenticatedUser = {
+    id: 'admin-1',
+    authId: 'auth-1',
+    email: 'admin@h.com',
+    fullName: 'Admin',
+    hospitalId: 'hospital-a',
+    roles: ['hospital_admin'],
+    permissions: [],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdmissionsService,
+        { provide: getRepositoryToken(Admission), useValue: admissionsRepo },
+        { provide: getRepositoryToken(Patient), useValue: patientsRepo },
+        { provide: getRepositoryToken(Ward), useValue: wardsRepo },
+        { provide: getRepositoryToken(Bed), useValue: bedsRepo },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+
+    service = module.get(AdmissionsService);
+  });
+
+  describe('admitPatient concurrency guards', () => {
+    it('rejects when bed is already occupied after lock', async () => {
+      manager.findOne
+        .mockResolvedValueOnce({
+          id: 'patient-1',
+          hospitalId: 'hospital-a',
+          status: 'registered',
+        })
+        .mockResolvedValueOnce({ id: 'ward-1', hospitalId: 'hospital-a' });
+
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'bed-1',
+          status: 'occupied',
+          hospitalId: 'hospital-a',
+          wardId: 'ward-1',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.admitPatient(
+          'hospital-a',
+          {
+            patientId: 'patient-1',
+            wardId: 'ward-1',
+            bedId: 'bed-1',
+          },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(qb.setLock).toHaveBeenCalledWith('pessimistic_write');
+    });
+
+    it('rejects when patient already has an active admission', async () => {
+      manager.findOne
+        .mockResolvedValueOnce({
+          id: 'patient-1',
+          hospitalId: 'hospital-a',
+          status: 'registered',
+        })
+        .mockResolvedValueOnce({ id: 'ward-1', hospitalId: 'hospital-a' })
+        .mockResolvedValueOnce({ id: 'adm-existing', status: 'active' });
+
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'bed-1',
+          status: 'available',
+          hospitalId: 'hospital-a',
+          wardId: 'ward-1',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.admitPatient(
+          'hospital-a',
+          {
+            patientId: 'patient-1',
+            wardId: 'ward-1',
+            bedId: 'bed-1',
+          },
+          actor,
+        ),
+      ).rejects.toThrow('Patient already has an active admission');
+    });
+
+    it('throws NotFound when patient missing', async () => {
+      manager.findOne.mockResolvedValueOnce(null);
+      await expect(
+        service.admitPatient(
+          'hospital-a',
+          {
+            patientId: 'missing',
+            wardId: 'ward-1',
+            bedId: 'bed-1',
+          },
+          actor,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { Admission, Bed, Patient, Ward } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
@@ -15,6 +15,14 @@ import {
   DischargeAdmissionInput,
   WardOccupancyType,
 } from './admissions.types';
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    typeof (error as QueryFailedError & { code?: string }).code === 'string' &&
+    (error as QueryFailedError & { code?: string }).code === '23505'
+  );
+}
 
 @Injectable()
 export class AdmissionsService {
@@ -119,62 +127,88 @@ export class AdmissionsService {
     input: AdmitPatientInput,
     actor: AuthenticatedUser,
   ): Promise<AdmissionType> {
-    const patient = await this.patientsRepo.findOne({
-      where: { id: input.patientId, hospitalId },
-    });
-    if (!patient) throw new NotFoundException('Patient not found');
+    try {
+      const savedId = await this.admissionsRepo.manager.transaction(
+        async (manager) => {
+          const patient = await manager.findOne(Patient, {
+            where: { id: input.patientId, hospitalId },
+          });
+          if (!patient) throw new NotFoundException('Patient not found');
 
-    const ward = await this.wardsRepo.findOne({
-      where: { id: input.wardId, hospitalId },
-    });
-    if (!ward) throw new NotFoundException('Ward not found');
+          const ward = await manager.findOne(Ward, {
+            where: { id: input.wardId, hospitalId },
+          });
+          if (!ward) throw new NotFoundException('Ward not found');
 
-    const bed = await this.bedsRepo.findOne({
-      where: { id: input.bedId, wardId: input.wardId, hospitalId },
-    });
-    if (!bed) throw new NotFoundException('Bed not found');
-    if (bed.status !== 'available') {
-      throw new BadRequestException('Bed is not available');
-    }
+          // Lock the bed row so concurrent admits serialize on the same bed
+          const bed = await manager
+            .createQueryBuilder(Bed, 'bed')
+            .setLock('pessimistic_write')
+            .where('bed.id = :id', { id: input.bedId })
+            .andWhere('bed.ward_id = :wardId', { wardId: input.wardId })
+            .andWhere('bed.hospital_id = :hospitalId', { hospitalId })
+            .getOne();
+          if (!bed) throw new NotFoundException('Bed not found');
+          if (bed.status !== 'available') {
+            throw new BadRequestException('Bed is not available');
+          }
 
-    const existingAdmission = await this.admissionsRepo.findOne({
-      where: { patientId: input.patientId, hospitalId, status: 'active' },
-    });
-    if (existingAdmission) {
-      throw new BadRequestException('Patient already has an active admission');
-    }
+          const existingAdmission = await manager.findOne(Admission, {
+            where: {
+              patientId: input.patientId,
+              hospitalId,
+              status: 'active',
+            },
+          });
+          if (existingAdmission) {
+            throw new BadRequestException(
+              'Patient already has an active admission',
+            );
+          }
 
-    bed.status = 'occupied';
-    await this.bedsRepo.save(bed);
+          bed.status = 'occupied';
+          await manager.save(bed);
 
-    const saved = await this.admissionsRepo.save(
-      this.admissionsRepo.create({
+          const saved = await manager.save(
+            manager.create(Admission, {
+              hospitalId,
+              patientId: input.patientId,
+              attendingDoctorId: input.attendingDoctorId,
+              wardId: input.wardId,
+              bedId: input.bedId,
+              reason: input.reason,
+              status: 'active',
+              admittedAt: new Date(),
+            }),
+          );
+
+          patient.status = 'admitted';
+          await manager.save(patient);
+
+          return saved.id;
+        },
+      );
+
+      const admission = await this.findAdmissionOrThrow(savedId, hospitalId);
+
+      await this.audit.log({
+        actorId: actor.id,
         hospitalId,
-        patientId: input.patientId,
-        attendingDoctorId: input.attendingDoctorId,
-        wardId: input.wardId,
-        bedId: input.bedId,
-        reason: input.reason,
-        status: 'active',
-        admittedAt: new Date(),
-      }),
-    );
+        action: 'admit',
+        resource: 'admission',
+        resourceId: admission.id,
+        metadata: { patientId: admission.patientId, bedId: admission.bedId },
+      });
 
-    patient.status = 'admitted';
-    await this.patientsRepo.save(patient);
-
-    const admission = await this.findAdmissionOrThrow(saved.id, hospitalId);
-
-    await this.audit.log({
-      actorId: actor.id,
-      hospitalId,
-      action: 'admit',
-      resource: 'admission',
-      resourceId: admission.id,
-      metadata: { patientId: admission.patientId, bedId: admission.bedId },
-    });
-
-    return this.toAdmissionType(admission);
+      return this.toAdmissionType(admission);
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new BadRequestException(
+          'Bed is not available or patient already has an active admission',
+        );
+      }
+      throw error;
+    }
   }
 
   async activeAdmissions(hospitalId: string): Promise<AdmissionType[]> {

--- a/supabase/migrations/20240609000011_admission_concurrency.sql
+++ b/supabase/migrations/20240609000011_admission_concurrency.sql
@@ -1,0 +1,10 @@
+-- Prevent concurrent double-occupancy and dual active admissions.
+-- Application also uses SELECT FOR UPDATE; these indexes are the DB backstop.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_admissions_active_bed
+  ON admissions (bed_id)
+  WHERE status = 'active' AND bed_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_admissions_active_patient
+  ON admissions (patient_id)
+  WHERE status = 'active';


### PR DESCRIPTION
## Summary
- Transactional `admitPatient` with pessimistic lock on the bed row
- Partial unique indexes on active admissions per bed and per patient
- Map unique violations to a clean BadRequest
- Unit tests for occupied-bed and dual-active-admission guards

Closes #5

## Test plan
- [x] AdmissionsService unit tests
- [ ] Two concurrent admits of the same bed: one succeeds, one fails
- [ ] Second active admission for same patient is rejected


Made with [Cursor](https://cursor.com)