### PR TITLE
fix: unify discharge path and prevent duplicates (#11)

### DIFF
--- a/apps/api/src/admissions/admissions.module.ts
+++ b/apps/api/src/admissions/admissions.module.ts
@@ -1,11 +1,15 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Admission, Bed, Patient, Ward } from '../database/entities';
+import { DischargeModule } from '../discharge/discharge.module';
 import { AdmissionsResolver } from './admissions.resolver';
 import { AdmissionsService } from './admissions.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Admission, Patient, Ward, Bed])],
+  imports: [
+    TypeOrmModule.forFeature([Admission, Patient, Ward, Bed]),
+    DischargeModule,
+  ],
   providers: [AdmissionsResolver, AdmissionsService],
   exports: [AdmissionsService],
 })

--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Admission, Bed, Patient, Ward } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { DischargeService } from '../discharge/discharge.service';
 import { AdmissionsService } from './admissions.service';
 
 describe('AdmissionsService', () => {
@@ -32,6 +33,7 @@ describe('AdmissionsService', () => {
   const wardsRepo = { findOne: jest.fn(), find: jest.fn() };
   const bedsRepo = { findOne: jest.fn(), find: jest.fn(), save: jest.fn() };
   const audit = { log: jest.fn() };
+  const dischargeService = { createDischarge: jest.fn() };
 
   const actor: AuthenticatedUser = {
     id: 'admin-1',
@@ -55,6 +57,7 @@ describe('AdmissionsService', () => {
         { provide: getRepositoryToken(Ward), useValue: wardsRepo },
         { provide: getRepositoryToken(Bed), useValue: bedsRepo },
         { provide: AuditService, useValue: audit },
+        { provide: DischargeService, useValue: dischargeService },
       ],
     }).compile();
 

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -9,6 +9,7 @@ import { QueryFailedError, Repository } from 'typeorm';
 import { Admission, Bed, Patient, Ward } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { DischargeService } from '../discharge/discharge.service';
 import {
   AdmissionType,
   AdmitPatientInput,
@@ -34,6 +35,7 @@ export class AdmissionsService {
     @InjectRepository(Ward) private readonly wardsRepo: Repository<Ward>,
     @InjectRepository(Bed) private readonly bedsRepo: Repository<Bed>,
     private readonly audit: AuditService,
+    private readonly dischargeService: DischargeService,
   ) {}
 
   assertHospitalAccess(user: AuthenticatedUser, hospitalId: string) {
@@ -225,50 +227,19 @@ export class AdmissionsService {
     input: DischargeAdmissionInput,
     actor: AuthenticatedUser,
   ): Promise<AdmissionType> {
-    const admission = await this.findAdmissionOrThrow(input.id, hospitalId);
-
-    if (admission.status !== 'active') {
-      throw new BadRequestException('Admission is not active');
-    }
-
-    admission.status = 'discharged';
-    admission.dischargedAt = new Date();
-    if (input.notes) {
-      admission.reason = admission.reason
-        ? `${admission.reason}\nDischarge notes: ${input.notes}`
-        : input.notes;
-    }
-
-    if (admission.bedId) {
-      const bed = await this.bedsRepo.findOne({
-        where: { id: admission.bedId, hospitalId },
-      });
-      if (bed) {
-        bed.status = 'available';
-        await this.bedsRepo.save(bed);
-      }
-    }
-
-    const saved = await this.admissionsRepo.save(admission);
-
-    const patient = await this.patientsRepo.findOne({
-      where: { id: admission.patientId, hospitalId },
-    });
-    if (patient) {
-      patient.status = 'discharged';
-      await this.patientsRepo.save(patient);
-    }
-
-    await this.audit.log({
-      actorId: actor.id,
+    // Canonical path: always create a clinical discharge summary via DischargeService
+    await this.dischargeService.createDischarge(
       hospitalId,
-      action: 'discharge',
-      resource: 'admission',
-      resourceId: saved.id,
-      metadata: { patientId: saved.patientId },
-    });
+      {
+        admissionId: input.id,
+        summary: input.notes?.trim() || 'Discharged',
+      },
+      actor,
+    );
 
-    return this.toAdmissionType(saved);
+    return this.toAdmissionType(
+      await this.findAdmissionOrThrow(input.id, hospitalId),
+    );
   }
 
   async wardOccupancy(hospitalId: string): Promise<WardOccupancyType[]> {

--- a/apps/api/src/discharge/discharge.service.spec.ts
+++ b/apps/api/src/discharge/discharge.service.spec.ts
@@ -1,0 +1,89 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Admission, Discharge, FollowUp, Patient } from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from '../audit/audit.service';
+import { DischargeService } from './discharge.service';
+
+describe('DischargeService', () => {
+  let service: DischargeService;
+
+  const manager = {
+    createQueryBuilder: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({
+      id: 'discharge-1',
+      ...data,
+    })),
+  };
+
+  const dischargesRepo = {
+    manager: {
+      transaction: jest.fn((cb: (m: typeof manager) => unknown) =>
+        Promise.resolve(cb(manager)),
+      ),
+    },
+    findOne: jest.fn(),
+    find: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+  };
+  const followUpsRepo = { save: jest.fn(), create: jest.fn(), find: jest.fn() };
+  const patientsRepo = { findOne: jest.fn(), save: jest.fn() };
+  const audit = { log: jest.fn() };
+
+  const actor: AuthenticatedUser = {
+    id: 'doc-1',
+    authId: 'auth-1',
+    email: 'doc@h.com',
+    fullName: 'Doctor',
+    hospitalId: 'hospital-a',
+    roles: ['doctor'],
+    permissions: ['patients:write'],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DischargeService,
+        { provide: getRepositoryToken(Discharge), useValue: dischargesRepo },
+        { provide: getRepositoryToken(FollowUp), useValue: followUpsRepo },
+        { provide: getRepositoryToken(Patient), useValue: patientsRepo },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = module.get(DischargeService);
+  });
+
+  describe('createDischarge', () => {
+    it('rejects duplicate discharge summary for the same admission', async () => {
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'adm-1',
+          hospitalId: 'hospital-a',
+          patientId: 'patient-1',
+          status: 'active',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+      manager.findOne.mockResolvedValue({ id: 'existing-discharge' });
+
+      await expect(
+        service.createDischarge(
+          'hospital-a',
+          { admissionId: 'adm-1', summary: 'Recovered' },
+          actor,
+        ),
+      ).rejects.toThrow(
+        'A discharge summary already exists for this admission',
+      );
+    });
+  });
+});

--- a/apps/api/src/discharge/discharge.service.spec.ts
+++ b/apps/api/src/discharge/discharge.service.spec.ts
@@ -1,7 +1,6 @@
-import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Admission, Discharge, FollowUp, Patient } from '../database/entities';
+import { Discharge, FollowUp, Patient } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
 import { DischargeService } from './discharge.service';

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -1,10 +1,11 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import {
   Admission,
   Bed,
@@ -22,6 +23,13 @@ import {
   UpdateFollowUpStatusInput,
 } from './discharge.types';
 
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error as QueryFailedError & { code?: string }).code === '23505'
+  );
+}
+
 @Injectable()
 export class DischargeService {
   constructor(
@@ -29,11 +37,8 @@ export class DischargeService {
     private readonly dischargesRepo: Repository<Discharge>,
     @InjectRepository(FollowUp)
     private readonly followUpsRepo: Repository<FollowUp>,
-    @InjectRepository(Admission)
-    private readonly admissionsRepo: Repository<Admission>,
     @InjectRepository(Patient)
     private readonly patientsRepo: Repository<Patient>,
-    @InjectRepository(Bed) private readonly bedsRepo: Repository<Bed>,
     private readonly audit: AuditService,
   ) {}
 
@@ -86,87 +91,116 @@ export class DischargeService {
     };
   }
 
-  private async dischargeAdmissionIfActive(
-    admission: Admission,
-    hospitalId: string,
-  ): Promise<void> {
-    if (admission.status !== 'active') return;
-
-    admission.status = 'discharged';
-    admission.dischargedAt = new Date();
-    await this.admissionsRepo.save(admission);
-
-    if (admission.bedId) {
-      const bed = await this.bedsRepo.findOne({
-        where: { id: admission.bedId, hospitalId },
-      });
-      if (bed) {
-        bed.status = 'available';
-        await this.bedsRepo.save(bed);
-      }
-    }
-
-    const patient = await this.patientsRepo.findOne({
-      where: { id: admission.patientId, hospitalId },
-    });
-    if (patient) {
-      patient.status = 'discharged';
-      await this.patientsRepo.save(patient);
-    }
-  }
-
   async createDischarge(
     hospitalId: string,
     input: CreateDischargeInput,
     actor: AuthenticatedUser,
   ): Promise<DischargeType> {
-    const admission = await this.admissionsRepo.findOne({
-      where: { id: input.admissionId, hospitalId },
-    });
-    if (!admission) throw new NotFoundException('Admission not found');
+    try {
+      const dischargeId = await this.dischargesRepo.manager.transaction(
+        async (manager) => {
+          const admission = await manager
+            .createQueryBuilder(Admission, 'admission')
+            .setLock('pessimistic_write')
+            .where('admission.id = :id', { id: input.admissionId })
+            .andWhere('admission.hospital_id = :hospitalId', { hospitalId })
+            .getOne();
+          if (!admission) throw new NotFoundException('Admission not found');
 
-    await this.dischargeAdmissionIfActive(admission, hospitalId);
+          const existing = await manager.findOne(Discharge, {
+            where: { admissionId: admission.id },
+          });
+          if (existing) {
+            throw new BadRequestException(
+              'A discharge summary already exists for this admission',
+            );
+          }
 
-    const discharge = await this.dischargesRepo.save(
-      this.dischargesRepo.create({
-        hospitalId,
-        admissionId: admission.id,
-        patientId: admission.patientId,
-        dischargedById: actor.id,
-        summary: input.summary,
-        medicationsAtDischarge: input.medicationsAtDischarge,
-        instructions: input.instructions,
-        dischargedAt: new Date(),
-      }),
-    );
+          if (admission.status === 'active') {
+            admission.status = 'discharged';
+            admission.dischargedAt = new Date();
+            await manager.save(admission);
 
-    if (input.followUpScheduledAt) {
-      await this.followUpsRepo.save(
-        this.followUpsRepo.create({
-          hospitalId,
-          patientId: admission.patientId,
-          dischargeId: discharge.id,
-          doctorId: input.followUpDoctorId ?? admission.attendingDoctorId,
-          scheduledAt: new Date(input.followUpScheduledAt),
-          type: input.followUpType ?? 'post_discharge',
-          status: 'scheduled',
-        }),
+            if (admission.bedId) {
+              const bed = await manager.findOne(Bed, {
+                where: { id: admission.bedId, hospitalId },
+              });
+              if (bed) {
+                bed.status = 'available';
+                await manager.save(bed);
+              }
+            }
+
+            const patient = await manager.findOne(Patient, {
+              where: { id: admission.patientId, hospitalId },
+            });
+            if (patient) {
+              patient.status = 'discharged';
+              await manager.save(patient);
+            }
+          } else if (admission.status !== 'discharged') {
+            throw new BadRequestException(
+              'Only active or already-discharged admissions can receive a discharge summary',
+            );
+          }
+
+          const discharge = await manager.save(
+            manager.create(Discharge, {
+              hospitalId,
+              admissionId: admission.id,
+              patientId: admission.patientId,
+              dischargedById: actor.id,
+              summary: input.summary,
+              medicationsAtDischarge: input.medicationsAtDischarge,
+              instructions: input.instructions,
+              dischargedAt: new Date(),
+            }),
+          );
+
+          if (input.followUpScheduledAt) {
+            await manager.save(
+              manager.create(FollowUp, {
+                hospitalId,
+                patientId: admission.patientId,
+                dischargeId: discharge.id,
+                doctorId: input.followUpDoctorId ?? admission.attendingDoctorId,
+                scheduledAt: new Date(input.followUpScheduledAt),
+                type: input.followUpType ?? 'post_discharge',
+                status: 'scheduled',
+              }),
+            );
+          }
+
+          return discharge.id;
+        },
       );
+
+      const discharge = await this.dischargesRepo.findOne({
+        where: { id: dischargeId, hospitalId },
+      });
+      if (!discharge) throw new NotFoundException('Discharge not found');
+
+      await this.audit.log({
+        actorId: actor.id,
+        hospitalId,
+        action: 'create',
+        resource: 'discharge',
+        resourceId: discharge.id,
+        metadata: {
+          patientId: discharge.patientId,
+          admissionId: discharge.admissionId,
+        },
+      });
+
+      return this.toDischargeType(discharge);
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new BadRequestException(
+          'A discharge summary already exists for this admission',
+        );
+      }
+      throw error;
     }
-
-    await this.audit.log({
-      actorId: actor.id,
-      hospitalId,
-      action: 'create',
-      resource: 'discharge',
-      resourceId: discharge.id,
-      metadata: {
-        patientId: discharge.patientId,
-        admissionId: discharge.admissionId,
-      },
-    });
-
-    return this.toDischargeType(discharge);
   }
 
   async createFollowUp(

--- a/supabase/migrations/20240609000014_unique_discharge_per_admission.sql
+++ b/supabase/migrations/20240609000014_unique_discharge_per_admission.sql
@@ -1,0 +1,3 @@
+-- One clinical discharge summary per admission
+CREATE UNIQUE INDEX IF NOT EXISTS idx_discharges_admission_unique
+  ON discharges (admission_id);


### PR DESCRIPTION
## Summary
- `createDischarge` is the single transactional discharge path (summary + bed + patient)
- `dischargeAdmission` delegates to `createDischarge` so both APIs stay consistent
- Unique index on `discharges.admission_id` blocks duplicate summaries
- Unit test for duplicate-discharge rejection

Closes #11

## Test plan
- [x] Discharge + admissions unit tests
- [ ] UI createDischarge still discharges patient and frees bed
- [ ] Second createDischarge for same admission fails


Made with [Cursor](https://cursor.com)