### PR TITLE
fix: client-side dashboard route RBAC (#12)

### DIFF
--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -4,13 +4,21 @@ import { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useQuery } from '@apollo/client';
 import { DashboardSidebar } from '@/components/layout/dashboard-sidebar';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { ME_QUERY } from '@/lib/graphql/queries';
+import { canAccessRoute } from '@/lib/route-access';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const { data } = useQuery(ME_QUERY, { errorPolicy: 'all' });
+  const { data, loading } = useQuery(ME_QUERY, { errorPolicy: 'all' });
   const me = data?.me;
+
+  const roles: string[] = me?.roles ?? [];
+  const permissions: string[] = me?.permissions ?? [];
+  const allowed =
+    !me ||
+    canAccessRoute(pathname, { roles, permissions });
 
   useEffect(() => {
     if (!me) return;
@@ -33,7 +41,13 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       </a>
       <DashboardSidebar />
       <main id="main-content" tabIndex={-1} className="flex-1 overflow-auto outline-none">
-        {children}
+        {loading && !me ? (
+          <p className="text-clay-text-muted">Loading...</p>
+        ) : !allowed ? (
+          <ForbiddenAccess />
+        ) : (
+          children
+        )}
       </main>
     </div>
   );

--- a/apps/web/src/components/auth/forbidden-access.tsx
+++ b/apps/web/src/components/auth/forbidden-access.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Link from 'next/link';
+import { ClayButton, ClayCard } from '@careconnect/ui';
+
+export function ForbiddenAccess({
+  title = 'Access denied',
+  message = 'You do not have permission to view this page.',
+}: {
+  title?: string;
+  message?: string;
+}) {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center p-6">
+      <ClayCard className="max-w-md space-y-4 p-8 text-center">
+        <h1 className="text-xl font-bold text-clay-text">{title}</h1>
+        <p className="text-sm text-clay-text-muted">{message}</p>
+        <Link href="/dashboard">
+          <ClayButton>Back to dashboard</ClayButton>
+        </Link>
+      </ClayCard>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/dashboard-sidebar.tsx
+++ b/apps/web/src/components/layout/dashboard-sidebar.tsx
@@ -25,30 +25,25 @@ import { useTranslations } from 'next-intl';
 import { useClerk } from '@clerk/nextjs';
 import { cn } from '@careconnect/ui';
 import { ME_QUERY } from '@/lib/graphql/queries';
+import { canSeeNavHref } from '@/lib/route-access';
 
 type NavItem = { href: string; key: string; icon: typeof LayoutDashboard };
 
-const baseNav: NavItem[] = [
+const allNav: NavItem[] = [
   { href: '/dashboard', key: 'dashboard', icon: LayoutDashboard },
   { href: '/staff', key: 'staff', icon: UserCog },
   { href: '/patients', key: 'patients', icon: Users },
   { href: '/appointments', key: 'appointments', icon: Calendar },
   { href: '/admissions', key: 'admissions', icon: BedDouble },
-  { href: '/follow-ups', key: 'followUps', icon: CalendarCheck },
-  { href: '/settings', key: 'settings', icon: Settings },
-];
-
-const clinicalNav: NavItem[] = [
   { href: '/doctor', key: 'doctor', icon: Stethoscope },
   { href: '/nurse', key: 'nurse', icon: HeartPulse },
   { href: '/lab', key: 'lab', icon: FlaskConical },
-];
-
-const adminNav: NavItem[] = [
+  { href: '/follow-ups', key: 'followUps', icon: CalendarCheck },
   { href: '/finance', key: 'finance', icon: DollarSign },
   { href: '/pharmacy', key: 'pharmacy', icon: Pill },
   { href: '/inventory', key: 'inventory', icon: Package },
   { href: '/reports', key: 'reports', icon: BarChart3 },
+  { href: '/settings', key: 'settings', icon: Settings },
 ];
 
 export function DashboardSidebar() {
@@ -59,41 +54,17 @@ export function DashboardSidebar() {
   const { data: meData } = useQuery(ME_QUERY);
 
   const roles: string[] = meData?.me?.roles ?? [];
+  const permissions: string[] = meData?.me?.permissions ?? [];
+  const access = { roles, permissions };
+
   const isHospitalAdmin =
     roles.includes('hospital_admin') ||
     roles.includes('hospital_manager') ||
     roles.includes('super_admin');
   const isDoctor = roles.includes('doctor');
   const isNurse = roles.includes('nurse');
-  const isLab = roles.includes('lab_technician');
-  const isPharmacist = roles.includes('pharmacist');
-  const isAccountant = roles.includes('accountant');
 
-  const navItems: NavItem[] = [...baseNav];
-  if (isDoctor) navItems.splice(5, 0, clinicalNav[0]);
-  if (isNurse) navItems.splice(5, 0, clinicalNav[1]);
-  if (isLab || isHospitalAdmin) navItems.splice(5, 0, clinicalNav[2]);
-  if (isHospitalAdmin || isAccountant) {
-    navItems.splice(navItems.length - 1, 0, ...adminNav.filter((n) => n.key === 'finance' || n.key === 'reports'));
-  }
-  if (isHospitalAdmin || isPharmacist) {
-    navItems.splice(navItems.length - 1, 0, ...adminNav.filter((n) => n.key === 'pharmacy' || n.key === 'inventory'));
-  }
-  if (isHospitalAdmin) {
-    for (const item of adminNav) {
-      if (!navItems.some((n) => n.href === item.href)) {
-        navItems.splice(navItems.length - 1, 0, item);
-      }
-    }
-  }
-
-  // Deduplicate by href
-  const seen = new Set<string>();
-  const uniqueNav = navItems.filter((item) => {
-    if (seen.has(item.href)) return false;
-    seen.add(item.href);
-    return true;
-  });
+  const uniqueNav = allNav.filter((item) => canSeeNavHref(item.href, access));
 
   const brandSubtitle = isHospitalAdmin
     ? t('brandSubtitleAdmin')
@@ -108,6 +79,8 @@ export function DashboardSidebar() {
     router.push('/login');
     router.refresh();
   };
+
+  const showFacility = canSeeNavHref('/settings', access);
 
   return (
     <aside
@@ -154,13 +127,15 @@ export function DashboardSidebar() {
       </nav>
 
       <div className="mt-auto space-y-1 border-t border-white/40 pt-4">
-        <Link
-          href="/settings/facility"
-          className="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm text-clay-text-muted hover:bg-clay-primary-light/50 hover:text-clay-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-clay-primary"
-        >
-          <Building2 className="h-5 w-5" aria-hidden="true" />
-          {t('facility')}
-        </Link>
+        {showFacility ? (
+          <Link
+            href="/settings/facility"
+            className="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm text-clay-text-muted hover:bg-clay-primary-light/50 hover:text-clay-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-clay-primary"
+          >
+            <Building2 className="h-5 w-5" aria-hidden="true" />
+            {t('facility')}
+          </Link>
+        ) : null}
         <button
           type="button"
           onClick={handleLogout}

--- a/apps/web/src/lib/route-access.ts
+++ b/apps/web/src/lib/route-access.ts
@@ -1,0 +1,80 @@
+/**
+ * Client-side route access rules (defense-in-depth; API still enforces).
+ * Prefer permissions when available; fall back to roles for role-specific boards.
+ */
+
+export type AccessContext = {
+  roles: string[];
+  permissions: string[];
+};
+
+type RouteRule = {
+  /** Path prefix matched with exact or `${prefix}/...` */
+  prefix: string;
+  anyPermissions?: string[];
+  anyRoles?: string[];
+};
+
+const ROUTE_RULES: RouteRule[] = [
+  { prefix: '/staff', anyPermissions: ['staff:read'] },
+  { prefix: '/patients', anyPermissions: ['patients:read'] },
+  { prefix: '/appointments', anyPermissions: ['appointments:read'] },
+  { prefix: '/admissions', anyPermissions: ['patients:read'] },
+  { prefix: '/wards', anyPermissions: ['hospitals:read', 'patients:read'] },
+  { prefix: '/follow-ups', anyPermissions: ['patients:read'] },
+  { prefix: '/finance', anyPermissions: ['billing:read'] },
+  {
+    prefix: '/pharmacy',
+    anyRoles: ['pharmacist', 'hospital_admin', 'hospital_manager', 'super_admin'],
+  },
+  {
+    prefix: '/inventory',
+    anyRoles: ['pharmacist', 'hospital_admin', 'hospital_manager', 'super_admin'],
+  },
+  { prefix: '/reports', anyPermissions: ['reports:read'] },
+  { prefix: '/dashboard/hospital', anyPermissions: ['reports:read'] },
+  {
+    prefix: '/doctor',
+    anyRoles: ['doctor', 'hospital_admin', 'hospital_manager', 'super_admin'],
+  },
+  {
+    prefix: '/nurse',
+    anyRoles: ['nurse', 'hospital_admin', 'hospital_manager', 'super_admin'],
+  },
+  {
+    prefix: '/lab',
+    anyRoles: ['lab_technician', 'hospital_admin', 'hospital_manager', 'super_admin'],
+    anyPermissions: ['lab:write'],
+  },
+  {
+    prefix: '/settings',
+    anyRoles: ['hospital_admin', 'hospital_manager', 'super_admin'],
+    anyPermissions: ['hospitals:write'],
+  },
+];
+
+/** Longest prefix first so /dashboard/hospital wins over /dashboard */
+const SORTED_RULES = [...ROUTE_RULES].sort(
+  (a, b) => b.prefix.length - a.prefix.length,
+);
+
+export function canAccessRoute(pathname: string, ctx: AccessContext): boolean {
+  if (ctx.roles.includes('super_admin')) return true;
+  if (ctx.roles.includes('patient')) return false;
+
+  const rule = SORTED_RULES.find(
+    (r) => pathname === r.prefix || pathname.startsWith(`${r.prefix}/`),
+  );
+  if (!rule) return true;
+
+  if (rule.anyRoles?.some((role) => ctx.roles.includes(role))) return true;
+  if (rule.anyPermissions?.some((perm) => ctx.permissions.includes(perm))) {
+    return true;
+  }
+  return false;
+}
+
+/** Whether a nav href should be shown for this user */
+export function canSeeNavHref(href: string, ctx: AccessContext): boolean {
+  return canAccessRoute(href, ctx);
+}


### PR DESCRIPTION
## Summary
- Shared `route-access` rules map path prefixes to roles/permissions
- Dashboard layout shows Access denied when unauthorized
- Sidebar nav filtered with the same rules (`me.permissions` used)

Closes #12

## Test plan
- [ ] Receptionist cannot open `/finance` (sees Access denied)
- [ ] Accountant can open `/finance`
- [ ] Doctor sees `/doctor` nav; nurse does not


Made with [Cursor](https://cursor.com)