### PR TITLE
fix: sync patient status with admissions (#20)

### DIFF
--- a/apps/api/src/patients/patients.module.ts
+++ b/apps/api/src/patients/patients.module.ts
@@ -28,6 +28,7 @@ import { PatientsService } from './patients.service';
       PatientConsent,
       PatientImportJob,
       User,
+      Admission,
     ]),
   ],
   providers: [PatientsResolver, PatientsService],

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -2,6 +2,7 @@ import { ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
+  Admission,
   Patient,
   PatientAllergy,
   PatientConsent,
@@ -36,6 +37,10 @@ describe('PatientsService', () => {
   };
 
   const usersRepo = {
+    findOne: jest.fn(),
+  };
+
+  const admissionsRepo = {
     findOne: jest.fn(),
   };
 
@@ -83,6 +88,7 @@ describe('PatientsService', () => {
           useValue: relatedRepo,
         },
         { provide: getRepositoryToken(User), useValue: usersRepo },
+        { provide: getRepositoryToken(Admission), useValue: admissionsRepo },
         { provide: AuditService, useValue: audit },
       ],
     }).compile();

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -20,6 +20,7 @@ import {
   PatientInsurance,
   PatientMedicalHistory,
   PatientMedication,
+  Admission,
   User,
 } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
@@ -69,6 +70,8 @@ export class PatientsService {
     private readonly importJobsRepo: Repository<PatientImportJob>,
     @InjectRepository(User)
     private readonly usersRepo: Repository<User>,
+    @InjectRepository(Admission)
+    private readonly admissionsRepo: Repository<Admission>,
     private readonly audit: AuditService,
   ) {}
 
@@ -402,6 +405,23 @@ export class PatientsService {
     }
 
     const patient = await this.findPatientOrThrow(id, hospitalId);
+
+    const activeAdmission = await this.admissionsRepo.findOne({
+      where: { patientId: id, hospitalId, status: 'active' },
+    });
+
+    if (activeAdmission) {
+      if (status !== 'admitted') {
+        throw new BadRequestException(
+          'Patient has an active admission; discharge the admission before changing status',
+        );
+      }
+    } else if (status === 'admitted') {
+      throw new BadRequestException(
+        'Cannot mark patient admitted without an active admission',
+      );
+    }
+
     patient.status = status;
     const saved = await this.patientsRepo.save(patient);
 


### PR DESCRIPTION
## Summary
- `updatePatientStatus` checks for active admissions
- Cannot leave admitted state without discharging
- Cannot set admitted without an active admission row

Closes #20

## Test plan
- [ ] Patient with active admission cannot be set to registered
- [ ] Patient without admission cannot be set to admitted


Made with [Cursor](https://cursor.com)