### PR TITLE
fix: lab/prescription/bed/admission status machines (#24)

### DIFF
--- a/apps/api/src/admissions/admissions.resolver.ts
+++ b/apps/api/src/admissions/admissions.resolver.ts
@@ -11,6 +11,8 @@ import {
   AdmissionType,
   AdmitPatientInput,
   DischargeAdmissionInput,
+  TransferAdmissionInput,
+  TransferOutAdmissionInput,
   WardOccupancyType,
 } from './admissions.types';
 
@@ -71,6 +73,42 @@ export class AdmissionsResolver {
       hospitalId,
     );
     return this.admissionsService.dischargeAdmission(
+      resolvedHospitalId,
+      input,
+      user,
+    );
+  }
+
+  @Mutation(() => AdmissionType)
+  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  async transferAdmission(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('input') input: TransferAdmissionInput,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+  ): Promise<AdmissionType> {
+    const resolvedHospitalId = this.admissionsService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.admissionsService.transferAdmission(
+      resolvedHospitalId,
+      input,
+      user,
+    );
+  }
+
+  @Mutation(() => AdmissionType)
+  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  async transferOutAdmission(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('input') input: TransferOutAdmissionInput,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+  ): Promise<AdmissionType> {
+    const resolvedHospitalId = this.admissionsService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.admissionsService.transferOutAdmission(
       resolvedHospitalId,
       input,
       user,

--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -157,4 +157,79 @@ describe('AdmissionsService', () => {
       ).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('transferOutAdmission', () => {
+    it('marks active admission as transferred and frees bed', async () => {
+      const admission = {
+        id: 'adm-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        bedId: 'bed-1',
+        status: 'active',
+        reason: 'fever',
+      };
+      const bed = { id: 'bed-1', hospitalId: 'hospital-a', status: 'occupied' };
+      const patient = {
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+        status: 'admitted',
+      };
+
+      const admissionQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(admission),
+      };
+      const bedQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(bed),
+      };
+      manager.createQueryBuilder
+        .mockReturnValueOnce(admissionQb)
+        .mockReturnValueOnce(bedQb);
+      manager.findOne.mockResolvedValue(patient);
+      manager.save.mockImplementation((row: unknown) =>
+        Promise.resolve(row),
+      );
+
+      admissionsRepo.findOne.mockResolvedValue({
+        ...admission,
+        status: 'transferred',
+        patient,
+      });
+
+      const result = await service.transferOutAdmission(
+        'hospital-a',
+        { admissionId: 'adm-1', notes: 'to City Hospital' },
+        actor,
+      );
+      expect(result.status).toBe('transferred');
+      expect(bed.status).toBe('available');
+      expect(patient.status).toBe('discharged');
+    });
+
+    it('rejects transfer-out of discharged admission', async () => {
+      const admissionQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'adm-1',
+          status: 'discharged',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(admissionQb);
+
+      await expect(
+        service.transferOutAdmission(
+          'hospital-a',
+          { admissionId: 'adm-1' },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
 });

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -15,8 +15,32 @@ import {
   AdmissionType,
   AdmitPatientInput,
   DischargeAdmissionInput,
+  TransferAdmissionInput,
+  TransferOutAdmissionInput,
   WardOccupancyType,
 } from './admissions.types';
+
+/**
+ * Admission status machine:
+ *   active → discharged (via discharge) | transferred (via transferOut)
+ * Internal bed moves keep status active.
+ * Terminal: discharged, transferred
+ */
+const ADMISSION_ALLOWED_TRANSITIONS: Record<string, readonly string[]> = {
+  active: ['discharged', 'transferred'],
+  discharged: [],
+  transferred: [],
+};
+
+function assertAdmissionTransition(from: string, to: string) {
+  if (from === to) return;
+  const allowed = ADMISSION_ALLOWED_TRANSITIONS[from] ?? [];
+  if (!allowed.includes(to)) {
+    throw new BadRequestException(
+      `Cannot transition admission from "${from}" to "${to}"`,
+    );
+  }
+}
 
 function isUniqueViolation(error: unknown): boolean {
   return (
@@ -248,6 +272,160 @@ export class AdmissionsService {
     return this.toAdmissionType(
       await this.findAdmissionOrThrow(input.id, hospitalId),
     );
+  }
+
+  async transferAdmission(
+    hospitalId: string,
+    input: TransferAdmissionInput,
+    actor: AuthenticatedUser,
+  ): Promise<AdmissionType> {
+    try {
+      await this.admissionsRepo.manager.transaction(async (manager) => {
+        const admission = await manager
+          .createQueryBuilder(Admission, 'admission')
+          .setLock('pessimistic_write')
+          .where('admission.id = :id', { id: input.admissionId })
+          .andWhere('admission.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!admission) throw new NotFoundException('Admission not found');
+        if (admission.status !== 'active') {
+          throw new BadRequestException(
+            'Only active admissions can be transferred to another bed',
+          );
+        }
+
+        const ward = await manager.findOne(Ward, {
+          where: { id: input.wardId, hospitalId },
+        });
+        if (!ward) throw new NotFoundException('Ward not found');
+
+        const newBed = await manager
+          .createQueryBuilder(Bed, 'bed')
+          .setLock('pessimistic_write')
+          .where('bed.id = :id', { id: input.bedId })
+          .andWhere('bed.ward_id = :wardId', { wardId: input.wardId })
+          .andWhere('bed.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!newBed) throw new NotFoundException('Bed not found');
+        if (newBed.status !== 'available') {
+          throw new BadRequestException('Target bed is not available');
+        }
+
+        if (admission.bedId === newBed.id) {
+          throw new BadRequestException(
+            'Patient is already assigned to this bed',
+          );
+        }
+
+        if (admission.bedId) {
+          const oldBed = await manager
+            .createQueryBuilder(Bed, 'bed')
+            .setLock('pessimistic_write')
+            .where('bed.id = :id', { id: admission.bedId })
+            .andWhere('bed.hospital_id = :hospitalId', { hospitalId })
+            .getOne();
+          if (oldBed) {
+            oldBed.status = 'available';
+            await manager.save(oldBed);
+          }
+        }
+
+        newBed.status = 'occupied';
+        await manager.save(newBed);
+
+        admission.wardId = input.wardId;
+        admission.bedId = input.bedId;
+        await manager.save(admission);
+      });
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new BadRequestException('Target bed is not available');
+      }
+      throw error;
+    }
+
+    const admission = await this.findAdmissionOrThrow(
+      input.admissionId,
+      hospitalId,
+    );
+
+    await this.audit.log({
+      actorId: actor.id,
+      hospitalId,
+      action: 'transfer',
+      resource: 'admission',
+      resourceId: admission.id,
+      metadata: {
+        wardId: admission.wardId,
+        bedId: admission.bedId,
+      },
+    });
+
+    return this.toAdmissionType(admission);
+  }
+
+  async transferOutAdmission(
+    hospitalId: string,
+    input: TransferOutAdmissionInput,
+    actor: AuthenticatedUser,
+  ): Promise<AdmissionType> {
+    await this.admissionsRepo.manager.transaction(async (manager) => {
+      const admission = await manager
+        .createQueryBuilder(Admission, 'admission')
+        .setLock('pessimistic_write')
+        .where('admission.id = :id', { id: input.admissionId })
+        .andWhere('admission.hospital_id = :hospitalId', { hospitalId })
+        .getOne();
+      if (!admission) throw new NotFoundException('Admission not found');
+
+      assertAdmissionTransition(admission.status, 'transferred');
+
+      if (admission.bedId) {
+        const bed = await manager
+          .createQueryBuilder(Bed, 'bed')
+          .setLock('pessimistic_write')
+          .where('bed.id = :id', { id: admission.bedId })
+          .andWhere('bed.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (bed) {
+          bed.status = 'available';
+          await manager.save(bed);
+        }
+      }
+
+      admission.status = 'transferred';
+      admission.dischargedAt = new Date();
+      if (input.notes) {
+        admission.reason = admission.reason
+          ? `${admission.reason}\nTransferred: ${input.notes}`
+          : `Transferred: ${input.notes}`;
+      }
+      await manager.save(admission);
+
+      const patient = await manager.findOne(Patient, {
+        where: { id: admission.patientId, hospitalId },
+      });
+      if (patient) {
+        patient.status = 'discharged';
+        await manager.save(patient);
+      }
+    });
+
+    const admission = await this.findAdmissionOrThrow(
+      input.admissionId,
+      hospitalId,
+    );
+
+    await this.audit.log({
+      actorId: actor.id,
+      hospitalId,
+      action: 'transfer_out',
+      resource: 'admission',
+      resourceId: admission.id,
+      metadata: { status: 'transferred', notes: input.notes },
+    });
+
+    return this.toAdmissionType(admission);
   }
 
   async wardOccupancy(hospitalId: string): Promise<WardOccupancyType[]> {

--- a/apps/api/src/admissions/admissions.types.ts
+++ b/apps/api/src/admissions/admissions.types.ts
@@ -110,3 +110,30 @@ export class DischargeAdmissionInput {
   @MinLength(1)
   notes?: string;
 }
+
+@InputType()
+export class TransferAdmissionInput {
+  @Field()
+  @IsUUID()
+  admissionId: string;
+
+  @Field()
+  @IsUUID()
+  wardId: string;
+
+  @Field()
+  @IsUUID()
+  bedId: string;
+}
+
+@InputType()
+export class TransferOutAdmissionInput {
+  @Field()
+  @IsUUID()
+  admissionId: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/apps/api/src/clinical/clinical.resolver.ts
+++ b/apps/api/src/clinical/clinical.resolver.ts
@@ -10,6 +10,7 @@ import { ClinicalService } from './clinical.service';
 import {
   ClinicalNoteType,
   CompleteLabResultInput,
+  CancelPrescriptionInput,
   CreateClinicalNoteInput,
   CreateDiagnosisInput,
   CreateLabOrderInput,
@@ -19,6 +20,7 @@ import {
   LabOrderType,
   LabResultType,
   PrescriptionType,
+  UpdateLabOrderStatusInput,
   VitalSignType,
 } from './clinical.types';
 import { UseGuards } from '@nestjs/common';
@@ -206,6 +208,43 @@ export class ClinicalResolver {
       hospitalId,
     );
     return this.clinicalService.completeLabResult(
+      resolvedHospitalId,
+      input,
+      user,
+    );
+  }
+
+  @Mutation(() => LabOrderType)
+  @Permissions(PERMISSIONS.LAB_WRITE)
+  async updateLabOrderStatus(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('input') input: UpdateLabOrderStatusInput,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+  ): Promise<LabOrderType> {
+    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.clinicalService.updateLabOrderStatus(
+      resolvedHospitalId,
+      input,
+      user,
+    );
+  }
+
+  @Mutation(() => PrescriptionType)
+  @Roles(...CLINICIAN_ROLES)
+  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  async cancelPrescription(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('input') input: CancelPrescriptionInput,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+  ): Promise<PrescriptionType> {
+    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.clinicalService.cancelPrescription(
       resolvedHospitalId,
       input,
       user,

--- a/apps/api/src/clinical/clinical.service.spec.ts
+++ b/apps/api/src/clinical/clinical.service.spec.ts
@@ -26,6 +26,7 @@ describe('ClinicalService', () => {
     save: jest.fn(),
     create: jest.fn(),
     find: jest.fn(),
+    findOne: jest.fn(),
   };
   const prescriptionItemsRepo = { save: jest.fn(), create: jest.fn() };
   const labOrdersRepo = {
@@ -111,6 +112,106 @@ describe('ClinicalService', () => {
         ),
       ).rejects.toThrow('Admission does not belong to the given patient');
       expect(vitalsRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('lab order status machine', () => {
+    it('rejects re-completing a completed lab order', async () => {
+      labOrdersRepo.findOne.mockResolvedValue({
+        id: 'lab-1',
+        hospitalId: 'hospital-a',
+        status: 'completed',
+      });
+
+      await expect(
+        service.completeLabResult(
+          'hospital-a',
+          { labOrderId: 'lab-1', resultValue: '5.0' },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(labResultsRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('advances ordered → collected', async () => {
+      const order = {
+        id: 'lab-1',
+        hospitalId: 'hospital-a',
+        status: 'ordered',
+        patientId: 'p1',
+        testName: 'CBC',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      labOrdersRepo.findOne.mockResolvedValue(order);
+      labOrdersRepo.save.mockImplementation((row: typeof order) =>
+        Promise.resolve(row),
+      );
+
+      const result = await service.updateLabOrderStatus(
+        'hospital-a',
+        { labOrderId: 'lab-1', status: 'collected' },
+        actor,
+      );
+      expect(result.status).toBe('collected');
+    });
+
+    it('rejects completing via updateLabOrderStatus', async () => {
+      labOrdersRepo.findOne.mockResolvedValue({
+        id: 'lab-1',
+        hospitalId: 'hospital-a',
+        status: 'ordered',
+      });
+
+      await expect(
+        service.updateLabOrderStatus(
+          'hospital-a',
+          { labOrderId: 'lab-1', status: 'completed' },
+          actor,
+        ),
+      ).rejects.toThrow('Use completeLabResult');
+    });
+  });
+
+  describe('prescription cancel', () => {
+    it('cancels a pending prescription', async () => {
+      const rx = {
+        id: 'rx-1',
+        hospitalId: 'hospital-a',
+        status: 'pending',
+        patientId: 'p1',
+        items: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prescriptionsRepo.findOne.mockResolvedValue(rx);
+      prescriptionsRepo.save.mockImplementation((row: typeof rx) =>
+        Promise.resolve(row),
+      );
+
+      const result = await service.cancelPrescription(
+        'hospital-a',
+        { prescriptionId: 'rx-1' },
+        actor,
+      );
+      expect(result.status).toBe('cancelled');
+    });
+
+    it('rejects cancelling a dispensed prescription', async () => {
+      prescriptionsRepo.findOne.mockResolvedValue({
+        id: 'rx-1',
+        hospitalId: 'hospital-a',
+        status: 'dispensed',
+        items: [],
+      });
+
+      await expect(
+        service.cancelPrescription(
+          'hospital-a',
+          { prescriptionId: 'rx-1' },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -22,6 +22,7 @@ import { AuditService } from '../audit/audit.service';
 import {
   ClinicalNoteType,
   CompleteLabResultInput,
+  CancelPrescriptionInput,
   CreateClinicalNoteInput,
   CreateDiagnosisInput,
   CreateLabOrderInput,
@@ -31,8 +32,54 @@ import {
   LabOrderType,
   LabResultType,
   PrescriptionType,
+  UpdateLabOrderStatusInput,
   VitalSignType,
 } from './clinical.types';
+
+/**
+ * Lab order status machine:
+ *   ordered → collected → processing → completed
+ *          ↘ cancelled (from ordered/collected/processing)
+ * Terminal: completed, cancelled
+ */
+const LAB_ALLOWED_TRANSITIONS: Record<string, readonly string[]> = {
+  ordered: ['collected', 'processing', 'completed', 'cancelled'],
+  collected: ['processing', 'completed', 'cancelled'],
+  processing: ['completed', 'cancelled'],
+  completed: [],
+  cancelled: [],
+};
+
+/**
+ * Prescription status machine:
+ *   pending → dispensed | cancelled
+ * Terminal: dispensed, cancelled
+ */
+const PRESCRIPTION_ALLOWED_TRANSITIONS: Record<string, readonly string[]> = {
+  pending: ['dispensed', 'cancelled'],
+  dispensed: [],
+  cancelled: [],
+};
+
+function assertLabTransition(from: string, to: string) {
+  if (from === to) return;
+  const allowed = LAB_ALLOWED_TRANSITIONS[from] ?? [];
+  if (!allowed.includes(to)) {
+    throw new BadRequestException(
+      `Cannot transition lab order from "${from}" to "${to}"`,
+    );
+  }
+}
+
+function assertPrescriptionTransition(from: string, to: string) {
+  if (from === to) return;
+  const allowed = PRESCRIPTION_ALLOWED_TRANSITIONS[from] ?? [];
+  if (!allowed.includes(to)) {
+    throw new BadRequestException(
+      `Cannot transition prescription from "${from}" to "${to}"`,
+    );
+  }
+}
 
 @Injectable()
 export class ClinicalService {
@@ -414,6 +461,13 @@ export class ClinicalService {
     });
     if (!order) throw new NotFoundException('Lab order not found');
 
+    if (order.status === 'completed' || order.status === 'cancelled') {
+      throw new BadRequestException(
+        `Cannot complete lab order with status "${order.status}"`,
+      );
+    }
+    assertLabTransition(order.status, 'completed');
+
     const result = await this.labResultsRepo.save(
       this.labResultsRepo.create({
         labOrderId: order.id,
@@ -440,6 +494,67 @@ export class ClinicalService {
     });
 
     return this.toLabResultType(result);
+  }
+
+  async updateLabOrderStatus(
+    hospitalId: string,
+    input: UpdateLabOrderStatusInput,
+    actor: AuthenticatedUser,
+  ): Promise<LabOrderType> {
+    const order = await this.labOrdersRepo.findOne({
+      where: { id: input.labOrderId, hospitalId },
+      relations: ['patient', 'orderedBy'],
+    });
+    if (!order) throw new NotFoundException('Lab order not found');
+
+    assertLabTransition(order.status, input.status);
+    // Completing requires a lab result via completeLabResult
+    if (input.status === 'completed') {
+      throw new BadRequestException(
+        'Use completeLabResult to mark a lab order completed',
+      );
+    }
+
+    order.status = input.status;
+    await this.labOrdersRepo.save(order);
+
+    await this.audit.log({
+      actorId: actor.id,
+      hospitalId,
+      action: 'update',
+      resource: 'lab_order',
+      resourceId: order.id,
+      metadata: { status: order.status },
+    });
+
+    return this.toLabOrderType(order);
+  }
+
+  async cancelPrescription(
+    hospitalId: string,
+    input: CancelPrescriptionInput,
+    actor: AuthenticatedUser,
+  ): Promise<PrescriptionType> {
+    const prescription = await this.prescriptionsRepo.findOne({
+      where: { id: input.prescriptionId, hospitalId },
+      relations: ['items'],
+    });
+    if (!prescription) throw new NotFoundException('Prescription not found');
+
+    assertPrescriptionTransition(prescription.status, 'cancelled');
+    prescription.status = 'cancelled';
+    await this.prescriptionsRepo.save(prescription);
+
+    await this.audit.log({
+      actorId: actor.id,
+      hospitalId,
+      action: 'update',
+      resource: 'prescription',
+      resourceId: prescription.id,
+      metadata: { status: 'cancelled' },
+    });
+
+    return this.toPrescriptionType(prescription);
   }
 
   async listLabOrders(

--- a/apps/api/src/clinical/clinical.types.ts
+++ b/apps/api/src/clinical/clinical.types.ts
@@ -2,6 +2,7 @@ import { Field, Float, ID, InputType, Int, ObjectType } from '@nestjs/graphql';
 import {
   IsArray,
   IsBoolean,
+  IsIn,
   IsInt,
   IsOptional,
   IsString,
@@ -12,6 +13,9 @@ import {
 import { Type } from 'class-transformer';
 import { PatientType } from '../patients/patients.types';
 import { UserSummaryType } from '../users/users.types';
+import { LAB_ORDER_STATUSES } from '../database/entities/lab-order.entity';
+
+export const LAB_ORDER_STATUS_VALUES = LAB_ORDER_STATUSES;
 
 @ObjectType()
 export class VitalSignType {
@@ -445,4 +449,22 @@ export class CompleteLabResultInput {
   @IsOptional()
   @IsString()
   resultFileUrl?: string;
+}
+
+@InputType()
+export class UpdateLabOrderStatusInput {
+  @Field()
+  @IsUUID()
+  labOrderId: string;
+
+  @Field()
+  @IsIn([...LAB_ORDER_STATUS_VALUES])
+  status: string;
+}
+
+@InputType()
+export class CancelPrescriptionInput {
+  @Field()
+  @IsUUID()
+  prescriptionId: string;
 }

--- a/apps/api/src/facility/facility.resolver.ts
+++ b/apps/api/src/facility/facility.resolver.ts
@@ -13,6 +13,7 @@ import {
   CreateDepartmentInput,
   CreateWardInput,
   DepartmentType,
+  UpdateBedStatusInput,
   WardType,
 } from './facility.types';
 
@@ -148,5 +149,23 @@ export class FacilityResolver {
       hospitalId,
     );
     return this.facilityService.deleteBed(resolvedHospitalId, id, user);
+  }
+
+  @Mutation(() => BedType)
+  @Permissions(PERMISSIONS.HOSPITALS_WRITE)
+  async updateBedStatus(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('input') input: UpdateBedStatusInput,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+  ): Promise<BedType> {
+    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.facilityService.updateBedStatus(
+      resolvedHospitalId,
+      input,
+      user,
+    );
   }
 }

--- a/apps/api/src/facility/facility.service.spec.ts
+++ b/apps/api/src/facility/facility.service.spec.ts
@@ -1,0 +1,84 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Bed, Department, Ward } from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from '../audit/audit.service';
+import { FacilityService } from './facility.service';
+
+describe('FacilityService', () => {
+  let service: FacilityService;
+
+  const departmentsRepo = {};
+  const wardsRepo = {};
+  const bedsRepo = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+  const audit = { log: jest.fn() };
+
+  const actor: AuthenticatedUser = {
+    id: 'admin-1',
+    authId: 'auth-1',
+    email: 'admin@h.com',
+    fullName: 'Admin',
+    hospitalId: 'hospital-a',
+    roles: ['hospital_admin'],
+    permissions: [],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FacilityService,
+        { provide: getRepositoryToken(Department), useValue: departmentsRepo },
+        { provide: getRepositoryToken(Ward), useValue: wardsRepo },
+        { provide: getRepositoryToken(Bed), useValue: bedsRepo },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = module.get(FacilityService);
+  });
+
+  describe('updateBedStatus', () => {
+    it('sets available bed to maintenance', async () => {
+      const bed = {
+        id: 'bed-1',
+        hospitalId: 'hospital-a',
+        wardId: 'ward-1',
+        label: 'A1',
+        status: 'available',
+        createdAt: new Date(),
+      };
+      bedsRepo.findOne.mockResolvedValue(bed);
+      bedsRepo.save.mockImplementation((row: typeof bed) =>
+        Promise.resolve(row),
+      );
+
+      const result = await service.updateBedStatus(
+        'hospital-a',
+        { bedId: 'bed-1', status: 'maintenance' },
+        actor,
+      );
+      expect(result.status).toBe('maintenance');
+    });
+
+    it('rejects changing an occupied bed', async () => {
+      bedsRepo.findOne.mockResolvedValue({
+        id: 'bed-1',
+        hospitalId: 'hospital-a',
+        status: 'occupied',
+      });
+
+      await expect(
+        service.updateBedStatus(
+          'hospital-a',
+          { bedId: 'bed-1', status: 'maintenance' },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/apps/api/src/facility/facility.service.ts
+++ b/apps/api/src/facility/facility.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -14,8 +15,30 @@ import {
   CreateDepartmentInput,
   CreateWardInput,
   DepartmentType,
+  UpdateBedStatusInput,
   WardType,
 } from './facility.types';
+
+/**
+ * Manual bed status machine (admit/discharge own occupied transitions):
+ *   available ↔ maintenance
+ * Occupied beds cannot be changed via this API.
+ */
+const MANUAL_BED_TRANSITIONS: Record<string, readonly string[]> = {
+  available: ['maintenance'],
+  maintenance: ['available'],
+  occupied: [],
+};
+
+function assertManualBedTransition(from: string, to: string) {
+  if (from === to) return;
+  const allowed = MANUAL_BED_TRANSITIONS[from] ?? [];
+  if (!allowed.includes(to)) {
+    throw new BadRequestException(
+      `Cannot transition bed from "${from}" to "${to}"`,
+    );
+  }
+}
 
 @Injectable()
 export class FacilityService {
@@ -260,5 +283,31 @@ export class FacilityService {
       resourceId: id,
     });
     return true;
+  }
+
+  async updateBedStatus(
+    hospitalId: string,
+    input: UpdateBedStatusInput,
+    actor: AuthenticatedUser,
+  ): Promise<BedType> {
+    const bed = await this.bedsRepo.findOne({
+      where: { id: input.bedId, hospitalId },
+    });
+    if (!bed) throw new NotFoundException('Bed not found');
+
+    assertManualBedTransition(bed.status, input.status);
+    bed.status = input.status;
+    await this.bedsRepo.save(bed);
+
+    await this.audit.log({
+      actorId: actor.id,
+      hospitalId,
+      action: 'update',
+      resource: 'bed',
+      resourceId: bed.id,
+      metadata: { status: bed.status },
+    });
+
+    return this.toBedType(bed);
   }
 }

--- a/apps/api/src/facility/facility.types.ts
+++ b/apps/api/src/facility/facility.types.ts
@@ -1,5 +1,8 @@
 import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
-import { IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
+import { IsIn, IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
+
+/** Manual bed updates only allow available ↔ maintenance (occupied is admit/discharge). */
+export const MANUAL_BED_STATUSES = ['available', 'maintenance'] as const;
 
 @ObjectType()
 export class DepartmentType {
@@ -105,4 +108,15 @@ export class CreateBedInput {
   @IsString()
   @MinLength(1)
   label: string;
+}
+
+@InputType()
+export class UpdateBedStatusInput {
+  @Field()
+  @IsUUID()
+  bedId: string;
+
+  @Field()
+  @IsIn([...MANUAL_BED_STATUSES])
+  status: string;
 }


### PR DESCRIPTION
## Summary
- Lab orders: `updateLabOrderStatus` for collected/processing/cancelled; `completeLabResult` rejects completed/cancelled orders
- Prescriptions: `cancelPrescription` for pending only
- Beds: `updateBedStatus` for available ↔ maintenance (occupied stays admit/discharge-owned)
- Admissions: `transferAdmission` (internal bed move) and `transferOutAdmission` (status → transferred)

## Test plan
- [x] Unit tests for lab transitions, Rx cancel, bed status, transfer-out
- [ ] CI lint-and-build

Closes #24

Made with [Cursor](https://cursor.com)