### PR TITLE
fix: P2 low — playground/TLS (#68) and orphan upload sweep (#69)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -79,61 +79,77 @@ import { UploadsModule } from './uploads/uploads.module';
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (config: ConfigService) => ({
-        type: 'postgres',
-        url: config.get<string>('DATABASE_URL'),
-        entities: [
-          Hospital,
-          Role,
-          Permission,
-          User,
-          UserRole,
-          StaffProfile,
-          StaffInvite,
-          AuditLog,
-          Patient,
-          PatientEmergencyContact,
-          PatientInsurance,
-          PatientAllergy,
-          PatientMedication,
-          PatientMedicalHistory,
-          PatientDocument,
-          PatientConsent,
-          PatientImportJob,
-          Department,
-          Ward,
-          Bed,
-          Appointment,
-          Admission,
-          VitalSign,
-          Diagnosis,
-          ClinicalNote,
-          Prescription,
-          PrescriptionItem,
-          LabOrder,
-          LabResult,
-          Discharge,
-          FollowUp,
-          Invoice,
-          InvoiceItem,
-          Payment,
-          InventoryItem,
-          PharmacyStock,
-        ],
-        synchronize: false,
-        logging: config.get('NODE_ENV') === 'development',
-        ssl:
-          config.get('DATABASE_SSL') === 'true'
-            ? { rejectUnauthorized: false }
-            : false,
-      }),
+      useFactory: (config: ConfigService) => {
+        const nodeEnv = config.get<string>('NODE_ENV');
+        return {
+          type: 'postgres',
+          url: config.get<string>('DATABASE_URL'),
+          entities: [
+            Hospital,
+            Role,
+            Permission,
+            User,
+            UserRole,
+            StaffProfile,
+            StaffInvite,
+            AuditLog,
+            Patient,
+            PatientEmergencyContact,
+            PatientInsurance,
+            PatientAllergy,
+            PatientMedication,
+            PatientMedicalHistory,
+            PatientDocument,
+            PatientConsent,
+            PatientImportJob,
+            Department,
+            Ward,
+            Bed,
+            Appointment,
+            Admission,
+            VitalSign,
+            Diagnosis,
+            ClinicalNote,
+            Prescription,
+            PrescriptionItem,
+            LabOrder,
+            LabResult,
+            Discharge,
+            FollowUp,
+            Invoice,
+            InvoiceItem,
+            Payment,
+            InventoryItem,
+            PharmacyStock,
+          ],
+          synchronize: false,
+          logging: config.get('NODE_ENV') === 'development',
+          // DATABASE_SSL=true relaxes pg TLS verification (rejectUnauthorized: false)
+          // for providers like Neon. Never relax verification in production.
+          ssl:
+            config.get('DATABASE_SSL') === 'true'
+              ? nodeEnv === 'production'
+                ? true // pg default: full certificate verification against system CAs
+                : { rejectUnauthorized: false }
+              : false,
+        };
+      },
     }),
