### PR TITLE
fix: invoice create/void payment semantics (#19)

### DIFF
--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -150,6 +150,11 @@ export class BillingService {
     await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
     const status = input.status ?? 'draft';
+    if (status !== 'draft' && status !== 'issued') {
+      throw new BadRequestException(
+        'New invoices may only be draft or issued; mark paid via payments',
+      );
+    }
     const totalAmount = input.items.reduce(
       (sum, item) => sum + item.quantity * item.unitPrice,
       0,
@@ -297,8 +302,17 @@ export class BillingService {
       relations: ['items', 'payments', 'patient'],
     });
     if (!invoice) throw new NotFoundException('Invoice not found');
+    if (invoice.status === 'void') {
+      throw new BadRequestException('Invoice is already void');
+    }
     if (invoice.status === 'paid') {
       throw new BadRequestException('Cannot void a paid invoice');
+    }
+    const paymentCount = (invoice.payments ?? []).length;
+    if (paymentCount > 0) {
+      throw new BadRequestException(
+        'Cannot void an invoice that has recorded payments',
+      );
     }
     invoice.status = 'void';
     await this.invoicesRepo.save(invoice);

--- a/apps/api/src/billing/billing.types.ts
+++ b/apps/api/src/billing/billing.types.ts
@@ -1,6 +1,7 @@
 import { Field, Float, ID, InputType, ObjectType } from '@nestjs/graphql';
 import {
   IsArray,
+  IsIn,
   IsNumber,
   IsOptional,
   IsString,
@@ -11,6 +12,8 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { PatientType } from '../patients/patients.types';
+
+export const CREATE_INVOICE_STATUSES = ['draft', 'issued'] as const;
 
 @ObjectType()
 export class InvoiceItemType {
@@ -121,7 +124,7 @@ export class CreateInvoiceInput {
 
   @Field({ nullable: true })
   @IsOptional()
-  @IsString()
+  @IsIn([...CREATE_INVOICE_STATUSES])
   status?: string;
 
   @Field(() => [CreateInvoiceItemInput])


### PR DESCRIPTION
## Summary
- `CreateInvoiceInput.status` limited to draft|issued
- Service rejects creating paid/void invoices
- Void blocked when payments exist (or already paid/void)

Closes #19

## Test plan
- [ ] Creating invoice with status=paid fails validation
- [ ] Void with existing payment fails
- [ ] Void on draft/issued with no payments succeeds


Made with [Cursor](https://cursor.com)