### PR TITLE
fix: gate patient portal by role (#15)

### DIFF
--- a/apps/web/src/app/(portal)/portal-layout-client.tsx
+++ b/apps/web/src/app/(portal)/portal-layout-client.tsx
@@ -1,25 +1,40 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import { useUser } from '@clerk/nextjs';
 import { COMPLETE_PATIENT_ONBOARDING, ME_QUERY } from '@/lib/graphql/queries';
 import { PortalSidebar } from '@/components/layout/portal-sidebar';
 
 export function PortalLayoutClient({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const { user } = useUser();
-  const { data, refetch } = useQuery(ME_QUERY);
+  const { data, loading, refetch } = useQuery(ME_QUERY);
   const [completePatientOnboarding] = useMutation(COMPLETE_PATIENT_ONBOARDING);
   const ran = useRef(false);
+  const me = data?.me;
+  const roles: string[] = me?.roles ?? [];
+  const isPatient = roles.includes('patient') || roles.includes('super_admin');
+  const isStaff =
+    roles.length > 0 &&
+    !roles.includes('patient') &&
+    me?.onboardingCompleted;
+
+  useEffect(() => {
+    // Staff/admin with completed onboarding must stay on the hospital dashboard
+    if (isStaff) {
+      router.replace('/dashboard');
+    }
+  }, [isStaff, router]);
 
   useEffect(() => {
     const needsComplete =
       searchParams.get('completePatient') === '1' ||
-      (data?.me &&
-        !data.me.roles?.includes('patient') &&
-        !data.me.onboardingCompleted &&
+      (me &&
+        !me.roles?.includes('patient') &&
+        !me.onboardingCompleted &&
         user?.unsafeMetadata?.accountType === 'patient');
 
     if (!needsComplete || ran.current || !user) return;
@@ -36,7 +51,23 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
       .catch(() => {
         ran.current = false;
       });
-  }, [searchParams, data?.me, user, completePatientOnboarding, refetch]);
+  }, [searchParams, me, user, completePatientOnboarding, refetch]);
+
+  if (loading && !me) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-clay-bg text-clay-text-muted">
+        Loading portal…
+      </div>
+    );
+  }
+
+  if (isStaff) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-clay-bg text-clay-text-muted">
+        Redirecting to dashboard…
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen gap-6 bg-clay-bg p-6">
@@ -48,6 +79,12 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
       </a>
       <PortalSidebar />
       <main id="portal-main" className="flex-1 overflow-auto">
+        {!isPatient && me?.onboardingCompleted ? (
+          <p className="mb-4 rounded-2xl bg-clay-warning/10 p-4 text-sm text-clay-text">
+            Your account is not a patient portal user. If you are hospital staff, use the
+            dashboard instead.
+          </p>
+        ) : null}
         {children}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Portal layout redirects completed non-patient (staff) users to `/dashboard`
- Patients and in-progress patient onboarding remain on portal
- Clear message if a non-patient somehow remains

Closes #15

## Test plan
- [ ] Hospital admin visiting `/portal` is redirected to `/dashboard`
- [ ] Patient can still use `/portal`
- [ ] New patient signup with `completePatient=1` still completes onboarding


Made with [Cursor](https://cursor.com)