-    GraphQLModule.forRoot<ApolloDriverConfig>({
+    GraphQLModule.forRootAsync<ApolloDriverConfig>({
       driver: ApolloDriver,
-      autoSchemaFile: join(process.cwd(), 'src/schema.gql'),
-      sortSchema: true,
-      playground: true,
-      context: ({ req }: { req: Request }) => ({ req }),
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        const isProduction = config.get('NODE_ENV') === 'production';
+        return {
+          autoSchemaFile: join(process.cwd(), 'src/schema.gql'),
+          sortSchema: true,
+          // Playground + introspection only outside production.
+          playground: !isProduction,
+          introspection: !isProduction,
+          context: ({ req }: { req: Request }) => ({ req }),
+        };
+      },
     }),
     AuthModule,
     RbacModule,

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -1,9 +1,30 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
+import { promises as fs } from 'fs';
+import { join } from 'path';
 import { Patient, PatientDocument } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { UploadsService } from './uploads.service';
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readdir: jest.fn(),
+      stat: jest.fn(),
+      unlink: jest.fn(),
+    },
+  };
+});
+
+const mockedFs = fs as unknown as {
+  readdir: jest.Mock;
+  stat: jest.Mock;
+  unlink: jest.Mock;
+};
 
 describe('UploadsService', () => {
   let service: UploadsService;
@@ -14,6 +35,14 @@ describe('UploadsService', () => {
   };
   const patientsRepo = {
     findOne: jest.fn(),
+  };
+  const queryRunner = {
+    connect: jest.fn().mockResolvedValue(undefined),
+    release: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn(),
+  };
+  const dataSource = {
+    createQueryRunner: jest.fn(() => queryRunner),
   };
 
   beforeEach(async () => {
@@ -26,6 +55,15 @@ describe('UploadsService', () => {
       };
       return qb;
     });
+    queryRunner.connect.mockResolvedValue(undefined);
+    queryRunner.release.mockResolvedValue(undefined);
+    queryRunner.query.mockImplementation((sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) {
+        return Promise.resolve([{ locked: true }]);
+      }
+      return Promise.resolve([]);
+    });
+    dataSource.createQueryRunner.mockReturnValue(queryRunner);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -35,6 +73,7 @@ describe('UploadsService', () => {
           useValue: documentsRepo,
         },
         { provide: getRepositoryToken(Patient), useValue: patientsRepo },
+        { provide: getDataSourceToken(), useValue: dataSource },
       ],
     }).compile();
 
@@ -199,6 +238,83 @@ describe('UploadsService', () => {
           permissions: [],
         }),
       ).resolves.toEqual(document);
