### PR TITLE
fix: P0 security and authz gaps (#49–#56)

### DIFF
--- a/apps/api/src/appointments/appointments.resolver.ts
+++ b/apps/api/src/appointments/appointments.resolver.ts
@@ -39,6 +39,7 @@ export class AppointmentsResolver {
       date,
       doctorId,
       status,
+      user,
     );
   }
 

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -96,4 +96,36 @@ describe('AppointmentsService status machine', () => {
       service.updateStatus('missing', 'checked_in', 'hospital-a', actor),
     ).rejects.toThrow(NotFoundException);
   });
+
+  describe('doctor appointment scoping', () => {
+    it('forces doctorId for doctor-only actors', async () => {
+      appointmentsRepo.find.mockResolvedValue([]);
+      const doctor: AuthenticatedUser = {
+        ...actor,
+        id: 'doc-9',
+        roles: ['doctor'],
+        permissions: ['appointments:read'],
+      };
+
+      await service.findAll('hospital-a', undefined, undefined, undefined, doctor);
+
+      expect(appointmentsRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ doctorId: 'doc-9' }),
+        }),
+      );
+    });
+
+    it('keeps hospital-wide list for receptionists', async () => {
+      appointmentsRepo.find.mockResolvedValue([]);
+
+      await service.findAll('hospital-a', undefined, undefined, undefined, actor);
+
+      expect(appointmentsRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { hospitalId: 'hospital-a' },
+        }),
+      );
+    });
+  });
 });

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -107,11 +107,17 @@ describe('AppointmentsService status machine', () => {
         permissions: ['appointments:read'],
       };
 
-      await service.findAll('hospital-a', undefined, undefined, undefined, doctor);
+      await service.findAll(
+        'hospital-a',
+        undefined,
+        undefined,
+        undefined,
+        doctor,
+      );
 
       expect(appointmentsRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ doctorId: 'doc-9' }),
+          where: { hospitalId: 'hospital-a', doctorId: 'doc-9' },
         }),
       );
     });
