### PR TITLE
fix: scope doctor dashboard to own appointments (#13)

### DIFF
--- a/apps/web/src/app/(dashboard)/doctor/page.tsx
+++ b/apps/web/src/app/(dashboard)/doctor/page.tsx
@@ -19,10 +19,11 @@ export default function DoctorDashboardPage() {
   const today = todayDateString();
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const doctorId = meData?.me?.id;
 
   const { data, loading } = useQuery(APPOINTMENTS_QUERY, {
-    variables: { hospitalId, date: today },
-    skip: !hospitalId,
+    variables: { hospitalId, date: today, doctorId },
+    skip: !hospitalId || !doctorId,
   });
 
   const appointments = data?.appointments ?? [];

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -413,8 +413,18 @@ export const DASHBOARD_STATS_QUERY = gql`
 `;
 
 export const APPOINTMENTS_QUERY = gql`
-  query Appointments($hospitalId: String, $date: String, $status: String) {
-    appointments(hospitalId: $hospitalId, date: $date, status: $status) {
+  query Appointments(
+    $hospitalId: String
+    $date: String
+    $status: String
+    $doctorId: String
+  ) {
+    appointments(
+      hospitalId: $hospitalId
+      date: $date
+      status: $status
+      doctorId: $doctorId
+    ) {
       id
       patientId
       patient {


### PR DESCRIPTION
## Summary
- Add `$doctorId` to `APPOINTMENTS_QUERY`
- Doctor dashboard passes `me.id` so only that doctor's appointments load
- Hospital-wide appointments page is unchanged (no doctorId filter)

Closes #13

## Test plan
- [ ] Doctor dashboard lists only appointments where doctorId === me.id
- [ ] `/appointments` without doctorId still shows hospital-wide schedule


Made with [Cursor](https://cursor.com)