### PR TITLE
fix: P1 medium security and flow gaps (#57–#67)

### DIFF
--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -191,9 +191,7 @@ describe('AdmissionsService', () => {
         .mockReturnValueOnce(admissionQb)
         .mockReturnValueOnce(bedQb);
       manager.findOne.mockResolvedValue(patient);
-      manager.save.mockImplementation((row: unknown) =>
-        Promise.resolve(row),
-      );
+      manager.save.mockImplementation((row: unknown) => Promise.resolve(row));
 
       admissionsRepo.findOne.mockResolvedValue({
         ...admission,

--- a/apps/api/src/clinical/clinical.resolver.ts
+++ b/apps/api/src/clinical/clinical.resolver.ts
@@ -31,6 +31,14 @@ const CLINICIAN_ROLES = [
   ROLES.HOSPITAL_MANAGER,
 ] as const;
 
+/** Doctors and nurses may author SOAP notes and lab orders. */
+const CLINICAL_AUTHOR_ROLES = [
+  ROLES.DOCTOR,
+  ROLES.NURSE,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+] as const;
+
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class ClinicalResolver {
@@ -146,6 +154,7 @@ export class ClinicalResolver {
   }
 
   @Mutation(() => ClinicalNoteType)
+  @Roles(...CLINICAL_AUTHOR_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async createClinicalNote(
     @CurrentUser() user: AuthenticatedUser,
@@ -183,6 +192,7 @@ export class ClinicalResolver {
   }
 
   @Mutation(() => LabOrderType)
+  @Roles(...CLINICAL_AUTHOR_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async createLabOrder(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/clinical/clinical.service.spec.ts
+++ b/apps/api/src/clinical/clinical.service.spec.ts
@@ -29,13 +29,23 @@ describe('ClinicalService', () => {
     findOne: jest.fn(),
   };
   const prescriptionItemsRepo = { save: jest.fn(), create: jest.fn() };
+  const labManager = {
+    createQueryBuilder: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => data),
+  };
   const labOrdersRepo = {
     save: jest.fn(),
     create: jest.fn(),
     find: jest.fn(),
     findOne: jest.fn(),
+    manager: {
+      transaction: jest.fn((cb: (m: typeof labManager) => unknown) =>
+        Promise.resolve(cb(labManager)),
+      ),
+    },
   };
-  const labResultsRepo = { save: jest.fn(), create: jest.fn() };
+  const labResultsRepo = { save: jest.fn(), create: jest.fn(), findOne: jest.fn() };
   const patientsRepo = { findOne: jest.fn() };
   const admissionsRepo = { findOne: jest.fn() };
   const audit = { log: jest.fn() };
@@ -117,11 +127,17 @@ describe('ClinicalService', () => {
 
   describe('lab order status machine', () => {
     it('rejects re-completing a completed lab order', async () => {
-      labOrdersRepo.findOne.mockResolvedValue({
-        id: 'lab-1',
-        hospitalId: 'hospital-a',
-        status: 'completed',
-      });
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'lab-1',
+          hospitalId: 'hospital-a',
+          status: 'completed',
+        }),
+      };
+      labManager.createQueryBuilder.mockReturnValue(qb);
 
       await expect(
         service.completeLabResult(
@@ -130,7 +146,7 @@ describe('ClinicalService', () => {
           actor,
         ),
       ).rejects.toThrow(BadRequestException);
-      expect(labResultsRepo.save).not.toHaveBeenCalled();
+      expect(labManager.save).not.toHaveBeenCalled();
     });
 
     it('advances ordered → collected', async () => {

--- a/apps/api/src/clinical/clinical.service.spec.ts
+++ b/apps/api/src/clinical/clinical.service.spec.ts
@@ -45,7 +45,11 @@ describe('ClinicalService', () => {
       ),
     },
   };
-  const labResultsRepo = { save: jest.fn(), create: jest.fn(), findOne: jest.fn() };
+  const labResultsRepo = {
+    save: jest.fn(),
+    create: jest.fn(),
+    findOne: jest.fn(),
+  };
   const patientsRepo = { findOne: jest.fn() };
   const admissionsRepo = { findOne: jest.fn() };
   const audit = { log: jest.fn() };

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -456,33 +456,46 @@ export class ClinicalService {
     input: CompleteLabResultInput,
     actor: AuthenticatedUser,
   ): Promise<LabResultType> {
-    const order = await this.labOrdersRepo.findOne({
-      where: { id: input.labOrderId, hospitalId },
-    });
-    if (!order) throw new NotFoundException('Lab order not found');
+    const resultId = await this.labOrdersRepo.manager.transaction(
+      async (manager) => {
+        const order = await manager
+          .createQueryBuilder(LabOrder, 'order')
+          .setLock('pessimistic_write')
+          .where('order.id = :id', { id: input.labOrderId })
+          .andWhere('order.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!order) throw new NotFoundException('Lab order not found');
 
-    if (order.status === 'completed' || order.status === 'cancelled') {
-      throw new BadRequestException(
-        `Cannot complete lab order with status "${order.status}"`,
-      );
-    }
-    assertLabTransition(order.status, 'completed');
+        if (order.status === 'completed' || order.status === 'cancelled') {
+          throw new BadRequestException(
+            `Cannot complete lab order with status "${order.status}"`,
+          );
+        }
+        assertLabTransition(order.status, 'completed');
 
-    const result = await this.labResultsRepo.save(
-      this.labResultsRepo.create({
-        labOrderId: order.id,
-        hospitalId,
-        resultValue: input.resultValue,
-        referenceRange: input.referenceRange,
-        unit: input.unit,
-        resultFileUrl: input.resultFileUrl,
-        enteredById: actor.id,
-        completedAt: new Date(),
-      }),
+        const result = await manager.save(
+          manager.create(LabResult, {
+            labOrderId: order.id,
+            hospitalId,
+            resultValue: input.resultValue,
+            referenceRange: input.referenceRange,
+            unit: input.unit,
+            resultFileUrl: input.resultFileUrl,
+            enteredById: actor.id,
+            completedAt: new Date(),
+          }),
+        );
+
+        order.status = 'completed';
+        await manager.save(order);
+        return result.id;
+      },
     );
 
-    order.status = 'completed';
-    await this.labOrdersRepo.save(order);
+    const result = await this.labResultsRepo.findOne({
+      where: { id: resultId, hospitalId },
+    });
+    if (!result) throw new NotFoundException('Lab result not found');
 
     await this.audit.log({
       actorId: actor.id,
@@ -490,7 +503,7 @@ export class ClinicalService {
       action: 'complete',
       resource: 'lab_result',
       resourceId: result.id,
-      metadata: { labOrderId: order.id },
+      metadata: { labOrderId: input.labOrderId },
     });
 
     return this.toLabResultType(result);

--- a/apps/api/src/discharge/discharge.module.ts
+++ b/apps/api/src/discharge/discharge.module.ts
@@ -7,12 +7,14 @@ import {
   FollowUp,
   Patient,
 } from '../database/entities';
+import { CommonModule } from '../common/common.module';
 import { DischargeResolver } from './discharge.resolver';
 import { DischargeService } from './discharge.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Discharge, FollowUp, Admission, Patient, Bed]),
+    CommonModule,
   ],
   providers: [DischargeResolver, DischargeService],
   exports: [DischargeService],

--- a/apps/api/src/discharge/discharge.service.spec.ts
+++ b/apps/api/src/discharge/discharge.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Discharge, FollowUp, Patient } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { HospitalDoctorValidator } from '../common/hospital-doctor.validator';
 import { DischargeService } from './discharge.service';
 
 describe('DischargeService', () => {
@@ -32,6 +33,9 @@ describe('DischargeService', () => {
   const followUpsRepo = { save: jest.fn(), create: jest.fn(), find: jest.fn() };
   const patientsRepo = { findOne: jest.fn(), save: jest.fn() };
   const audit = { log: jest.fn() };
+  const doctorValidator = {
+    assertHospitalDoctor: jest.fn().mockResolvedValue(undefined),
+  };
 
   const actor: AuthenticatedUser = {
     id: 'doc-1',
@@ -53,6 +57,7 @@ describe('DischargeService', () => {
         { provide: getRepositoryToken(FollowUp), useValue: followUpsRepo },
         { provide: getRepositoryToken(Patient), useValue: patientsRepo },
         { provide: AuditService, useValue: audit },
+        { provide: HospitalDoctorValidator, useValue: doctorValidator },
       ],
     }).compile();
     service = module.get(DischargeService);

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -15,6 +15,7 @@ import {
 } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { HospitalDoctorValidator } from '../common/hospital-doctor.validator';
 import {
   CreateDischargeInput,
   CreateFollowUpInput,
@@ -40,6 +41,7 @@ export class DischargeService {
     @InjectRepository(Patient)
     private readonly patientsRepo: Repository<Patient>,
     private readonly audit: AuditService,
+    private readonly doctorValidator: HospitalDoctorValidator,
   ) {}
 
   assertHospitalAccess(user: AuthenticatedUser, hospitalId: string) {
@@ -218,6 +220,19 @@ export class DischargeService {
         where: { id: input.dischargeId, hospitalId },
       });
       if (!discharge) throw new NotFoundException('Discharge not found');
+      if (discharge.patientId !== input.patientId) {
+        throw new BadRequestException(
+          'Discharge does not belong to the given patient',
+        );
+      }
+    }
+
+    if (input.doctorId) {
+      await this.doctorValidator.assertHospitalDoctor(
+        hospitalId,
+        input.doctorId,
+        'Follow-up doctor',
+      );
     }
 
     const followUp = await this.followUpsRepo.save(

--- a/apps/api/src/hospitals/hospitals.resolver.ts
+++ b/apps/api/src/hospitals/hospitals.resolver.ts
@@ -50,9 +50,7 @@ export class HospitalsResolver {
       throw new ForbiddenException('Patients cannot create hospitals');
     }
 
-    const hasStaffRole = user.roles.some((role) =>
-      STAFF_ROLES.includes(role as (typeof STAFF_ROLES)[number]),
-    );
+    const hasStaffRole = user.roles.some((role) => STAFF_ROLES.includes(role));
 
     const canBootstrap = !user.hospitalId && !hasStaffRole;
     const canWrite =

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -527,21 +527,39 @@ export class PatientsService {
     const lookupEmail =
       email?.trim().toLowerCase() || patient.email?.toLowerCase();
 
-    if (!targetUserId && lookupEmail) {
-      const portalUser = await this.usersRepo.findOne({
-        where: { email: lookupEmail },
+    let targetUser: User | null = null;
+    if (targetUserId) {
+      targetUser = await this.usersRepo.findOne({
+        where: { id: targetUserId },
+        relations: ['userRoles', 'userRoles.role'],
       });
-      if (!portalUser) {
+    } else if (lookupEmail) {
+      targetUser = await this.usersRepo
+        .createQueryBuilder('user')
+        .leftJoinAndSelect('user.userRoles', 'userRoles')
+        .leftJoinAndSelect('userRoles.role', 'role')
+        .where('LOWER(user.email) = :email', { email: lookupEmail })
+        .getOne();
+      if (!targetUser) {
         throw new NotFoundException(
           `No CareConnect user found for email ${lookupEmail}. Ask the patient to register first.`,
         );
       }
-      targetUserId = portalUser.id;
+      targetUserId = targetUser.id;
     }
 
-    if (!targetUserId) {
+    if (!targetUserId || !targetUser) {
       throw new BadRequestException(
         'Provide a portal user email or userId to link (cannot default to staff account)',
+      );
+    }
+
+    const hasPatientRole = (targetUser.userRoles ?? []).some(
+      (ur) => ur.role?.slug === 'patient',
+    );
+    if (!hasPatientRole) {
+      throw new BadRequestException(
+        'Only users with the patient role can be linked to a patient chart',
       );
     }
 

--- a/apps/api/src/pharmacy/pharmacy.service.spec.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.spec.ts
@@ -19,6 +19,7 @@ describe('PharmacyService', () => {
     findOne: jest.fn(),
     save: jest.fn(),
     create: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
   const prescriptionsRepo = {
     find: jest.fn(),

--- a/apps/api/src/pharmacy/pharmacy.service.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.ts
@@ -109,9 +109,16 @@ export class PharmacyService {
     input: UpsertPharmacyStockInput,
     actor: AuthenticatedUser,
   ): Promise<PharmacyStockType> {
-    const existing = await this.pharmacyStockRepo.findOne({
-      where: { hospitalId, drugName: input.drugName },
-    });
+    const drugName = input.drugName.trim();
+    if (!drugName) {
+      throw new BadRequestException('Drug name is required');
+    }
+
+    const existing = await this.pharmacyStockRepo
+      .createQueryBuilder('stock')
+      .where('stock.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('LOWER(stock.drug_name) = LOWER(:drugName)', { drugName })
+      .getOne();
 
     const stock = existing
       ? await this.pharmacyStockRepo.save({
@@ -122,7 +129,7 @@ export class PharmacyService {
       : await this.pharmacyStockRepo.save(
           this.pharmacyStockRepo.create({
             hospitalId,
-            drugName: input.drugName,
+            drugName,
             quantity: input.quantity.toFixed(2),
             unit: input.unit ?? 'each',
           }),

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -172,6 +172,21 @@ describe('UploadsService', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
+    it('allows dual-role doctor+patient to download hospital docs', async () => {
+      mockDocLookup(document);
+      patientsRepo.findOne.mockResolvedValue({
+        ...patient,
+        userId: 'other-patient',
+      });
+
+      await expect(
+        service.assertCanDownload('abc.pdf', {
+          ...staffUser,
+          roles: ['doctor', 'patient'],
+        }),
+      ).resolves.toEqual(document);
+    });
+
     it('allows super_admin across hospitals', async () => {
       mockDocLookup(document);
       patientsRepo.findOne.mockResolvedValue(patient);

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -10,6 +10,7 @@ describe('UploadsService', () => {
 
   const documentsRepo = {
     findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
   const patientsRepo = {
     findOne: jest.fn(),
@@ -17,6 +18,14 @@ describe('UploadsService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    documentsRepo.createQueryBuilder.mockImplementation(() => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        orWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      };
+      return qb;
+    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -99,15 +108,30 @@ describe('UploadsService', () => {
       userId: 'user-patient-1',
     };
 
+    const mockDocLookup = (doc: typeof document | null) => {
+      documentsRepo.createQueryBuilder.mockImplementation(() => ({
+        where: jest.fn().mockReturnThis(),
+        orWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(doc),
+      }));
+    };
+
     it('throws NotFound when no document row matches', async () => {
-      documentsRepo.findOne.mockResolvedValue(null);
+      mockDocLookup(null);
       await expect(
         service.assertCanDownload('missing.pdf', staffUser),
       ).rejects.toThrow(NotFoundException);
     });
 
+    it('rejects filenames with LIKE wildcards without querying', async () => {
+      await expect(
+        service.assertCanDownload('%.pdf', staffUser),
+      ).rejects.toThrow(NotFoundException);
+      expect(documentsRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
     it('allows same-hospital staff with patients:read', async () => {
-      documentsRepo.findOne.mockResolvedValue(document);
+      mockDocLookup(document);
       patientsRepo.findOne.mockResolvedValue(patient);
 
       await expect(
@@ -116,7 +140,7 @@ describe('UploadsService', () => {
     });
 
     it('denies staff from another hospital', async () => {
-      documentsRepo.findOne.mockResolvedValue(document);
+      mockDocLookup(document);
       patientsRepo.findOne.mockResolvedValue(patient);
 
       await expect(
@@ -128,7 +152,7 @@ describe('UploadsService', () => {
     });
 
     it('allows linked patient for their own document', async () => {
-      documentsRepo.findOne.mockResolvedValue(document);
+      mockDocLookup(document);
       patientsRepo.findOne.mockResolvedValue(patient);
 
       await expect(
@@ -137,7 +161,7 @@ describe('UploadsService', () => {
     });
 
     it('denies patient for another patient document', async () => {
-      documentsRepo.findOne.mockResolvedValue(document);
+      mockDocLookup(document);
       patientsRepo.findOne.mockResolvedValue({
         ...patient,
         userId: 'other-user',
@@ -149,7 +173,7 @@ describe('UploadsService', () => {
     });
 
     it('allows super_admin across hospitals', async () => {
-      documentsRepo.findOne.mockResolvedValue(document);
+      mockDocLookup(document);
       patientsRepo.findOne.mockResolvedValue(patient);
 
       await expect(

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -4,7 +4,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Like, Repository } from 'typeorm';
+import { basename } from 'path';
+import { Repository } from 'typeorm';
 import { PERMISSIONS } from '@careconnect/types';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Patient, PatientDocument } from '../database/entities';
@@ -75,15 +76,26 @@ export class UploadsService {
   private async findDocumentByFilename(
     filename: string,
   ): Promise<PatientDocument | null> {
-    // fileUrl is stored as absolute URL ending in /uploads/<filename>
-    const bySuffix = await this.documentsRepo.findOne({
-      where: { fileUrl: Like(`%/uploads/${filename}`) },
-    });
-    if (bySuffix) return bySuffix;
+    const safe = basename(filename);
+    if (
+      !safe ||
+      safe !== filename ||
+      safe.includes('..') ||
+      /[%_]/.test(safe)
+    ) {
+      return null;
+    }
 
-    // Fallback: exact filename match for relative paths
-    return this.documentsRepo.findOne({
-      where: { fileUrl: filename },
-    });
+    const suffix = `/uploads/${safe}`;
+    // Exact suffix match via RIGHT — avoids LIKE metacharacters in user input
+    return this.documentsRepo
+      .createQueryBuilder('doc')
+      .where('doc.file_url = :relative', { relative: suffix })
+      .orWhere('doc.file_url = :filename', { filename: safe })
+      .orWhere('RIGHT(doc.file_url, :len) = :suffix', {
+        len: suffix.length,
+        suffix,
+      })
+      .getOne();
   }
 }

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -43,22 +43,22 @@ export class UploadsService {
       return document;
     }
 
-    // Linked patient portal user: only their own documents
+    // Hospital staff (including dual-role patient+staff): same hospital + patients read/write
+    const isHospitalStaff =
+      !!user.hospitalId &&
+      user.hospitalId === patient.hospitalId &&
+      (user.permissions.includes(PERMISSIONS.PATIENTS_READ) ||
+        user.permissions.includes(PERMISSIONS.PATIENTS_WRITE));
+    if (isHospitalStaff) {
+      return document;
+    }
+
+    // Pure patient portal user: only their linked chart's documents
     if (user.roles.includes('patient')) {
       if (patient.userId && patient.userId === user.id) {
         return document;
       }
       throw new ForbiddenException('Access denied');
-    }
-
-    // Hospital staff: same hospital + patients:read (or write)
-    if (
-      user.hospitalId &&
-      user.hospitalId === patient.hospitalId &&
-      (user.permissions.includes(PERMISSIONS.PATIENTS_READ) ||
-        user.permissions.includes(PERMISSIONS.PATIENTS_WRITE))
-    ) {
-      return document;
     }
 
     throw new ForbiddenException('Access denied');

--- a/apps/web/src/app/(dashboard)/lab/page.tsx
+++ b/apps/web/src/app/(dashboard)/lab/page.tsx
@@ -42,6 +42,7 @@ export default function LabPage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canCreateOrders = (meData?.me?.permissions ?? []).includes('patients:write');
 
   const { data, loading, refetch } = useQuery(LAB_ORDERS_QUERY, {
     variables: { hospitalId, status: undefined },
@@ -50,7 +51,7 @@ export default function LabPage() {
 
   const { data: patientsData } = useQuery(PATIENTS_QUERY, {
     variables: { search: patientSearch, limit: 8, hospitalId },
-    skip: !hospitalId || patientSearch.length < 2,
+    skip: !hospitalId || !canCreateOrders || patientSearch.length < 2,
   });
 
   const [completeResult, { loading: completing }] = useMutation(COMPLETE_LAB_RESULT_MUTATION, {
@@ -132,9 +133,11 @@ export default function LabPage() {
       ) : null}
 
       <div className="mb-6 flex justify-end">
-        <ClayButton onClick={() => setShowNewOrder(!showNewOrder)}>
-          {showNewOrder ? 'Hide Order Form' : 'New Lab Order'}
-        </ClayButton>
+        {canCreateOrders ? (
+          <ClayButton onClick={() => setShowNewOrder(!showNewOrder)}>
+            {showNewOrder ? 'Hide Order Form' : 'New Lab Order'}
+          </ClayButton>
+        ) : null}
       </div>
 
       {showNewOrder ? (

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -11,14 +11,13 @@ import { canAccessRoute } from '@/lib/route-access';
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const { data, loading } = useQuery(ME_QUERY, { errorPolicy: 'all' });
+  const { data, loading, error } = useQuery(ME_QUERY, { errorPolicy: 'all' });
   const me = data?.me;
 
   const roles: string[] = me?.roles ?? [];
   const permissions: string[] = me?.permissions ?? [];
-  const allowed =
-    !me ||
-    canAccessRoute(pathname, { roles, permissions });
+  // Fail closed: never treat missing/failed me as authorized
+  const allowed = !!me && canAccessRoute(pathname, { roles, permissions });
 
   useEffect(() => {
     if (!me) return;
@@ -43,6 +42,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       <main id="main-content" tabIndex={-1} className="flex-1 overflow-auto outline-none">
         {loading && !me ? (
           <p className="text-clay-text-muted">Loading...</p>
+        ) : error && !me ? (
+          <ForbiddenAccess />
         ) : !allowed ? (
           <ForbiddenAccess />
         ) : (

--- a/apps/web/src/components/onboarding/onboarding-form.tsx
+++ b/apps/web/src/components/onboarding/onboarding-form.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useUser } from '@clerk/nextjs';
 import { useMutation } from '@apollo/client';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
-import { COMPLETE_ONBOARDING_MUTATION, CREATE_HOSPITAL_MUTATION } from '@/lib/graphql/queries';
+import { COMPLETE_ONBOARDING_MUTATION, COMPLETE_PATIENT_ONBOARDING, CREATE_HOSPITAL_MUTATION } from '@/lib/graphql/queries';
 
 type ClerkMeta = { hospitalName?: string; fullName?: string; accountType?: string };
 
@@ -45,6 +45,7 @@ function OnboardingFormFields({
 
   const [createHospital] = useMutation(CREATE_HOSPITAL_MUTATION);
   const [completeOnboarding] = useMutation(COMPLETE_ONBOARDING_MUTATION);
+  const [completePatientOnboarding] = useMutation(COMPLETE_PATIENT_ONBOARDING);
 
   // Staff must join via invite — never bootstrap as hospital_admin from this form
   if (accountType === 'staff') {
@@ -63,6 +64,46 @@ function OnboardingFormFields({
             <ClayButton>Register as hospital admin</ClayButton>
           </Link>
         </div>
+      </ClayCard>
+    );
+  }
+
+  if (accountType === 'patient') {
+    const handlePatientSubmit = async (e: React.FormEvent) => {
+      e.preventDefault();
+      setLoading(true);
+      setError('');
+      try {
+        await completePatientOnboarding({
+          variables: { fullName: fullName.trim() },
+        });
+        router.push('/portal');
+        router.refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Onboarding failed');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    return (
+      <ClayCard className="w-full max-w-lg">
+        <h1 className="mb-2 text-2xl font-bold text-clay-text">Complete patient setup</h1>
+        <p className="mb-6 text-sm text-clay-text-muted">
+          Finish your portal profile. A hospital must link your account before chart data appears.
+        </p>
+        <form onSubmit={handlePatientSubmit} className="flex flex-col gap-4">
+          <ClayInput
+            label="Your Full Name"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            required
+          />
+          {error ? <p className="text-sm text-clay-error">{error}</p> : null}
+          <ClayButton type="submit" isLoading={loading}>
+            Continue to portal
+          </ClayButton>
+        </form>
       </ClayCard>
     );
   }

--- a/apps/web/src/lib/route-access.ts
+++ b/apps/web/src/lib/route-access.ts
@@ -48,7 +48,7 @@ const ROUTE_RULES: RouteRule[] = [
   },
   {
     prefix: '/settings',
-    anyRoles: ['hospital_admin', 'hospital_manager', 'super_admin'],
+    anyRoles: ['hospital_admin', 'super_admin'],
     anyPermissions: ['hospitals:write'],
   },
 ];

--- a/supabase/migrations/20240609000016_pharmacy_stock_case_insensitive.sql
+++ b/supabase/migrations/20240609000016_pharmacy_stock_case_insensitive.sql
@@ -1,0 +1,48 @@
+-- Normalize pharmacy stock uniqueness to case-insensitive drug names.
+-- Merge any existing case-variant duplicates, then replace the unique constraint.
+
+WITH ranked AS (
+  SELECT
+    id,
+    hospital_id,
+    LOWER(drug_name) AS drug_key,
+    quantity::numeric AS qty,
+    ROW_NUMBER() OVER (
+      PARTITION BY hospital_id, LOWER(drug_name)
+      ORDER BY created_at ASC, id ASC
+    ) AS rn
+  FROM pharmacy_stock
+),
+totals AS (
+  SELECT hospital_id, drug_key, SUM(qty) AS total_qty
+  FROM ranked
+  GROUP BY hospital_id, drug_key
+  HAVING COUNT(*) > 1
+)
+UPDATE pharmacy_stock ps
+SET quantity = t.total_qty::numeric(12, 2)
+FROM ranked r
+JOIN totals t
+  ON t.hospital_id = r.hospital_id
+ AND t.drug_key = r.drug_key
+WHERE ps.id = r.id
+  AND r.rn = 1;
+
+DELETE FROM pharmacy_stock ps
+USING (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY hospital_id, LOWER(drug_name)
+      ORDER BY created_at ASC, id ASC
+    ) AS rn
+  FROM pharmacy_stock
+) d
+WHERE ps.id = d.id
+  AND d.rn > 1;
+
+ALTER TABLE pharmacy_stock
+  DROP CONSTRAINT IF EXISTS pharmacy_stock_hospital_id_drug_name_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_pharmacy_stock_hospital_drug_lower
+  ON pharmacy_stock (hospital_id, LOWER(drug_name));

--- a/supabase/migrations/20240609000017_staff_read_clinical_roles.sql
+++ b/supabase/migrations/20240609000017_staff_read_clinical_roles.sql
@@ -1,0 +1,13 @@
+-- Grant staff:read so clinicians/front desk can populate doctor pickers
+-- without full staff-admin access.
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.slug = 'staff:read'
+WHERE r.slug IN ('doctor', 'nurse', 'receptionist')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM role_permissions rp
+    WHERE rp.role_id = r.id AND rp.permission_id = p.id
+  );


### PR DESCRIPTION
## Summary
Fixes all open Medium (P1) issues from the post-rescan backlog without removing working clinician/admin flows.

- **#57** Exact upload filename suffix lookup (no LIKE wildcards)
- **#58** Clinical notes / lab orders require doctor|nurse|admin|manager
- **#59** `completeLabResult` transactional + row lock
- **#60** Follow-up `dischargeId` bound to patient; doctor validated
- **#61** `linkPatientAccount` requires patient role + case-insensitive email
- **#62** Dual-role staff downloads work (staff check before patient short-circuit)
- **#63** Pharmacy stock unique on `LOWER(drug_name)` + case-insensitive upsert
- **#64** Dashboard RBAC fails closed when `me` is missing
- **#65** Patient `accountType` uses patient onboarding → `/portal`
- **#66** Grant `staff:read` to doctor/nurse/receptionist
- **#67** Hide lab create without `patients:write`; settings admin-only

## Test plan
- [x] Unit tests for uploads, clinical, pharmacy, patients, discharge
- [x] API lint/build + web tsc locally
- [ ] CI lint-and-build
- [ ] Spot-check: nurse can still create notes; receptionist cannot
- [ ] Spot-check: lab tech sees queue but not New Order
- [ ] Spot-check: doctor appointment doctor picker loads after migration

Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #65
Closes #66
Closes #67

Made with [Cursor](https://cursor.com)