+    });
+  });
+
+  describe('removeOrphanUploads', () => {
+    const NOW = new Date('2026-08-02T12:00:00Z');
+    const ORPHAN = '123e4567-e89b-42d3-a456-426614174000.pdf';
+    const LINKED = '123e4567-e89b-42d3-a456-426614174001.pdf';
+    const NOT_UUID = 'readme.txt';
+    const DOTFILE = '...env';
+
+    const statFor = (mtimeMs: number) => ({
+      isFile: () => true,
+      mtimeMs,
+    });
+    const oldEnough = NOW.getTime() - 48 * 60 * 60 * 1000; // 48h ago (TTL is 24h)
+    const tooRecent = NOW.getTime() - 60 * 60 * 1000; // 1h ago
+
+    it('removes old uploads that have no document row', async () => {
+      mockedFs.readdir.mockResolvedValue([ORPHAN, LINKED, NOT_UUID, DOTFILE]);
+      mockedFs.stat.mockResolvedValue(statFor(oldEnough));
+      let lookup = 0;
+      documentsRepo.createQueryBuilder.mockImplementation(() => ({
+        where: jest.fn().mockReturnThis(),
+        orWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockImplementation(() => {
+          lookup += 1;
+          // First UUID file = orphan; second = linked document
+          return Promise.resolve(lookup === 1 ? null : { id: 'doc-1' });
+        }),
+      }));
+
+      await service.removeOrphanUploads(NOW);
+
+      expect(mockedFs.unlink).toHaveBeenCalledTimes(1);
+      expect(mockedFs.unlink).toHaveBeenCalledWith(
+        join(process.cwd(), 'uploads', ORPHAN),
+      );
+    });
+
+    it('keeps files newer than the TTL even when unlinked', async () => {
+      mockedFs.readdir.mockResolvedValue([ORPHAN]);
+      mockedFs.stat.mockResolvedValue(statFor(tooRecent));
+
+      await service.removeOrphanUploads(NOW);
+
+      expect(mockedFs.unlink).not.toHaveBeenCalled();
+      expect(documentsRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('releases the advisory lock and query runner when uploads dir is missing', async () => {
+      mockedFs.readdir.mockRejectedValue(new Error('ENOENT'));
+
+      await expect(service.removeOrphanUploads(NOW)).resolves.toBeUndefined();
+
+      const calls = queryRunner.query.mock.calls as [string, ...unknown[]][];
+      const unlock = calls.find(([sql]) => sql.includes('pg_advisory_unlock'));
+      expect(unlock).toBeDefined();
+      expect(queryRunner.release).toHaveBeenCalled();
+    });
+
+    it('does nothing when another instance already holds the lock', async () => {
+      queryRunner.query.mockImplementation((sql: string) => {
+        if (sql.includes('pg_try_advisory_lock')) {
+          return Promise.resolve([{ locked: false }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      await service.removeOrphanUploads(NOW);
+
+      expect(mockedFs.readdir).not.toHaveBeenCalled();
+      expect(mockedFs.unlink).not.toHaveBeenCalled();
+      const unlock = (
+        queryRunner.query.mock.calls as [string, ...unknown[]][]
+      ).find(([sql]) => sql.includes('pg_advisory_unlock'));
+      expect(unlock).toBeUndefined();
+      expect(queryRunner.release).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -1,23 +1,142 @@
 import {
   ForbiddenException,
   Injectable,
+  Logger,
   NotFoundException,
+  OnApplicationBootstrap,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { basename } from 'path';
-import { Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { promises as fs } from 'fs';
+import { basename, extname, join } from 'path';
+import { DataSource, Repository } from 'typeorm';
 import { PERMISSIONS } from '@careconnect/types';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Patient, PatientDocument } from '../database/entities';
 
 @Injectable()
-export class UploadsService {
+export class UploadsService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(UploadsService.name);
+
+  /** Time an uploaded file may sit unlinked before the sweep removes it. */
+  static readonly ORPHAN_TTL_HOURS = 24;
+
+  /** Arbitrary Postgres advisory lock id for the orphan sweep. */
+  private static readonly ORPHAN_SWEEP_LOCK_KEY = 727003;
+
   constructor(
     @InjectRepository(PatientDocument)
     private readonly documentsRepo: Repository<PatientDocument>,
     @InjectRepository(Patient)
     private readonly patientsRepo: Repository<Patient>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
+
+  /**
+   * Delete uploads/ files that are older than the TTL and have never been
+   * linked to a patient_documents row (abandoned PHI uploads). Runs on
+   * application bootstrap; a Postgres advisory lock prevents concurrent
+   * sweeps when multiple instances boot together.
+   *
+   * Uses a dedicated QueryRunner so lock + unlock share one pooled connection
+   * (session advisory locks are connection-scoped).
+   */
+  async removeOrphanUploads(now: Date = new Date()): Promise<void> {
+    const runner = this.dataSource.createQueryRunner();
+    await runner.connect();
+    let locked = false;
+    try {
+      const [lockRow] = (await runner.query(
+        'SELECT pg_try_advisory_lock($1) AS locked',
+        [UploadsService.ORPHAN_SWEEP_LOCK_KEY],
+      )) as { locked: boolean | string | number }[];
+      const raw = lockRow?.locked;
+      // node-pg usually returns boolean; accept common postgres truthies too
+      locked = raw === true || raw === 't' || raw === 1;
+      if (!locked) {
+        this.logger.log(
+          'Orphan upload sweep skipped — another instance holds the lock',
+        );
+        return;
+      }
+
+      const dir = join(process.cwd(), 'uploads');
+      const cutoffMs =
+        now.getTime() - UploadsService.ORPHAN_TTL_HOURS * 60 * 60 * 1000;
+      let entries: string[];
+      try {
+        entries = await fs.readdir(dir);
+      } catch {
+        return; // uploads dir missing — nothing to do
+      }
+
+      let removed = 0;
+      for (const entry of entries) {
+        if (!this.isStoredUploadName(entry)) continue;
+        const path = join(dir, entry);
+        let stat;
+        try {
+          stat = await fs.stat(path);
+        } catch {
+          continue;
+        }
+        if (!stat.isFile() || stat.mtimeMs > cutoffMs) continue;
+
+        const linked = await this.findDocumentByFilename(entry);
+        if (linked) continue; // referenced by a document row — keep
+        try {
+          await fs.unlink(path);
+          removed++;
+        } catch (err) {
+          this.logger.warn(
+            `Failed to remove orphan upload ${entry}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+      if (removed > 0) {
+        this.logger.log(`Orphan upload sweep removed ${removed} file(s)`);
+      }
+    } finally {
+      if (locked) {
+        await runner
+          .query('SELECT pg_advisory_unlock($1)', [
+            UploadsService.ORPHAN_SWEEP_LOCK_KEY,
+          ])
+          .catch(() => undefined);
+      }
+      await runner.release().catch(() => undefined);
+    }
+  }
+
+  /** Match multer-generated names: UUID + safe extension (no dots/dirs). */
+  private isStoredUploadName(name: string): boolean {
+    if (name.includes('..') || name !== basename(name)) return false;
+    const stem = name.slice(0, name.length - extname(name).length);
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        stem,
+      )
+    ) {
+      return false;
+    }
+    const ext = extname(name);
+    return ext === '' || /^\.[A-Za-z0-9]{1,15}$/.test(ext);
+  }
+
+  /** Run the orphan sweep after the app is listening (never blocks boot). */
+  onApplicationBootstrap(): void {
+    setImmediate(() => {
+      this.removeOrphanUploads().catch((err: unknown) => {
+        this.logger.warn(
+          `Orphan upload sweep failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      });
+    });
+  }
 
   /**
    * Authorize download of a stored file by resolving it to a patient_documents

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,4 +44,11 @@ Hospital-scoped data is filtered by the authenticated user's `hospitalId` unless
 
 ## Local docs
 
-Open Apollo Sandbox / Playground at `http://localhost:4000/graphql` while the API is running.
+When `NODE_ENV` is not `production`, open Apollo Sandbox / Playground at `http://localhost:4000/graphql` while the API is running. In production the GraphQL Playground and schema introspection are disabled.
+
+## Database TLS policy
+
+- Set `DATABASE_SSL=true` to enable TLS for the Postgres connection (recommended for hosted providers such as Neon).
+- Outside production (`NODE_ENV != production`), `DATABASE_SSL=true` connects with `rejectUnauthorized: false` because local/dev environments usually lack the provider CA certificates. Do not expose such an instance publicly.
+- In production (`NODE_ENV=production`), `DATABASE_SSL=true` uses pg's default TLS settings — the server certificate chain is fully verified against the system CA store. For providers whose CA is not in the system store, set `PGSSLROOTCERT` (and related `PGSSL*` env vars) to the CA bundle instead of relaxing verification.
+- When `DATABASE_SSL` is unset or `false`, the connection is plaintext — only suitable for local databases.


### PR DESCRIPTION
## Summary
- **#68** — Disable GraphQL Playground and introspection when `NODE_ENV=production`; production `DATABASE_SSL=true` uses full TLS verification (no `rejectUnauthorized: false`). Document TLS policy in `docs/api.md`.
- **#69** — On API bootstrap, delete unlinked `uploads/` files older than 24h (UUID+ext multer names only). Uses a connection-scoped Postgres advisory lock so pooled instances do not race.

## Test plan
- [ ] `pnpm test -- uploads.service.spec.ts` in `apps/api` passes
- [ ] Non-production: Playground still available at `/graphql`
- [ ] Production config: Playground/introspection off; SSL connects with CA verification
- [ ] Fresh uploads under 24h are kept even without a document row
- [ ] Files older than 24h with no `patient_documents` row are removed on boot
- [ ] Files referenced by a document row are never removed


Made with [Cursor](https://cursor.com)