### PR TITLE
fix: enforce appointment status machine (#17)

### DIFF
--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -1,0 +1,94 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Appointment, Department, Patient } from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from '../audit/audit.service';
+import { AppointmentsService } from './appointments.service';
+
+describe('AppointmentsService status machine', () => {
+  let service: AppointmentsService;
+
+  const appointmentsRepo = {
+    findOne: jest.fn(),
+    save: jest.fn(async (a: Appointment) => a),
+    find: jest.fn(),
+    create: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+  const patientsRepo = { findOne: jest.fn() };
+  const departmentsRepo = { findOne: jest.fn() };
+  const audit = { log: jest.fn() };
+
+  const actor: AuthenticatedUser = {
+    id: 'user-1',
+    authId: 'auth-1',
+    email: 'r@h.com',
+    fullName: 'Reception',
+    hospitalId: 'hospital-a',
+    roles: ['receptionist'],
+    permissions: ['appointments:write'],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppointmentsService,
+        {
+          provide: getRepositoryToken(Appointment),
+          useValue: appointmentsRepo,
+        },
+        { provide: getRepositoryToken(Patient), useValue: patientsRepo },
+        { provide: getRepositoryToken(Department), useValue: departmentsRepo },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = module.get(AppointmentsService);
+  });
+
+  it('allows scheduled → checked_in', async () => {
+    appointmentsRepo.findOne.mockResolvedValue({
+      id: 'appt-1',
+      hospitalId: 'hospital-a',
+      status: 'scheduled',
+    });
+    const result = await service.updateStatus(
+      'appt-1',
+      'checked_in',
+      'hospital-a',
+      actor,
+    );
+    expect(result.status).toBe('checked_in');
+  });
+
+  it('rejects completed → scheduled', async () => {
+    appointmentsRepo.findOne.mockResolvedValue({
+      id: 'appt-1',
+      hospitalId: 'hospital-a',
+      status: 'completed',
+    });
+    await expect(
+      service.updateStatus('appt-1', 'scheduled', 'hospital-a', actor),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects cancelling a completed appointment', async () => {
+    appointmentsRepo.findOne.mockResolvedValue({
+      id: 'appt-1',
+      hospitalId: 'hospital-a',
+      status: 'completed',
+    });
+    await expect(
+      service.cancel('hospital-a', { id: 'appt-1' }, actor),
+    ).rejects.toThrow(/Cannot transition/);
+  });
+
+  it('throws NotFound when appointment missing', async () => {
+    appointmentsRepo.findOne.mockResolvedValue(null);
+    await expect(
+      service.updateStatus('missing', 'checked_in', 'hospital-a', actor),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -11,7 +11,7 @@ describe('AppointmentsService status machine', () => {
 
   const appointmentsRepo = {
     findOne: jest.fn(),
-    save: jest.fn(async (a: Appointment) => a),
+    save: jest.fn((a: Appointment) => Promise.resolve(a)),
     find: jest.fn(),
     create: jest.fn(),
     createQueryBuilder: jest.fn(),

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -16,6 +16,31 @@ import {
   CreateAppointmentInput,
 } from './appointments.types';
 
+/**
+ * Appointment status machine:
+ *   scheduled → checked_in → completed
+ *            ↘ cancelled / no_show
+ *   checked_in → completed / cancelled / no_show
+ * Terminal: completed, cancelled, no_show (immutable)
+ */
+const ALLOWED_TRANSITIONS: Record<string, readonly string[]> = {
+  scheduled: ['checked_in', 'cancelled', 'no_show', 'completed'],
+  checked_in: ['completed', 'cancelled', 'no_show'],
+  completed: [],
+  cancelled: [],
+  no_show: [],
+};
+
+function assertTransition(from: string, to: string) {
+  if (from === to) return;
+  const allowed = ALLOWED_TRANSITIONS[from] ?? [];
+  if (!allowed.includes(to)) {
+    throw new BadRequestException(
+      `Cannot transition appointment from "${from}" to "${to}"`,
+    );
+  }
+}
+
 @Injectable()
 export class AppointmentsService {
   constructor(
@@ -194,6 +219,7 @@ export class AppointmentsService {
     }
 
     const appointment = await this.findAppointmentOrThrow(id, hospitalId);
+    assertTransition(appointment.status, status);
     appointment.status = status;
     const saved = await this.appointmentsRepo.save(appointment);
 
@@ -216,9 +242,7 @@ export class AppointmentsService {
   ): Promise<AppointmentType> {
     const appointment = await this.findAppointmentOrThrow(input.id, hospitalId);
 
-    if (appointment.status === 'cancelled') {
-      throw new BadRequestException('Appointment is already cancelled');
-    }
+    assertTransition(appointment.status, 'cancelled');
 
     appointment.status = 'cancelled';
     if (input.reason) {


### PR DESCRIPTION
## Summary
- Documented transition matrix: scheduled → checked_in → completed; cancel/no_show from non-terminal
- Terminal statuses (completed/cancelled/no_show) cannot change
- Unit tests for legal/illegal transitions

Closes #17

## Test plan
- [x] AppointmentsService status machine unit tests
- [ ] Cancelling a completed appointment fails


Made with [Cursor](https://cursor.com)