### PR TITLE
fix: prevent duplicate hospital admin bootstrap (#7)

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,17 +1,33 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Role, User, UserRole, Hospital } from '../database/entities';
+import type { AuthenticatedUser } from './auth.types';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;
+
+  const manager = {
+    query: jest.fn().mockResolvedValue(undefined),
+    findOne: jest.fn(),
+    count: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => data),
+  };
 
   const usersRepo = {
     findOne: jest.fn(),
     create: jest.fn(),
     save: jest.fn(),
     update: jest.fn(),
+    manager: {
+      transaction: jest.fn((cb: (m: typeof manager) => unknown) =>
+        Promise.resolve(cb(manager)),
+      ),
+    },
   };
 
   const userRolesRepo = {
@@ -31,6 +47,7 @@ describe('AuthService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    manager.query.mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -44,6 +61,16 @@ describe('AuthService', () => {
 
     service = module.get(AuthService);
   });
+
+  const actor: AuthenticatedUser = {
+    id: 'user-1',
+    authId: 'auth-1',
+    email: 'founder@hospital.com',
+    fullName: 'Founder',
+    roles: [],
+    permissions: [],
+    onboardingCompleted: false,
+  };
 
   describe('syncAndGetUser', () => {
     it('rejects inactive users', async () => {
@@ -166,6 +193,56 @@ describe('AuthService', () => {
 
       expect(result.roles).toEqual(['super_admin']);
       expect(result.permissions).toEqual(['hospitals:write']);
+    });
+  });
+
+  describe('completeOnboarding bootstrap', () => {
+    it('takes an advisory lock and assigns hospital_admin when none exist', async () => {
+      usersRepo.findOne.mockResolvedValue({
+        id: 'user-1',
+        hospitalId: undefined,
+      });
+      hospitalsRepo.findOne.mockResolvedValue({ id: 'hospital-a' });
+      manager.findOne.mockResolvedValue({
+        id: 'role-admin',
+        slug: 'hospital_admin',
+      });
+      manager.count.mockResolvedValue(0);
+      manager.find.mockResolvedValue([]);
+
+      await service.completeOnboarding(actor, 'Founder', 'hospital-a', true);
+
+      expect(manager.query).toHaveBeenCalledWith(
+        `SELECT pg_advisory_xact_lock(hashtext($1::text))`,
+        ['hospital-admin-bootstrap:hospital-a'],
+      );
+      expect(manager.save).toHaveBeenCalled();
+      expect(manager.update).toHaveBeenCalledWith(
+        User,
+        'user-1',
+        expect.objectContaining({
+          hospitalId: 'hospital-a',
+          onboardingCompleted: true,
+        }),
+      );
+    });
+
+    it('rejects bootstrap when an admin already exists under the lock', async () => {
+      usersRepo.findOne.mockResolvedValue({
+        id: 'user-1',
+        hospitalId: undefined,
+      });
+      hospitalsRepo.findOne.mockResolvedValue({ id: 'hospital-a' });
+      manager.findOne.mockResolvedValue({
+        id: 'role-admin',
+        slug: 'hospital_admin',
+      });
+      manager.count.mockResolvedValue(1);
+
+      await expect(
+        service.completeOnboarding(actor, 'Founder', 'hospital-a', true),
+      ).rejects.toThrow(ForbiddenException);
+      expect(manager.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -5,9 +5,16 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { Hospital, Role, User, UserRole } from '../database/entities';
 import type { AuthenticatedUser } from './auth.types';
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error as QueryFailedError & { code?: string }).code === '23505'
+  );
+}
 
 @Injectable()
 export class AuthService {
@@ -149,22 +156,69 @@ export class AuthService {
           'Hospital membership requires a staff invite or hospital registration',
         );
       }
+    }
 
-      if (!user.hospitalId && assignHospitalAdmin && !isSuperAdmin) {
-        const adminRole = await this.rolesRepo.findOne({
-          where: { slug: 'hospital_admin' },
-        });
-        if (adminRole) {
-          const existingAdmins = await this.userRolesRepo.count({
-            where: { roleId: adminRole.id, hospitalId },
+    // Bootstrap hospital_admin under a transaction + advisory lock so two
+    // concurrent registrants cannot both observe zero admins and both win.
+    if (hospitalId && assignHospitalAdmin) {
+      try {
+        await this.usersRepo.manager.transaction(async (manager) => {
+          await manager.query(
+            `SELECT pg_advisory_xact_lock(hashtext($1::text))`,
+            [`hospital-admin-bootstrap:${hospitalId}`],
+          );
+
+          const adminRole = await manager.findOne(Role, {
+            where: { slug: 'hospital_admin' },
           });
-          if (existingAdmins > 0) {
-            throw new ForbiddenException(
-              'Hospital already has an administrator; join via staff invite',
+          if (!adminRole) {
+            await manager.update(User, user.id, {
+              fullName,
+              hospitalId,
+              onboardingCompleted: true,
+            });
+            return;
+          }
+
+          if (!isSuperAdmin) {
+            const existingAdmins = await manager.count(UserRole, {
+              where: { roleId: adminRole.id, hospitalId },
+            });
+            if (existingAdmins > 0) {
+              throw new ForbiddenException(
+                'Hospital already has an administrator; join via staff invite',
+              );
+            }
+          }
+
+          await manager.update(User, user.id, {
+            fullName,
+            hospitalId,
+            onboardingCompleted: true,
+          });
+
+          const existingRoles = await manager.find(UserRole, {
+            where: { userId: user.id },
+          });
+          if (existingRoles.length === 0) {
+            await manager.save(
+              manager.create(UserRole, {
+                userId: user.id,
+                roleId: adminRole.id,
+                hospitalId,
+              }),
             );
           }
+        });
+      } catch (error) {
+        if (isUniqueViolation(error)) {
+          throw new ForbiddenException(
+            'Hospital already has an administrator; join via staff invite',
+          );
         }
+        throw error;
       }
+      return;
     }
 
     await this.usersRepo.update(user.id, {
@@ -172,27 +226,6 @@ export class AuthService {
       hospitalId: hospitalId ?? user.hospitalId,
       onboardingCompleted: true,
     });
-
-    if (hospitalId && assignHospitalAdmin) {
-      const existingRoles = await this.userRolesRepo.find({
-        where: { userId: user.id },
-      });
-      if (existingRoles.length === 0) {
-        const adminRole = await this.rolesRepo.findOne({
-          where: { slug: 'hospital_admin' },
-        });
-
-        if (adminRole) {
-          await this.userRolesRepo.save(
-            this.userRolesRepo.create({
-              userId: user.id,
-              roleId: adminRole.id,
-              hospitalId,
-            }),
-          );
-        }
-      }
-    }
   }
 
   /** Patient portal path: assign patient role and mark onboarding complete. */

--- a/supabase/migrations/20240609000012_one_hospital_admin_bootstrap.sql
+++ b/supabase/migrations/20240609000012_one_hospital_admin_bootstrap.sql
@@ -1,0 +1,17 @@
+-- At most one hospital_admin per hospital (bootstrap + invite policy).
+-- Role id is resolved at migration time because index predicates must be immutable.
+
+DO $$
+DECLARE
+  admin_role_id UUID;
+BEGIN
+  SELECT id INTO admin_role_id FROM roles WHERE slug = 'hospital_admin';
+  IF admin_role_id IS NOT NULL THEN
+    EXECUTE format(
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_user_roles_one_hospital_admin
+       ON user_roles (hospital_id)
+       WHERE role_id = %L AND hospital_id IS NOT NULL',
+      admin_role_id
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Wrap hospital_admin bootstrap in a transaction with `pg_advisory_xact_lock`
- Re-check existing admins under the lock before insert
- Unique partial index: at most one `hospital_admin` per hospital
- Unit tests for lock + reject-when-admin-exists

Closes #7

## Test plan
- [x] AuthService bootstrap unit tests
- [ ] Two concurrent `completeOnboarding(..., assignHospitalAdmin=true)`: one succeeds, one Forbidden


Made with [Cursor](https://cursor.com)