@@ -119,7 +125,13 @@ describe('AppointmentsService status machine', () => {
     it('keeps hospital-wide list for receptionists', async () => {
       appointmentsRepo.find.mockResolvedValue([]);
 
-      await service.findAll('hospital-a', undefined, undefined, undefined, actor);
+      await service.findAll(
+        'hospital-a',
+        undefined,
+        undefined,
+        undefined,
+        actor,
+      );
 
       expect(appointmentsRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -177,11 +177,13 @@ export class AppointmentsService {
     date?: string,
     doctorId?: string,
     status?: string,
+    actor?: AuthenticatedUser,
   ): Promise<AppointmentType[]> {
     const where: Record<string, unknown> = { hospitalId };
 
-    if (doctorId) {
-      where.doctorId = doctorId;
+    const effectiveDoctorId = this.resolveDoctorScope(actor, doctorId);
+    if (effectiveDoctorId) {
+      where.doctorId = effectiveDoctorId;
     }
 
     if (status) {
@@ -210,6 +212,30 @@ export class AppointmentsService {
     });
 
     return appointments.map((a) => this.toAppointmentType(a));
+  }
+
+  /**
+   * Doctors without a hospital-wide schedule role only see their own appointments.
+   * Reception/nurse/admin keep hospital-wide visibility.
+   */
+  private resolveDoctorScope(
+    actor: AuthenticatedUser | undefined,
+    requestedDoctorId?: string,
+  ): string | undefined {
+    if (!actor) return requestedDoctorId;
+    const hospitalWide = actor.roles.some((role) =>
+      [
+        'super_admin',
+        'hospital_admin',
+        'hospital_manager',
+        'receptionist',
+        'nurse',
+      ].includes(role),
+    );
+    if (!hospitalWide && actor.roles.includes('doctor')) {
+      return actor.id;
+    }
+    return requestedDoctorId;
   }
 
   async updateStatus(

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -296,33 +296,42 @@ export class BillingService {
     id: string,
     actor: AuthenticatedUser,
   ): Promise<InvoiceType> {
-    const invoice = await this.invoicesRepo.findOne({
-      where: { id, hospitalId },
-      relations: ['items', 'payments', 'patient'],
+    await this.invoicesRepo.manager.transaction(async (manager) => {
+      const invoice = await manager
+        .createQueryBuilder(Invoice, 'invoice')
+        .setLock('pessimistic_write')
+        .where('invoice.id = :id', { id })
+        .andWhere('invoice.hospital_id = :hospitalId', { hospitalId })
+        .getOne();
+      if (!invoice) throw new NotFoundException('Invoice not found');
+      if (invoice.status === 'void') {
+        throw new BadRequestException('Invoice is already void');
+      }
+      if (invoice.status === 'paid') {
+        throw new BadRequestException('Cannot void a paid invoice');
+      }
+
+      const paymentCount = await manager.count(Payment, {
+        where: { invoiceId: invoice.id },
+      });
+      if (paymentCount > 0) {
+        throw new BadRequestException(
+          'Cannot void an invoice that has recorded payments',
+        );
+      }
+
+      invoice.status = 'void';
+      await manager.save(invoice);
     });
-    if (!invoice) throw new NotFoundException('Invoice not found');
-    if (invoice.status === 'void') {
-      throw new BadRequestException('Invoice is already void');
-    }
-    if (invoice.status === 'paid') {
-      throw new BadRequestException('Cannot void a paid invoice');
-    }
-    const paymentCount = (invoice.payments ?? []).length;
-    if (paymentCount > 0) {
-      throw new BadRequestException(
-        'Cannot void an invoice that has recorded payments',
-      );
-    }
-    invoice.status = 'void';
-    await this.invoicesRepo.save(invoice);
+
     await this.audit.log({
       actorId: actor.id,
       hospitalId,
       action: 'void',
       resource: 'invoice',
-      resourceId: invoice.id,
+      resourceId: id,
     });
-    return this.toInvoiceType(invoice);
+    return this.getInvoice(hospitalId, id);
   }
 
   async sumRevenue(hospitalId: string): Promise<number> {

--- a/apps/api/src/hospitals/hospitals.resolver.ts
+++ b/apps/api/src/hospitals/hospitals.resolver.ts
@@ -7,6 +7,7 @@ import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
+import { STAFF_ROLES } from '../rbac/staff-roles';
 import { AuditService } from '../audit/audit.service';
 import { HospitalsService } from './hospitals.service';
 import {
@@ -39,13 +40,21 @@ export class HospitalsResolver {
     return this.hospitalsService.findByIdForUser(id, user);
   }
 
-  /** Bootstrap: any authenticated user without a hospital may create one during onboarding. */
+  /** Bootstrap: only unassigned non-patient/non-staff users may create a hospital during admin onboarding. */
   @Mutation(() => HospitalType)
   async createHospital(
     @CurrentUser() user: AuthenticatedUser,
     @Args('input') input: CreateHospitalInput,
   ): Promise<HospitalType> {
-    const canBootstrap = !user.hospitalId;
+    if (user.roles.includes(ROLES.PATIENT)) {
+      throw new ForbiddenException('Patients cannot create hospitals');
+    }
+
+    const hasStaffRole = user.roles.some((role) =>
+      STAFF_ROLES.includes(role as (typeof STAFF_ROLES)[number]),
+    );
+
+    const canBootstrap = !user.hospitalId && !hasStaffRole;
     const canWrite =
       user.roles.includes('super_admin') ||
       user.permissions.includes(PERMISSIONS.HOSPITALS_WRITE);

--- a/apps/api/src/inventory/inventory.resolver.ts
+++ b/apps/api/src/inventory/inventory.resolver.ts
@@ -1,10 +1,11 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { PERMISSIONS } from '@careconnect/types';
+import { PERMISSIONS, ROLES } from '@careconnect/types';
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
+import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { InventoryService } from './inventory.service';
 import {
@@ -13,13 +14,20 @@ import {
   UpdateInventoryQuantityInput,
 } from './inventory.types';
 
+const INVENTORY_ROLES = [
+  ROLES.PHARMACIST,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+] as const;
+
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class InventoryResolver {
   constructor(private readonly inventoryService: InventoryService) {}
 
   @Query(() => [InventoryItemType])
-  @Permissions(PERMISSIONS.HOSPITALS_READ)
+  @Roles(...INVENTORY_ROLES)
+  @Permissions(PERMISSIONS.PATIENTS_READ)
   async inventoryItems(
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
@@ -32,7 +40,8 @@ export class InventoryResolver {
   }
 
   @Mutation(() => InventoryItemType)
-  @Permissions(PERMISSIONS.HOSPITALS_WRITE)
+  @Roles(...INVENTORY_ROLES)
+  @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async createInventoryItem(
     @CurrentUser() user: AuthenticatedUser,
     @Args('input') input: CreateInventoryItemInput,
@@ -50,7 +59,8 @@ export class InventoryResolver {
   }
 
   @Mutation(() => InventoryItemType)
-  @Permissions(PERMISSIONS.HOSPITALS_WRITE)
+  @Roles(...INVENTORY_ROLES)
+  @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async updateInventoryQuantity(
     @CurrentUser() user: AuthenticatedUser,
     @Args('input') input: UpdateInventoryQuantityInput,

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -1,6 +1,7 @@
-import { ConflictException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { existsSync } from 'fs';
 import {
   Admission,
   Patient,
@@ -18,6 +19,13 @@ import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
 import { PatientsService } from './patients.service';
 
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+}));
+
+const existsSyncMock = existsSync as jest.MockedFunction<typeof existsSync>;
+
 describe('PatientsService', () => {
   let service: PatientsService;
 
@@ -34,6 +42,8 @@ describe('PatientsService', () => {
     create: jest.fn(),
     delete: jest.fn(),
     remove: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
   };
 
   const usersRepo = {
@@ -59,6 +69,8 @@ describe('PatientsService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    relatedRepo.find.mockResolvedValue([]);
+    existsSyncMock.mockReturnValue(true);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -185,6 +197,72 @@ describe('PatientsService', () => {
       expect(audit.log).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'create', resource: 'patient' }),
       );
+    });
+  });
+
+  describe('addDocument fileUrl validation', () => {
+    it('rejects non-upload URL paths', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-1',
+      });
+
+      await expect(
+        service.addDocument(
+          'patient-1',
+          'hospital-1',
+          {
+            name: 'scan.pdf',
+            fileUrl: 'https://evil.example/files/secret.pdf',
+          },
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when the upload file is missing on disk', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-1',
+      });
+      existsSyncMock.mockReturnValue(false);
+
+      await expect(
+        service.addDocument(
+          'patient-1',
+          'hospital-1',
+          {
+            name: 'scan.pdf',
+            fileUrl: 'https://evil.example/uploads/missing-file.pdf',
+          },
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('stores a relative /uploads path for valid local files', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-1',
+      });
+      relatedRepo.find.mockResolvedValue([]);
+      relatedRepo.create.mockImplementation((row: unknown) => row);
+      relatedRepo.save.mockImplementation((row: unknown) =>
+        Promise.resolve(row),
+      );
+      existsSyncMock.mockReturnValue(true);
+
+      const result = await service.addDocument(
+        'patient-1',
+        'hospital-1',
+        {
+          name: 'scan.pdf',
+          fileUrl: 'http://localhost:4000/uploads/a1b2c3d4-e5f6.pdf',
+        },
+        'user-1',
+      );
+
+      expect(result.fileUrl).toBe('/uploads/a1b2c3d4-e5f6.pdf');
     });
   });
 });

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -19,10 +19,13 @@ import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
 import { PatientsService } from './patients.service';
 
-jest.mock('fs', () => ({
-  ...jest.requireActual('fs'),
-  existsSync: jest.fn(),
-}));
+jest.mock('fs', () => {
+  const actual = jest.requireActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: jest.fn(),
+  };
+});
 
 const existsSyncMock = existsSync as jest.MockedFunction<typeof existsSync>;
 

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -821,15 +821,89 @@ export class PatientsService {
     });
     if (!patient) throw new NotFoundException('Patient not found');
 
+    const safeFileUrl = await this.assertOwnedUploadFileUrl(
+      input.fileUrl,
+      hospitalId,
+    );
+
     return this.documentsRepo.save(
       this.documentsRepo.create({
         patientId,
         name: input.name,
-        fileUrl: input.fileUrl,
+        fileUrl: safeFileUrl,
         fileType: input.fileType,
         documentType: input.documentType,
         uploadedById,
       }),
     );
+  }
+
+  /**
+   * Only allow same-origin upload paths produced by POST /uploads/patient-documents.
+   * Rejects third-party URLs and files already attached under another hospital.
+   */
+  private async assertOwnedUploadFileUrl(
+    fileUrl: string,
+    hospitalId: string,
+  ): Promise<string> {
+    const trimmed = fileUrl.trim();
+    let pathname: string;
+    try {
+      if (trimmed.startsWith('/uploads/')) {
+        pathname = trimmed.split('?')[0] ?? trimmed;
+      } else {
+        pathname = new URL(trimmed).pathname;
+      }
+    } catch {
+      throw new BadRequestException(
+        'Document fileUrl must be a valid /uploads/... path from this API',
+      );
+    }
+
+    const match = pathname.match(/^\/uploads\/([^/]+)$/);
+    if (!match) {
+      throw new BadRequestException(
+        'Document fileUrl must be an /uploads/<filename> path from this API',
+      );
+    }
+
+    const filename = basename(match[1]);
+    if (
+      !filename ||
+      filename !== match[1] ||
+      filename.includes('..') ||
+      /[%_]/.test(filename)
+    ) {
+      throw new BadRequestException('Invalid upload filename');
+    }
+
+    // UUID-style names from multer storage (uuid + optional extension)
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(filename)) {
+      throw new BadRequestException('Invalid upload filename');
+    }
+
+    const diskPath = join(process.cwd(), 'uploads', filename);
+    if (!existsSync(diskPath)) {
+      throw new BadRequestException('Upload file not found on server');
+    }
+
+    const existingDocs = await this.documentsRepo.find({
+      where: { fileUrl: ILike(`%/uploads/${filename}`) },
+      take: 20,
+    });
+
+    for (const doc of existingDocs) {
+      const owner = await this.patientsRepo.findOne({
+        where: { id: doc.patientId },
+      });
+      if (owner && owner.hospitalId !== hospitalId) {
+        throw new BadRequestException(
+          'Upload file is already linked to another hospital',
+        );
+      }
+    }
+
+    // Store a stable relative path so clients always hit this API origin
+    return `/uploads/${filename}`;
   }
 }

--- a/apps/api/src/pharmacy/pharmacy.resolver.ts
+++ b/apps/api/src/pharmacy/pharmacy.resolver.ts
@@ -1,10 +1,11 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { PERMISSIONS } from '@careconnect/types';
+import { PERMISSIONS, ROLES } from '@careconnect/types';
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
+import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { PharmacyService } from './pharmacy.service';
 import {
@@ -13,6 +14,12 @@ import {
   PharmacyStockType,
   UpsertPharmacyStockInput,
 } from './pharmacy.types';
+
+const PHARMACY_ROLES = [
+  ROLES.PHARMACIST,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+] as const;
 
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
@@ -46,6 +53,7 @@ export class PharmacyResolver {
   }
 
   @Mutation(() => PharmacyStockType)
+  @Roles(...PHARMACY_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async upsertPharmacyStock(
     @CurrentUser() user: AuthenticatedUser,
@@ -64,6 +72,7 @@ export class PharmacyResolver {
   }
 
   @Mutation(() => PendingPrescriptionType)
+  @Roles(...PHARMACY_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async dispensePrescription(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/portal/portal.service.spec.ts
+++ b/apps/api/src/portal/portal.service.spec.ts
@@ -20,8 +20,12 @@ describe('PortalService', () => {
   const prescriptionsRepo = { find: jest.fn() };
   const labOrdersRepo = { find: jest.fn() };
   const labResultsRepo = { find: jest.fn() };
-  const appointmentsService = { toAppointmentType: jest.fn((a) => a) };
-  const clinicalService = { toPrescriptionType: jest.fn((p) => p) };
+  const appointmentsService = {
+    toAppointmentType: jest.fn((a: unknown) => a),
+  };
+  const clinicalService = {
+    toPrescriptionType: jest.fn((p: unknown) => p),
+  };
 
   const actor: AuthenticatedUser = {
     id: 'user-1',

--- a/apps/api/src/portal/portal.service.spec.ts
+++ b/apps/api/src/portal/portal.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  Appointment,
+  LabOrder,
+  LabResult,
+  Patient,
+  Prescription,
+} from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AppointmentsService } from '../appointments/appointments.service';
+import { ClinicalService } from '../clinical/clinical.service';
+import { PortalService } from './portal.service';
+
+describe('PortalService', () => {
+  let service: PortalService;
+
+  const patientsRepo = { findOne: jest.fn(), find: jest.fn() };
+  const appointmentsRepo = { find: jest.fn() };
+  const prescriptionsRepo = { find: jest.fn() };
+  const labOrdersRepo = { find: jest.fn() };
+  const labResultsRepo = { find: jest.fn() };
+  const appointmentsService = { toAppointmentType: jest.fn((a) => a) };
+  const clinicalService = { toPrescriptionType: jest.fn((p) => p) };
+
+  const actor: AuthenticatedUser = {
+    id: 'user-1',
+    authId: 'auth-1',
+    email: 'same@example.com',
+    fullName: 'Patient User',
+    hospitalId: undefined,
+    roles: ['patient'],
+    permissions: [],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortalService,
+        { provide: getRepositoryToken(Patient), useValue: patientsRepo },
+        {
+          provide: getRepositoryToken(Appointment),
+          useValue: appointmentsRepo,
+        },
+        {
+          provide: getRepositoryToken(Prescription),
+          useValue: prescriptionsRepo,
+        },
+        { provide: getRepositoryToken(LabOrder), useValue: labOrdersRepo },
+        { provide: getRepositoryToken(LabResult), useValue: labResultsRepo },
+        { provide: AppointmentsService, useValue: appointmentsService },
+        { provide: ClinicalService, useValue: clinicalService },
+      ],
+    }).compile();
+    service = module.get(PortalService);
+  });
+
+  it('does not expose PHI for same email when patient.userId is unset', async () => {
+    patientsRepo.findOne.mockResolvedValue(null);
+
+    const result = await service.portalPatientRecords(actor);
+
+    expect(result.patient).toBeUndefined();
+    expect(result.appointments).toEqual([]);
+    expect(result.prescriptions).toEqual([]);
+    expect(result.labResults).toEqual([]);
+    expect(patientsRepo.findOne).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+    });
+    expect(patientsRepo.find).not.toHaveBeenCalled();
+    expect(appointmentsRepo.find).not.toHaveBeenCalled();
+  });
+
+  it('returns records when patient is explicitly linked by userId', async () => {
+    patientsRepo.findOne.mockResolvedValue({
+      id: 'patient-1',
+      hospitalId: 'hospital-a',
+      userId: 'user-1',
+      fullName: 'Linked',
+      email: 'same@example.com',
+      status: 'registered',
+    });
+    appointmentsRepo.find.mockResolvedValue([]);
+    prescriptionsRepo.find.mockResolvedValue([]);
+    labOrdersRepo.find.mockResolvedValue([]);
+
+    const result = await service.portalPatientRecords(actor);
+
+    expect(result.patient?.id).toBe('patient-1');
+    expect(appointmentsRepo.find).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/portal/portal.service.ts
+++ b/apps/api/src/portal/portal.service.ts
@@ -41,31 +41,16 @@ export class PortalService {
     }
   }
 
+  /**
+   * Portal PHI is only available after an explicit hospital link
+   * (`patients.user_id`). Email must never auto-grant chart access.
+   */
   private async findLinkedPatient(
     user: AuthenticatedUser,
   ): Promise<Patient | null> {
-    const byUserId = await this.patientsRepo.findOne({
+    return this.patientsRepo.findOne({
       where: { userId: user.id },
     });
-    if (byUserId) return byUserId;
-
-    if (user.email) {
-      // Prefer hospital-scoped match when the patient user is linked to a hospital
-      if (user.hospitalId) {
-        return this.patientsRepo.findOne({
-          where: { email: user.email, hospitalId: user.hospitalId },
-        });
-      }
-      // Without hospital context, only match when exactly one patient has this email
-      const matches = await this.patientsRepo.find({
-        where: { email: user.email },
-        take: 2,
-      });
-      if (matches.length === 1) return matches[0];
-      return null;
-    }
-
-    return null;
   }
 
   private toProfile(patient: Patient): PortalPatientProfileType {

--- a/apps/web/src/app/(dashboard)/appointments/page.tsx
+++ b/apps/web/src/app/(dashboard)/appointments/page.tsx
@@ -37,11 +37,21 @@ const statusVariant = (status: string) => {
 
 export default function AppointmentsPage() {
   const [selectedDate, setSelectedDate] = useState(todayDateString());
-  const { data: meData } = useQuery(ME_QUERY);
-  const hospitalId = meData?.me?.hospitalId;
+  const me = meData?.me;
+  const hospitalId = me?.hospitalId;
+  const isDoctorOnly =
+    Array.isArray(me?.roles) &&
+    me.roles.includes('doctor') &&
+    !me.roles.some((r: string) =>
+      ['hospital_admin', 'hospital_manager', 'super_admin', 'receptionist', 'nurse'].includes(r),
+    );
 
   const { data, loading, refetch } = useQuery(APPOINTMENTS_QUERY, {
-    variables: { hospitalId, date: selectedDate },
+    variables: {
+      hospitalId,
+      date: selectedDate,
+      ...(isDoctorOnly && me?.id ? { doctorId: me.id } : {}),
+    },
     skip: !hospitalId,
   });
 

--- a/apps/web/src/app/(dashboard)/appointments/page.tsx
+++ b/apps/web/src/app/(dashboard)/appointments/page.tsx
@@ -37,6 +37,7 @@ const statusVariant = (status: string) => {
 
 export default function AppointmentsPage() {
   const [selectedDate, setSelectedDate] = useState(todayDateString());
+  const { data: meData } = useQuery(ME_QUERY);
   const me = meData?.me;
   const hospitalId = me?.hospitalId;
   const isDoctorOnly =

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -22,6 +22,13 @@ export default function DashboardPage() {
   const today = todayDateString();
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const me = meData?.me;
+  const isDoctorOnly =
+    Array.isArray(me?.roles) &&
+    me.roles.includes('doctor') &&
+    !me.roles.some((r: string) =>
+      ['hospital_admin', 'hospital_manager', 'super_admin', 'receptionist', 'nurse'].includes(r),
+    );
 
   const { data: staffData } = useQuery(STAFF_MEMBERS_QUERY, {
     variables: { hospitalId },
@@ -39,7 +46,11 @@ export default function DashboardPage() {
   });
 
   const { data: appointmentsData } = useQuery(APPOINTMENTS_QUERY, {
-    variables: { hospitalId, date: today },
+    variables: {
+      hospitalId,
+      date: today,
+      ...(isDoctorOnly && me?.id ? { doctorId: me.id } : {}),
+    },
     skip: !hospitalId || !!statsData?.dashboardStats,
     errorPolicy: 'ignore',
   });

--- a/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
@@ -65,7 +65,21 @@ export default function PatientDetailPage() {
 
   const handleOpenDocument = async (fileUrl: string) => {
     const token = await getToken();
-    const res = await fetch(fileUrl, {
+    // Only fetch same-origin upload paths — never send the Clerk JWT to arbitrary URLs
+    let pathname: string;
+    try {
+      pathname = fileUrl.startsWith('/uploads/')
+        ? fileUrl.split('?')[0] ?? fileUrl
+        : new URL(fileUrl, apiBase).pathname;
+    } catch {
+      setUploadError('Invalid document URL');
+      return;
+    }
+    if (!/^\/uploads\/[^/]+$/.test(pathname) || pathname.includes('..')) {
+      setUploadError('Invalid document URL');
+      return;
+    }
+    const res = await fetch(`${apiBase}${pathname}`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
     if (!res.ok) {

--- a/supabase/migrations/20240609000015_facility_read_clinical_roles.sql
+++ b/supabase/migrations/20240609000015_facility_read_clinical_roles.sql
@@ -1,0 +1,13 @@
+-- Grant facility read to clinical/front-desk roles that admit patients
+-- so wards/beds queries succeed without granting hospitals:write.
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.slug = 'hospitals:read'
+WHERE r.slug IN ('hospital_manager', 'doctor', 'nurse', 'receptionist')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM role_permissions rp
+    WHERE rp.role_id = r.id AND rp.permission_id = p.id
+  );


### PR DESCRIPTION
## Summary
Fixes all open Critical/High issues from the post-#24 rescan without removing working staff/admin flows.

- **#49** Portal PHI only after explicit `patients.user_id` link (no email auto-bind)
- **#50** Document `fileUrl` constrained to local `/uploads/*`; client never sends JWT to arbitrary hosts
- **#51** Pharmacy dispense/stock require pharmacist/admin/manager roles
- **#52** Patients and staff cannot bootstrap `createHospital`
- **#53** `voidInvoice` uses the same pessimistic lock as payments
- **#54** Grant `hospitals:read` to clinical/front-desk roles for ward/bed lists
- **#55** Doctor appointment lists scoped to acting doctor (server + client)
- **#56** Inventory API uses pharmacist roles + patients permissions (matches UI)

## Test plan
- [x] Unit tests: portal, patients documents, appointments doctor scope
- [x] API build / web tsc
- [ ] CI lint-and-build
- [ ] Spot-check: hospital-admin onboarding still creates hospital
- [ ] Spot-check: linked portal patient still sees records; unlinked same-email does not
- [ ] Spot-check: receptionist cannot dispense; pharmacist can
- [ ] Spot-check: doctor admit form loads wards/beds after migration

Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54
Closes #55
Closes #56

Made with [Cursor](https://cursor.com)