### PR TITLE
fix: let lab technicians complete results (#8)

### DIFF
--- a/apps/api/src/clinical/clinical.resolver.ts
+++ b/apps/api/src/clinical/clinical.resolver.ts
@@ -186,7 +186,7 @@ export class ClinicalResolver {
   }
 
   @Mutation(() => LabResultType)
-  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  @Permissions(PERMISSIONS.LAB_WRITE)
   async completeLabResult(
     @CurrentUser() user: AuthenticatedUser,
     @Args('input') input: CompleteLabResultInput,

--- a/packages/types/src/roles.ts
+++ b/packages/types/src/roles.ts
@@ -26,6 +26,7 @@ export const PERMISSIONS = {
   BILLING_WRITE: 'billing:write',
   REPORTS_READ: 'reports:read',
   ROLES_MANAGE: 'roles:manage',
+  LAB_WRITE: 'lab:write',
 } as const;
 
 export type PermissionSlug = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];

--- a/supabase/migrations/20240609000013_lab_write_permission.sql
+++ b/supabase/migrations/20240609000013_lab_write_permission.sql
@@ -1,0 +1,25 @@
+-- Lab-scoped write permission so lab technicians can complete results
+-- without gaining patients:write (demographics / unrelated patient mutations).
+
+INSERT INTO permissions (slug, name, description)
+VALUES (
+  'lab:write',
+  'Write Lab Results',
+  'Enter and complete laboratory results'
+)
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE p.slug = 'lab:write'
+  AND r.slug IN (
+    'lab_technician',
+    'doctor',
+    'nurse',
+    'hospital_admin',
+    'hospital_manager',
+    'super_admin'
+  )
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- Add `lab:write` permission in shared types + migration
- Gate `completeLabResult` on `lab:write` instead of `patients:write`
- Grant to `lab_technician` (and doctor/nurse/admin roles) without giving demographics write

Closes #8

## Test plan
- [ ] Lab technician with `lab:write` can call `completeLabResult`
- [ ] Lab technician still cannot call patient update/create mutations
- [ ] Doctor/admin with `lab:write` can still complete results


Made with [Cursor](https://cursor.com)