### PR TITLE
fix: bind admissionId to patientId (#9)

### DIFF
--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -143,4 +143,30 @@ describe('BillingService', () => {
       ).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('createInvoice admission binding', () => {
+    it('rejects when admission belongs to a different patient', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+      });
+      admissionsRepo.findOne.mockResolvedValue({
+        id: 'adm-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-other',
+      });
+
+      await expect(
+        service.createInvoice(
+          'hospital-a',
+          {
+            patientId: 'patient-1',
+            admissionId: 'adm-1',
+            items: [{ description: 'Consult', quantity: 1, unitPrice: 50 }],
+          },
+          actor,
+        ),
+      ).rejects.toThrow('Admission does not belong to the given patient');
+    });
+  });
 });

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -120,12 +120,21 @@ export class BillingService {
     return patient;
   }
 
-  private async assertAdmission(hospitalId: string, admissionId?: string) {
+  private async assertAdmission(
+    hospitalId: string,
+    patientId: string,
+    admissionId?: string,
+  ) {
     if (!admissionId) return;
     const admission = await this.admissionsRepo.findOne({
       where: { id: admissionId, hospitalId },
     });
     if (!admission) throw new NotFoundException('Admission not found');
+    if (admission.patientId !== patientId) {
+      throw new BadRequestException(
+        'Admission does not belong to the given patient',
+      );
+    }
   }
 
   async createInvoice(
@@ -138,7 +147,7 @@ export class BillingService {
     }
 
     await this.assertPatient(hospitalId, input.patientId);
-    await this.assertAdmission(hospitalId, input.admissionId);
+    await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
     const status = input.status ?? 'draft';
     const totalAmount = input.items.reduce(

--- a/apps/api/src/clinical/clinical.service.spec.ts
+++ b/apps/api/src/clinical/clinical.service.spec.ts
@@ -1,0 +1,116 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  Admission,
+  ClinicalNote,
+  Diagnosis,
+  LabOrder,
+  LabResult,
+  Patient,
+  Prescription,
+  PrescriptionItem,
+  VitalSign,
+} from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from '../audit/audit.service';
+import { ClinicalService } from './clinical.service';
+
+describe('ClinicalService', () => {
+  let service: ClinicalService;
+
+  const vitalsRepo = { save: jest.fn(), create: jest.fn(), find: jest.fn() };
+  const diagnosesRepo = { save: jest.fn(), create: jest.fn(), find: jest.fn() };
+  const notesRepo = { save: jest.fn(), create: jest.fn(), find: jest.fn() };
+  const prescriptionsRepo = {
+    save: jest.fn(),
+    create: jest.fn(),
+    find: jest.fn(),
+  };
+  const prescriptionItemsRepo = { save: jest.fn(), create: jest.fn() };
+  const labOrdersRepo = {
+    save: jest.fn(),
+    create: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+  };
+  const labResultsRepo = { save: jest.fn(), create: jest.fn() };
+  const patientsRepo = { findOne: jest.fn() };
+  const admissionsRepo = { findOne: jest.fn() };
+  const audit = { log: jest.fn() };
+
+  const actor: AuthenticatedUser = {
+    id: 'doc-1',
+    authId: 'auth-1',
+    email: 'doc@h.com',
+    fullName: 'Doctor',
+    hospitalId: 'hospital-a',
+    roles: ['doctor'],
+    permissions: ['patients:write'],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClinicalService,
+        { provide: getRepositoryToken(VitalSign), useValue: vitalsRepo },
+        { provide: getRepositoryToken(Diagnosis), useValue: diagnosesRepo },
+        { provide: getRepositoryToken(ClinicalNote), useValue: notesRepo },
+        {
+          provide: getRepositoryToken(Prescription),
+          useValue: prescriptionsRepo,
+        },
+        {
+          provide: getRepositoryToken(PrescriptionItem),
+          useValue: prescriptionItemsRepo,
+        },
+        { provide: getRepositoryToken(LabOrder), useValue: labOrdersRepo },
+        { provide: getRepositoryToken(LabResult), useValue: labResultsRepo },
+        { provide: getRepositoryToken(Patient), useValue: patientsRepo },
+        { provide: getRepositoryToken(Admission), useValue: admissionsRepo },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = module.get(ClinicalService);
+  });
+
+  describe('admission patient binding', () => {
+    it('rejects vitals when admission belongs to another patient', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+      });
+      admissionsRepo.findOne.mockResolvedValue({
+        id: 'adm-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-other',
+      });
+
+      await expect(
+        service.createVital(
+          'hospital-a',
+          {
+            patientId: 'patient-1',
+            admissionId: 'adm-1',
+            heartRate: 72,
+          },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.createVital(
+          'hospital-a',
+          {
+            patientId: 'patient-1',
+            admissionId: 'adm-1',
+            heartRate: 72,
+          },
+          actor,
+        ),
+      ).rejects.toThrow('Admission does not belong to the given patient');
+      expect(vitalsRepo.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -83,12 +84,21 @@ export class ClinicalService {
     return patient;
   }
 
-  private async assertAdmission(hospitalId: string, admissionId?: string) {
+  private async assertAdmission(
+    hospitalId: string,
+    patientId: string,
+    admissionId?: string,
+  ) {
     if (!admissionId) return;
     const admission = await this.admissionsRepo.findOne({
       where: { id: admissionId, hospitalId },
     });
     if (!admission) throw new NotFoundException('Admission not found');
+    if (admission.patientId !== patientId) {
+      throw new BadRequestException(
+        'Admission does not belong to the given patient',
+      );
+    }
   }
 
   toVitalType(vital: VitalSign): VitalSignType {
@@ -219,7 +229,7 @@ export class ClinicalService {
     actor: AuthenticatedUser,
   ): Promise<VitalSignType> {
     await this.assertPatient(hospitalId, input.patientId);
-    await this.assertAdmission(hospitalId, input.admissionId);
+    await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
     const vital = await this.vitalsRepo.save(
       this.vitalsRepo.create({
@@ -256,7 +266,7 @@ export class ClinicalService {
     actor: AuthenticatedUser,
   ): Promise<DiagnosisType> {
     await this.assertPatient(hospitalId, input.patientId);
-    await this.assertAdmission(hospitalId, input.admissionId);
+    await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
     const diagnosis = await this.diagnosesRepo.save(
       this.diagnosesRepo.create({
@@ -289,7 +299,7 @@ export class ClinicalService {
     actor: AuthenticatedUser,
   ): Promise<ClinicalNoteType> {
     await this.assertPatient(hospitalId, input.patientId);
-    await this.assertAdmission(hospitalId, input.admissionId);
+    await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
     const note = await this.notesRepo.save(
       this.notesRepo.create({
@@ -322,7 +332,7 @@ export class ClinicalService {
     actor: AuthenticatedUser,
   ): Promise<PrescriptionType> {
     await this.assertPatient(hospitalId, input.patientId);
-    await this.assertAdmission(hospitalId, input.admissionId);
+    await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
     const prescription = await this.prescriptionsRepo.save(
       this.prescriptionsRepo.create({
@@ -368,7 +378,7 @@ export class ClinicalService {
     actor: AuthenticatedUser,
   ): Promise<LabOrderType> {
     await this.assertPatient(hospitalId, input.patientId);
-    await this.assertAdmission(hospitalId, input.admissionId);
+    await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
     const order = await this.labOrdersRepo.save(
       this.labOrdersRepo.create({


### PR DESCRIPTION
## Summary
- `assertAdmission` now requires `admission.patientId === patientId`
- Applied in clinical create paths and invoice creation
- Unit tests for mismatch on vitals and invoices

Closes #9

## Test plan
- [x] Clinical + billing unit tests for mismatched admission
- [ ] Creating a vital with wrong admissionId returns validation error


Made with [Cursor](https://cursor.com)