### PR TITLE
fix: prevent concurrent invoice overpayment (#6)

### DIFF
--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -13,13 +13,13 @@ describe('AdmissionsService', () => {
     findOne: jest.fn(),
     createQueryBuilder: jest.fn(),
     save: jest.fn(),
-    create: jest.fn((_entity, data) => data),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => data),
   };
 
   const admissionsRepo = {
     manager: {
-      transaction: jest.fn(async (cb: (m: typeof manager) => unknown) =>
-        cb(manager),
+      transaction: jest.fn((cb: (m: typeof manager) => unknown) =>
+        Promise.resolve(cb(manager)),
       ),
     },
     findOne: jest.fn(),

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -19,13 +19,16 @@ describe('BillingService', () => {
     createQueryBuilder: jest.fn(),
     find: jest.fn(),
     save: jest.fn(),
-    create: jest.fn((_entity, data) => ({ id: 'pay-1', ...data })),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({
+      id: 'pay-1',
+      ...data,
+    })),
   };
 
   const invoicesRepo = {
     manager: {
-      transaction: jest.fn(async (cb: (m: typeof manager) => unknown) =>
-        cb(manager),
+      transaction: jest.fn((cb: (m: typeof manager) => unknown) =>
+        Promise.resolve(cb(manager)),
       ),
     },
     findOne: jest.fn(),

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -1,0 +1,143 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  Admission,
+  Invoice,
+  InvoiceItem,
+  Patient,
+  Payment,
+} from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from '../audit/audit.service';
+import { BillingService } from './billing.service';
+
+describe('BillingService', () => {
+  let service: BillingService;
+
+  const manager = {
+    createQueryBuilder: jest.fn(),
+    find: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn((_entity, data) => ({ id: 'pay-1', ...data })),
+  };
+
+  const invoicesRepo = {
+    manager: {
+      transaction: jest.fn(async (cb: (m: typeof manager) => unknown) =>
+        cb(manager),
+      ),
+    },
+    findOne: jest.fn(),
+    find: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+  };
+  const invoiceItemsRepo = { save: jest.fn(), create: jest.fn() };
+  const paymentsRepo = {
+    save: jest.fn(),
+    create: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+  const patientsRepo = { findOne: jest.fn() };
+  const admissionsRepo = { findOne: jest.fn() };
+  const audit = { log: jest.fn() };
+
+  const actor: AuthenticatedUser = {
+    id: 'acct-1',
+    authId: 'auth-1',
+    email: 'acct@h.com',
+    fullName: 'Accountant',
+    hospitalId: 'hospital-a',
+    roles: ['accountant'],
+    permissions: ['billing:write'],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BillingService,
+        { provide: getRepositoryToken(Invoice), useValue: invoicesRepo },
+        {
+          provide: getRepositoryToken(InvoiceItem),
+          useValue: invoiceItemsRepo,
+        },
+        { provide: getRepositoryToken(Payment), useValue: paymentsRepo },
+        { provide: getRepositoryToken(Patient), useValue: patientsRepo },
+        { provide: getRepositoryToken(Admission), useValue: admissionsRepo },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = module.get(BillingService);
+  });
+
+  describe('recordPayment concurrency', () => {
+    it('rejects payment that exceeds remaining balance under lock', async () => {
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'inv-1',
+          hospitalId: 'hospital-a',
+          status: 'issued',
+          totalAmount: '100.00',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+      manager.find.mockResolvedValue([{ amount: '100.00' }]);
+
+      await expect(
+        service.recordPayment(
+          'hospital-a',
+          { invoiceId: 'inv-1', amount: 50, method: 'cash' },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(qb.setLock).toHaveBeenCalledWith('pessimistic_write');
+    });
+
+    it('rejects payment on already-paid invoice', async () => {
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'inv-1',
+          hospitalId: 'hospital-a',
+          status: 'paid',
+          totalAmount: '100.00',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.recordPayment(
+          'hospital-a',
+          { invoiceId: 'inv-1', amount: 10, method: 'cash' },
+          actor,
+        ),
+      ).rejects.toThrow('Invoice is already paid in full');
+    });
+
+    it('throws NotFound when invoice missing', async () => {
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.recordPayment(
+          'hospital-a',
+          { invoiceId: 'missing', amount: 10, method: 'cash' },
+          actor,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -208,64 +208,74 @@ export class BillingService {
     input: RecordPaymentInput,
     actor: AuthenticatedUser,
   ): Promise<InvoiceType> {
-    const invoice = await this.invoicesRepo.findOne({
-      where: { id: input.invoiceId, hospitalId },
-      relations: ['items', 'payments', 'patient'],
-    });
-    if (!invoice) throw new NotFoundException('Invoice not found');
-    if (invoice.status === 'void') {
-      throw new BadRequestException('Cannot record payment on a void invoice');
-    }
+    const paymentId = await this.invoicesRepo.manager.transaction(
+      async (manager) => {
+        // Lock invoice so concurrent payments serialize on the same row
+        const invoice = await manager
+          .createQueryBuilder(Invoice, 'invoice')
+          .setLock('pessimistic_write')
+          .where('invoice.id = :id', { id: input.invoiceId })
+          .andWhere('invoice.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!invoice) throw new NotFoundException('Invoice not found');
+        if (invoice.status === 'void') {
+          throw new BadRequestException(
+            'Cannot record payment on a void invoice',
+          );
+        }
+        if (invoice.status === 'paid') {
+          throw new BadRequestException('Invoice is already paid in full');
+        }
 
-    const currentPaid = (invoice.payments ?? []).reduce(
-      (sum, p) => sum + this.toNumber(p.amount),
-      0,
+        const payments = await manager.find(Payment, {
+          where: { invoiceId: invoice.id },
+        });
+        const currentPaid = payments.reduce(
+          (sum, p) => sum + this.toNumber(p.amount),
+          0,
+        );
+        const invoiceTotal = this.toNumber(invoice.totalAmount);
+        const remaining = Math.max(0, invoiceTotal - currentPaid);
+        if (input.amount > remaining + 0.001) {
+          throw new BadRequestException(
+            `Payment exceeds remaining balance of ${remaining.toFixed(2)}`,
+          );
+        }
+
+        const payment = await manager.save(
+          manager.create(Payment, {
+            invoiceId: invoice.id,
+            hospitalId,
+            amount: input.amount.toFixed(2),
+            method: input.method,
+            paidAt: new Date(),
+            recordedById: actor.id,
+          }),
+        );
+
+        const paidTotal = currentPaid + this.toNumber(payment.amount);
+        if (paidTotal >= invoiceTotal) {
+          invoice.status = 'paid';
+        } else if (invoice.status === 'draft') {
+          invoice.status = 'issued';
+          invoice.issuedAt = invoice.issuedAt ?? new Date();
+        }
+
+        await manager.save(invoice);
+        return payment.id as string;
+      },
     );
-    const invoiceTotal = this.toNumber(invoice.totalAmount);
-    const remaining = Math.max(0, invoiceTotal - currentPaid);
-    if (input.amount > remaining + 0.001) {
-      throw new BadRequestException(
-        `Payment exceeds remaining balance of ${remaining.toFixed(2)}`,
-      );
-    }
-
-    const payment = await this.paymentsRepo.save(
-      this.paymentsRepo.create({
-        invoiceId: invoice.id,
-        hospitalId,
-        amount: input.amount.toFixed(2),
-        method: input.method,
-        paidAt: new Date(),
-        recordedById: actor.id,
-      }),
-    );
-
-    invoice.payments = [...(invoice.payments ?? []), payment];
-
-    const paidTotal = invoice.payments.reduce(
-      (sum, p) => sum + this.toNumber(p.amount),
-      0,
-    );
-
-    if (paidTotal >= invoiceTotal) {
-      invoice.status = 'paid';
-    } else if (invoice.status === 'draft') {
-      invoice.status = 'issued';
-      invoice.issuedAt = invoice.issuedAt ?? new Date();
-    }
-
-    await this.invoicesRepo.save(invoice);
 
     await this.audit.log({
       actorId: actor.id,
       hospitalId,
       action: 'create',
       resource: 'payment',
-      resourceId: payment.id,
-      metadata: { invoiceId: invoice.id, amount: input.amount },
+      resourceId: paymentId,
+      metadata: { invoiceId: input.invoiceId, amount: input.amount },
     });
 
-    return this.toInvoiceType(invoice);
+    return this.getInvoice(hospitalId, input.invoiceId);
   }
 
   async voidInvoice(

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -262,7 +262,7 @@ export class BillingService {
         }
 
         await manager.save(invoice);
-        return payment.id as string;
+        return payment.id;
       },
     );
 

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -126,7 +126,10 @@ describe('StaffService', () => {
 
   describe('create — cross-hospital invite', () => {
     it('rejects inviting a user who already belongs to another hospital', async () => {
-      rolesRepo.findOne.mockResolvedValue({ id: 'role-doctor', slug: 'doctor' });
+      rolesRepo.findOne.mockResolvedValue({
+        id: 'role-doctor',
+        slug: 'doctor',
+      });
       usersRepo.findOne.mockResolvedValue({
         id: 'user-1',
         email: 'doc@example.com',

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -300,11 +300,10 @@ export class StaffService {
       : null;
     if (!staff) throw new NotFoundException('Staff profile missing for invite');
 
-    const invitee = await this.usersRepo.findOne({ where: { id: staff.userId } });
-    if (
-      invitee?.hospitalId &&
-      invitee.hospitalId !== invite.hospitalId
-    ) {
+    const invitee = await this.usersRepo.findOne({
+      where: { id: staff.userId },
+    });
+    if (invitee?.hospitalId && invitee.hospitalId !== invite.hospitalId) {
       throw new BadRequestException(
         'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
       );

--- a/apps/api/src/uploads/uploads.module.ts
+++ b/apps/api/src/uploads/uploads.module.ts
@@ -6,10 +6,7 @@ import { UploadsController } from './uploads.controller';
 import { UploadsService } from './uploads.service';
 
 @Module({
-  imports: [
-    AuthModule,
-    TypeOrmModule.forFeature([PatientDocument, Patient]),
-  ],
+  imports: [AuthModule, TypeOrmModule.forFeature([PatientDocument, Patient])],
   controllers: [UploadsController],
   providers: [UploadsService],
   exports: [UploadsService],


### PR DESCRIPTION
## Summary
- Wrap `recordPayment` in a transaction with `SELECT … FOR UPDATE` on the invoice
- Re-check remaining balance under the lock before inserting payment
- Reject payments on already-paid invoices
- Unit tests for overpay and paid-invoice guards

Closes #6

## Test plan
- [x] BillingService unit tests
- [ ] Two concurrent full-balance payments: one succeeds, one rejected
- [ ] Invoice status never shows paid with total payments > totalAmount


Made with [Cursor](https://cursor.com)