### PR TITLE
fix: revoke Clerk access on staff deactivation (#23)

### DIFF
--- a/apps/api/src/clerk/clerk-admin.service.ts
+++ b/apps/api/src/clerk/clerk-admin.service.ts
@@ -94,4 +94,15 @@ export class ClerkAdminService implements OnModuleInit {
       );
     }
   }
+
+  async reactivateUser(clerkUserId: string): Promise<void> {
+    if (!this.client) return;
+    try {
+      await this.client.users.unbanUser(clerkUserId);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to reactivate Clerk user ${clerkUserId}: ${(error as Error).message}`,
+      );
+    }
+  }
 }

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -244,8 +244,10 @@ export class StaffService {
     const saved = await this.staffRepo.save(staff);
     if (input.isActive === false) {
       await this.usersRepo.update(staff.userId, { isActive: false });
+      await this.syncClerkActiveState(staff.userId, false);
     } else if (input.isActive === true) {
       await this.usersRepo.update(staff.userId, { isActive: true });
+      await this.syncClerkActiveState(staff.userId, true);
     }
 
     await this.audit.log({
@@ -266,6 +268,7 @@ export class StaffService {
     staff.isActive = false;
     await this.staffRepo.save(staff);
     await this.usersRepo.update(staff.userId, { isActive: false });
+    await this.syncClerkActiveState(staff.userId, false);
 
     await this.audit.log({
       actorId: actor.id,
@@ -276,6 +279,16 @@ export class StaffService {
     });
 
     return true;
+  }
+
+  private async syncClerkActiveState(userId: string, active: boolean) {
+    const user = await this.usersRepo.findOne({ where: { id: userId } });
+    if (!user?.authId || user.authId.startsWith('pending_')) return;
+    if (active) {
+      await this.clerkAdmin.reactivateUser(user.authId);
+    } else {
+      await this.clerkAdmin.deactivateUser(user.authId);
+    }
   }
 
   async acceptInvite(


### PR DESCRIPTION
## Summary
- Staff deactivate/remove bans the Clerk user
- Reactivation unbans the Clerk user
- Skips pending_ invite placeholders

Closes #23

## Test plan
- [ ] Deactivate staff → Clerk banUser called (when configured)
- [ ] Reactivate staff → Clerk unbanUser called


Made with [Cursor](https://cursor.com)