### PR TITLE
fix: decrement stock on pharmacy dispense (#10)

### DIFF
--- a/apps/api/src/pharmacy/pharmacy.service.spec.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.spec.ts
@@ -1,0 +1,208 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PharmacyStock, Prescription } from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from '../audit/audit.service';
+import { PharmacyService } from './pharmacy.service';
+
+describe('PharmacyService', () => {
+  let service: PharmacyService;
+
+  const manager = {
+    createQueryBuilder: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const pharmacyStockRepo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+  };
+  const prescriptionsRepo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+    manager: {
+      transaction: jest.fn((cb: (m: typeof manager) => unknown) =>
+        Promise.resolve(cb(manager)),
+      ),
+    },
+  };
+  const audit = { log: jest.fn() };
+
+  const actor: AuthenticatedUser = {
+    id: 'pharm-1',
+    authId: 'auth-1',
+    email: 'pharm@h.com',
+    fullName: 'Pharmacist',
+    hospitalId: 'hospital-a',
+    roles: ['pharmacist'],
+    permissions: ['patients:write'],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PharmacyService,
+        {
+          provide: getRepositoryToken(PharmacyStock),
+          useValue: pharmacyStockRepo,
+        },
+        {
+          provide: getRepositoryToken(Prescription),
+          useValue: prescriptionsRepo,
+        },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = module.get(PharmacyService);
+  });
+
+  describe('dispensePrescription stock checks', () => {
+    it('rejects when stock is missing for a drug', async () => {
+      const rxQb = {
+        setLock: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          status: 'pending',
+          items: [{ drugName: 'Amoxicillin' }],
+        }),
+      };
+      const stockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      };
+      manager.createQueryBuilder
+        .mockReturnValueOnce(rxQb)
+        .mockReturnValueOnce(stockQb);
+
+      await expect(
+        service.dispensePrescription(
+          'hospital-a',
+          { prescriptionId: 'rx-1' },
+          actor,
+        ),
+      ).rejects.toThrow('No pharmacy stock found for "Amoxicillin"');
+    });
+
+    it('rejects when stock quantity is insufficient', async () => {
+      const rxQb = {
+        setLock: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          status: 'pending',
+          items: [{ drugName: 'Amoxicillin' }, { drugName: 'Amoxicillin' }],
+        }),
+      };
+      const stockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'stock-1',
+          drugName: 'Amoxicillin',
+          quantity: '1.00',
+        }),
+      };
+      manager.createQueryBuilder
+        .mockReturnValueOnce(rxQb)
+        .mockReturnValueOnce(stockQb);
+
+      await expect(
+        service.dispensePrescription(
+          'hospital-a',
+          { prescriptionId: 'rx-1' },
+          actor,
+        ),
+      ).rejects.toThrow(/Insufficient stock/);
+    });
+
+    it('decrements stock and marks dispensed when sufficient', async () => {
+      const stock = {
+        id: 'stock-1',
+        drugName: 'Amoxicillin',
+        quantity: '5.00',
+      };
+      const rxQb = {
+        setLock: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          status: 'pending',
+          items: [{ drugName: 'Amoxicillin' }],
+          patient: null,
+        }),
+      };
+      const stockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(stock),
+      };
+      manager.createQueryBuilder
+        .mockReturnValueOnce(rxQb)
+        .mockReturnValueOnce(stockQb);
+      manager.save
+        .mockResolvedValueOnce({ ...stock, quantity: '4.00' })
+        .mockResolvedValueOnce({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          status: 'dispensed',
+          items: [{ drugName: 'Amoxicillin' }],
+        });
+      prescriptionsRepo.findOne.mockResolvedValue({
+        id: 'rx-1',
+        hospitalId: 'hospital-a',
+        status: 'dispensed',
+        items: [{ drugName: 'Amoxicillin' }],
+        patient: null,
+      });
+
+      const result = await service.dispensePrescription(
+        'hospital-a',
+        { prescriptionId: 'rx-1' },
+        actor,
+      );
+
+      expect(stock.quantity).toBe('4.00');
+      expect(result.status).toBe('dispensed');
+      expect(audit.log).toHaveBeenCalled();
+    });
+
+    it('throws NotFound when prescription missing', async () => {
+      const rxQb = {
+        setLock: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      };
+      manager.createQueryBuilder.mockReturnValueOnce(rxQb);
+
+      await expect(
+        service.dispensePrescription(
+          'hospital-a',
+          { prescriptionId: 'missing' },
+          actor,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/pharmacy/pharmacy.service.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.ts
@@ -158,19 +158,82 @@ export class PharmacyService {
     input: DispensePrescriptionInput,
     actor: AuthenticatedUser,
   ): Promise<PendingPrescriptionType> {
-    const prescription = await this.prescriptionsRepo.findOne({
-      where: { id: input.prescriptionId, hospitalId },
+    const savedId = await this.prescriptionsRepo.manager.transaction(
+      async (manager) => {
+        const prescription = await manager
+          .createQueryBuilder(Prescription, 'prescription')
+          .setLock('pessimistic_write')
+          .leftJoinAndSelect('prescription.items', 'items')
+          .leftJoinAndSelect('prescription.patient', 'patient')
+          .where('prescription.id = :id', { id: input.prescriptionId })
+          .andWhere('prescription.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!prescription)
+          throw new NotFoundException('Prescription not found');
+        if (prescription.status !== 'pending') {
+          throw new BadRequestException(
+            'Only pending prescriptions can be dispensed',
+          );
+        }
+
+        const items = prescription.items ?? [];
+        if (items.length === 0) {
+          throw new BadRequestException(
+            'Prescription has no items to dispense',
+          );
+        }
+
+        // Aggregate required units by normalized drug name (1 unit per line item)
+        const requiredByDrug = new Map<
+          string,
+          { label: string; qty: number }
+        >();
+        for (const item of items) {
+          const key = item.drugName.trim().toLowerCase();
+          const existing = requiredByDrug.get(key);
+          if (existing) {
+            existing.qty += 1;
+          } else {
+            requiredByDrug.set(key, { label: item.drugName.trim(), qty: 1 });
+          }
+        }
+
+        for (const [key, { label, qty }] of requiredByDrug) {
+          const stock = await manager
+            .createQueryBuilder(PharmacyStock, 'stock')
+            .setLock('pessimistic_write')
+            .where('stock.hospital_id = :hospitalId', { hospitalId })
+            .andWhere('LOWER(stock.drug_name) = :drugName', { drugName: key })
+            .getOne();
+
+          if (!stock) {
+            throw new BadRequestException(
+              `No pharmacy stock found for "${label}"`,
+            );
+          }
+
+          const available = this.toNumber(stock.quantity);
+          if (available < qty) {
+            throw new BadRequestException(
+              `Insufficient stock for "${label}": need ${qty}, have ${available}`,
+            );
+          }
+
+          stock.quantity = (available - qty).toFixed(2);
+          await manager.save(stock);
+        }
+
+        prescription.status = 'dispensed';
+        const saved = await manager.save(prescription);
+        return saved.id;
+      },
+    );
+
+    const saved = await this.prescriptionsRepo.findOne({
+      where: { id: savedId, hospitalId },
       relations: ['items', 'patient'],
     });
-    if (!prescription) throw new NotFoundException('Prescription not found');
-    if (prescription.status !== 'pending') {
-      throw new BadRequestException(
-        'Only pending prescriptions can be dispensed',
-      );
-    }
-
-    prescription.status = 'dispensed';
-    const saved = await this.prescriptionsRepo.save(prescription);
+    if (!saved) throw new NotFoundException('Prescription not found');
 
     await this.audit.log({
       actorId: actor.id,
@@ -178,7 +241,7 @@ export class PharmacyService {
       action: 'update',
       resource: 'prescription',
       resourceId: saved.id,
-      metadata: { status: 'dispensed' },
+      metadata: { status: 'dispensed', stockDecremented: true },
     });
 
     return this.toPendingPrescriptionType(saved);


### PR DESCRIPTION
## Summary
- Transactional dispense with pessimistic locks on prescription + stock
- Match stock by drug name (case-insensitive); decrement 1 unit per item
- Clear errors for missing/insufficient stock
- Unit tests for missing stock, insufficient qty, and successful decrement

Closes #10

## Test plan
- [x] PharmacyService unit tests
- [ ] Dispense with stock succeeds and quantity decreases
- [ ] Dispense without stock / low stock fails cleanly


Made with [Cursor](https://cursor.com)