### PR TITLE
fix: validate doctor/attending against hospital staff (#18)

### DIFF
--- a/apps/api/src/admissions/admissions.module.ts
+++ b/apps/api/src/admissions/admissions.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Admission, Bed, Patient, Ward } from '../database/entities';
+import { CommonModule } from '../common/common.module';
 import { DischargeModule } from '../discharge/discharge.module';
 import { AdmissionsResolver } from './admissions.resolver';
 import { AdmissionsService } from './admissions.service';
@@ -9,6 +10,7 @@ import { AdmissionsService } from './admissions.service';
   imports: [
     TypeOrmModule.forFeature([Admission, Patient, Ward, Bed]),
     DischargeModule,
+    CommonModule,
   ],
   providers: [AdmissionsResolver, AdmissionsService],
   exports: [AdmissionsService],

--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Admission, Bed, Patient, Ward } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { HospitalDoctorValidator } from '../common/hospital-doctor.validator';
 import { DischargeService } from '../discharge/discharge.service';
 import { AdmissionsService } from './admissions.service';
 
@@ -34,6 +35,9 @@ describe('AdmissionsService', () => {
   const bedsRepo = { findOne: jest.fn(), find: jest.fn(), save: jest.fn() };
   const audit = { log: jest.fn() };
   const dischargeService = { createDischarge: jest.fn() };
+  const doctorValidator = {
+    assertHospitalDoctor: jest.fn().mockResolvedValue(undefined),
+  };
 
   const actor: AuthenticatedUser = {
     id: 'admin-1',
@@ -58,6 +62,7 @@ describe('AdmissionsService', () => {
         { provide: getRepositoryToken(Bed), useValue: bedsRepo },
         { provide: AuditService, useValue: audit },
         { provide: DischargeService, useValue: dischargeService },
+        { provide: HospitalDoctorValidator, useValue: doctorValidator },
       ],
     }).compile();
 

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -9,6 +9,7 @@ import { QueryFailedError, Repository } from 'typeorm';
 import { Admission, Bed, Patient, Ward } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { HospitalDoctorValidator } from '../common/hospital-doctor.validator';
 import { DischargeService } from '../discharge/discharge.service';
 import {
   AdmissionType,
@@ -36,6 +37,7 @@ export class AdmissionsService {
     @InjectRepository(Bed) private readonly bedsRepo: Repository<Bed>,
     private readonly audit: AuditService,
     private readonly dischargeService: DischargeService,
+    private readonly doctorValidator: HospitalDoctorValidator,
   ) {}
 
   assertHospitalAccess(user: AuthenticatedUser, hospitalId: string) {
@@ -154,6 +156,12 @@ export class AdmissionsService {
           if (bed.status !== 'available') {
             throw new BadRequestException('Bed is not available');
           }
+
+          await this.doctorValidator.assertHospitalDoctor(
+            hospitalId,
+            input.attendingDoctorId,
+            'Attending doctor',
+          );
 
           const existingAdmission = await manager.findOne(Admission, {
             where: {

--- a/apps/api/src/appointments/appointments.module.ts
+++ b/apps/api/src/appointments/appointments.module.ts
@@ -1,11 +1,15 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Appointment, Department, Patient } from '../database/entities';
+import { CommonModule } from '../common/common.module';
 import { AppointmentsResolver } from './appointments.resolver';
 import { AppointmentsService } from './appointments.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Appointment, Patient, Department])],
+  imports: [
+    TypeOrmModule.forFeature([Appointment, Patient, Department]),
+    CommonModule,
+  ],
   providers: [AppointmentsResolver, AppointmentsService],
   exports: [AppointmentsService],
 })

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Appointment, Department, Patient } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { HospitalDoctorValidator } from '../common/hospital-doctor.validator';
 import { AppointmentsService } from './appointments.service';
 
 describe('AppointmentsService status machine', () => {
@@ -19,6 +20,9 @@ describe('AppointmentsService status machine', () => {
   const patientsRepo = { findOne: jest.fn() };
   const departmentsRepo = { findOne: jest.fn() };
   const audit = { log: jest.fn() };
+  const doctorValidator = {
+    assertHospitalDoctor: jest.fn().mockResolvedValue(undefined),
+  };
 
   const actor: AuthenticatedUser = {
     id: 'user-1',
@@ -43,6 +47,7 @@ describe('AppointmentsService status machine', () => {
         { provide: getRepositoryToken(Patient), useValue: patientsRepo },
         { provide: getRepositoryToken(Department), useValue: departmentsRepo },
         { provide: AuditService, useValue: audit },
+        { provide: HospitalDoctorValidator, useValue: doctorValidator },
       ],
     }).compile();
     service = module.get(AppointmentsService);

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -9,6 +9,7 @@ import { Between, Repository } from 'typeorm';
 import { Appointment, Department, Patient } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { HospitalDoctorValidator } from '../common/hospital-doctor.validator';
 import {
   APPOINTMENT_STATUSES,
   AppointmentType,
@@ -51,6 +52,7 @@ export class AppointmentsService {
     @InjectRepository(Department)
     private readonly departmentsRepo: Repository<Department>,
     private readonly audit: AuditService,
+    private readonly doctorValidator: HospitalDoctorValidator,
   ) {}
 
   assertHospitalAccess(user: AuthenticatedUser, hospitalId: string) {
@@ -135,6 +137,12 @@ export class AppointmentsService {
       });
       if (!department) throw new NotFoundException('Department not found');
     }
+
+    await this.doctorValidator.assertHospitalDoctor(
+      hospitalId,
+      input.doctorId,
+      'Doctor',
+    );
 
     const saved = await this.appointmentsRepo.save(
       this.appointmentsRepo.create({

--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StaffProfile } from '../database/entities';
+import { HospitalDoctorValidator } from './hospital-doctor.validator';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([StaffProfile])],
+  providers: [HospitalDoctorValidator],
+  exports: [HospitalDoctorValidator],
+})
+export class CommonModule {}

--- a/apps/api/src/common/hospital-doctor.validator.spec.ts
+++ b/apps/api/src/common/hospital-doctor.validator.spec.ts
@@ -1,0 +1,63 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { StaffProfile } from '../database/entities';
+import { HospitalDoctorValidator } from './hospital-doctor.validator';
+
+describe('HospitalDoctorValidator', () => {
+  let validator: HospitalDoctorValidator;
+  const staffRepo = { findOne: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HospitalDoctorValidator,
+        { provide: getRepositoryToken(StaffProfile), useValue: staffRepo },
+      ],
+    }).compile();
+    validator = module.get(HospitalDoctorValidator);
+  });
+
+  it('allows missing doctor id', async () => {
+    await expect(
+      validator.assertHospitalDoctor('hospital-a', undefined),
+    ).resolves.toBeUndefined();
+    expect(staffRepo.findOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects when not hospital staff', async () => {
+    staffRepo.findOne.mockResolvedValue(null);
+    await expect(
+      validator.assertHospitalDoctor('hospital-a', 'user-1'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects non-doctor staff', async () => {
+    staffRepo.findOne.mockResolvedValue({
+      userId: 'user-1',
+      hospitalId: 'hospital-a',
+      isActive: true,
+      user: {
+        userRoles: [{ hospitalId: 'hospital-a', role: { slug: 'nurse' } }],
+      },
+    });
+    await expect(
+      validator.assertHospitalDoctor('hospital-a', 'user-1'),
+    ).rejects.toThrow(/must have the doctor role/);
+  });
+
+  it('allows active doctor staff', async () => {
+    staffRepo.findOne.mockResolvedValue({
+      userId: 'user-1',
+      hospitalId: 'hospital-a',
+      isActive: true,
+      user: {
+        userRoles: [{ hospitalId: 'hospital-a', role: { slug: 'doctor' } }],
+      },
+    });
+    await expect(
+      validator.assertHospitalDoctor('hospital-a', 'user-1'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/common/hospital-doctor.validator.ts
+++ b/apps/api/src/common/hospital-doctor.validator.ts
@@ -1,0 +1,60 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { StaffProfile } from '../database/entities';
+
+/**
+ * Shared validation: doctor/attending user must be active hospital staff
+ * with the doctor role for that hospital.
+ */
+@Injectable()
+export class HospitalDoctorValidator {
+  constructor(
+    @InjectRepository(StaffProfile)
+    private readonly staffRepo: Repository<StaffProfile>,
+  ) {}
+
+  async assertHospitalDoctor(
+    hospitalId: string,
+    doctorUserId: string | undefined,
+    fieldLabel = 'Doctor',
+  ): Promise<void> {
+    if (!doctorUserId) return;
+
+    const staff = await this.staffRepo.findOne({
+      where: { userId: doctorUserId, hospitalId, isActive: true },
+      relations: ['user', 'user.userRoles', 'user.userRoles.role'],
+    });
+    if (!staff) {
+      throw new BadRequestException(
+        `${fieldLabel} is not active staff at this hospital`,
+      );
+    }
+
+    const isDoctor = (staff.user?.userRoles ?? []).some(
+      (ur) =>
+        ur.role?.slug === 'doctor' &&
+        (!ur.hospitalId || ur.hospitalId === hospitalId),
+    );
+    if (!isDoctor) {
+      throw new BadRequestException(
+        `${fieldLabel} must have the doctor role at this hospital`,
+      );
+    }
+  }
+
+  async assertHospitalDoctorOrThrow(
+    hospitalId: string,
+    doctorUserId: string,
+    fieldLabel = 'Doctor',
+  ): Promise<void> {
+    if (!doctorUserId) {
+      throw new NotFoundException(`${fieldLabel} id is required`);
+    }
+    await this.assertHospitalDoctor(hospitalId, doctorUserId, fieldLabel);
+  }
+}


### PR DESCRIPTION
## Summary
- Shared `HospitalDoctorValidator` checks active staff_profiles + doctor role
- Wired into appointment create and patient admit
- Unit tests for missing staff / non-doctor / valid doctor

Closes #18

## Test plan
- [x] HospitalDoctorValidator unit tests
- [ ] Creating appointment with random UUID doctorId fails
- [ ] Admit with nurse as attendingDoctorId fails


Made with [Cursor](https://cursor.com)