### PR TITLE
fix: rescan findings #73–#87 (locks, email uniqueness, UI RBAC)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -16,7 +16,9 @@ CLERK_ISSUER=https://REPLACE_WITH_YOUR_CLERK_FRONTEND_API
 
 # Optional — comma-separated authorized parties (azp) allowed in Clerk JWTs
 # Example: http://localhost:3000,https://your-app.example.com
+# Required in production (JWT azp allowlist). Recommended in all environments.
 # CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+CLERK_AUTHORIZED_PARTIES=http://localhost:3000
 
 CORS_ORIGIN=http://localhost:3000
 NODE_ENV=development

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -10,12 +10,21 @@ import { AppointmentsService } from './appointments.service';
 describe('AppointmentsService status machine', () => {
   let service: AppointmentsService;
 
+  const apptManager = {
+    createQueryBuilder: jest.fn(),
+    save: jest.fn(),
+  };
   const appointmentsRepo = {
     findOne: jest.fn(),
     save: jest.fn((a: Appointment) => Promise.resolve(a)),
     find: jest.fn(),
     create: jest.fn(),
     createQueryBuilder: jest.fn(),
+    manager: {
+      transaction: jest.fn((cb: (m: typeof apptManager) => unknown) =>
+        Promise.resolve(cb(apptManager)),
+      ),
+    },
   };
   const patientsRepo = { findOne: jest.fn() };
   const departmentsRepo = { findOne: jest.fn() };
@@ -37,6 +46,10 @@ describe('AppointmentsService status machine', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    appointmentsRepo.manager.transaction.mockImplementation(
+      (cb: (m: typeof apptManager) => unknown) =>
+        Promise.resolve(cb(apptManager)),
+    );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AppointmentsService,
@@ -53,8 +66,27 @@ describe('AppointmentsService status machine', () => {
     service = module.get(AppointmentsService);
   });
 
+  const mockLockedAppointment = (row: Record<string, unknown>) => {
+    const state = { ...row };
+    const qb = {
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(state),
+    };
+    apptManager.createQueryBuilder.mockReturnValue(qb);
+    apptManager.save.mockImplementation((a: typeof state) => {
+      Object.assign(state, a);
+      return Promise.resolve(state);
+    });
+    appointmentsRepo.findOne.mockImplementation(() =>
+      Promise.resolve({ ...state }),
+    );
+    return qb;
+  };
+
   it('allows scheduled → checked_in', async () => {
-    appointmentsRepo.findOne.mockResolvedValue({
+    mockLockedAppointment({
       id: 'appt-1',
       hospitalId: 'hospital-a',
       status: 'scheduled',
@@ -69,7 +101,7 @@ describe('AppointmentsService status machine', () => {
   });
 
   it('rejects completed → scheduled', async () => {
-    appointmentsRepo.findOne.mockResolvedValue({
+    mockLockedAppointment({
       id: 'appt-1',
       hospitalId: 'hospital-a',
       status: 'completed',
@@ -80,7 +112,7 @@ describe('AppointmentsService status machine', () => {
   });
 
   it('rejects cancelling a completed appointment', async () => {
-    appointmentsRepo.findOne.mockResolvedValue({
+    mockLockedAppointment({
       id: 'appt-1',
       hospitalId: 'hospital-a',
       status: 'completed',
@@ -91,7 +123,13 @@ describe('AppointmentsService status machine', () => {
   });
 
   it('throws NotFound when appointment missing', async () => {
-    appointmentsRepo.findOne.mockResolvedValue(null);
+    const qb = {
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(null),
+    };
+    apptManager.createQueryBuilder.mockReturnValue(qb);
     await expect(
       service.updateStatus('missing', 'checked_in', 'hospital-a', actor),
     ).rejects.toThrow(NotFoundException);

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -252,10 +252,24 @@ export class AppointmentsService {
       throw new BadRequestException(`Invalid appointment status: ${status}`);
     }
 
-    const appointment = await this.findAppointmentOrThrow(id, hospitalId);
-    assertTransition(appointment.status, status);
-    appointment.status = status;
-    const saved = await this.appointmentsRepo.save(appointment);
+    const appointmentId = await this.appointmentsRepo.manager.transaction(
+      async (manager) => {
+        const appointment = await manager
+          .createQueryBuilder(Appointment, 'appointment')
+          .setLock('pessimistic_write')
+          .where('appointment.id = :id', { id })
+          .andWhere('appointment.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!appointment) throw new NotFoundException('Appointment not found');
+
+        assertTransition(appointment.status, status);
+        appointment.status = status;
+        await manager.save(appointment);
+        return appointment.id;
+      },
+    );
+
+    const saved = await this.findAppointmentOrThrow(appointmentId, hospitalId);
 
     await this.audit.log({
       actorId: actor.id,
@@ -274,18 +288,31 @@ export class AppointmentsService {
     input: CancelAppointmentInput,
     actor: AuthenticatedUser,
   ): Promise<AppointmentType> {
-    const appointment = await this.findAppointmentOrThrow(input.id, hospitalId);
+    const appointmentId = await this.appointmentsRepo.manager.transaction(
+      async (manager) => {
+        const appointment = await manager
+          .createQueryBuilder(Appointment, 'appointment')
+          .setLock('pessimistic_write')
+          .where('appointment.id = :id', { id: input.id })
+          .andWhere('appointment.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!appointment) throw new NotFoundException('Appointment not found');
 
-    assertTransition(appointment.status, 'cancelled');
+        assertTransition(appointment.status, 'cancelled');
 
-    appointment.status = 'cancelled';
-    if (input.reason) {
-      appointment.notes = appointment.notes
-        ? `${appointment.notes}\nCancelled: ${input.reason}`
-        : `Cancelled: ${input.reason}`;
-    }
+        appointment.status = 'cancelled';
+        if (input.reason) {
+          appointment.notes = appointment.notes
+            ? `${appointment.notes}\nCancelled: ${input.reason}`
+            : `Cancelled: ${input.reason}`;
+        }
 
-    const saved = await this.appointmentsRepo.save(appointment);
+        await manager.save(appointment);
+        return appointment.id;
+      },
+    );
+
+    const saved = await this.findAppointmentOrThrow(appointmentId, hospitalId);
 
     await this.audit.log({
       actorId: actor.id,

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -244,5 +244,23 @@ describe('AuthService', () => {
       ).rejects.toThrow(ForbiddenException);
       expect(manager.save).not.toHaveBeenCalled();
     });
+
+    it('rejects bootstrap when actor already has roles (e.g. patient)', async () => {
+      usersRepo.findOne.mockResolvedValue({
+        id: 'user-1',
+        hospitalId: undefined,
+      });
+      hospitalsRepo.findOne.mockResolvedValue({ id: 'hospital-a' });
+
+      await expect(
+        service.completeOnboarding(
+          { ...actor, roles: ['patient'] },
+          'Patient',
+          'hospital-a',
+          true,
+        ),
+      ).rejects.toThrow(/first-time registration/);
+      expect(usersRepo.manager.transaction).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -40,14 +40,13 @@ export class AuthService {
 
     // Link invited staff who were created with a different auth_id placeholder
     if (!user && email) {
-      user = await this.usersRepo.findOne({
-        where: { email },
-        relations: [
-          'userRoles',
-          'userRoles.role',
-          'userRoles.role.permissions',
-        ],
-      });
+      user = await this.usersRepo
+        .createQueryBuilder('user')
+        .leftJoinAndSelect('user.userRoles', 'userRoles')
+        .leftJoinAndSelect('userRoles.role', 'role')
+        .leftJoinAndSelect('role.permissions', 'permissions')
+        .where('LOWER(user.email) = LOWER(:email)', { email })
+        .getOne();
       if (user) {
         // Only reclaim pending invite placeholders — never steal an active Clerk-linked account
         const isPending = user.authId.startsWith('pending_');
@@ -55,18 +54,30 @@ export class AuthService {
           await this.usersRepo.update(user.id, { authId });
           user.authId = authId;
         } else {
-          user = null;
+          // Fail closed: do not create a duplicate users row for the same email
+          throw new UnauthorizedException(
+            'An account with this email already exists. Sign in with the original identity or contact support.',
+          );
         }
       }
     }
 
     if (!user && email) {
-      user = this.usersRepo.create({
-        authId,
-        email,
-        fullName: email.split('@')[0],
-      });
-      user = await this.usersRepo.save(user);
+      try {
+        user = this.usersRepo.create({
+          authId,
+          email,
+          fullName: email.split('@')[0],
+        });
+        user = await this.usersRepo.save(user);
+      } catch (error) {
+        if (isUniqueViolation(error)) {
+          throw new UnauthorizedException(
+            'An account with this email already exists. Sign in with the original identity or contact support.',
+          );
+        }
+        throw error;
+      }
       user = await this.usersRepo.findOne({
         where: { id: user.id },
         relations: [
@@ -161,6 +172,12 @@ export class AuthService {
     // Bootstrap hospital_admin under a transaction + advisory lock so two
     // concurrent registrants cannot both observe zero admins and both win.
     if (hospitalId && assignHospitalAdmin) {
+      // Patients (and any already-roled users) must join via invite, not bootstrap
+      if (!isSuperAdmin && actor.roles.length > 0) {
+        throw new ForbiddenException(
+          'Hospital bootstrap is only available during first-time registration',
+        );
+      }
       try {
         await this.usersRepo.manager.transaction(async (manager) => {
           await manager.query(

--- a/apps/api/src/clinical/clinical.service.spec.ts
+++ b/apps/api/src/clinical/clinical.service.spec.ts
@@ -78,7 +78,8 @@ describe('ClinicalService', () => {
       (cb: (m: typeof rxManager) => unknown) => Promise.resolve(cb(rxManager)),
     );
     labOrdersRepo.manager.transaction.mockImplementation(
-      (cb: (m: typeof labManager) => unknown) => Promise.resolve(cb(labManager)),
+      (cb: (m: typeof labManager) => unknown) =>
+        Promise.resolve(cb(labManager)),
     );
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/apps/api/src/clinical/clinical.service.spec.ts
+++ b/apps/api/src/clinical/clinical.service.spec.ts
@@ -27,8 +27,15 @@ describe('ClinicalService', () => {
     create: jest.fn(),
     find: jest.fn(),
     findOne: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
   const prescriptionItemsRepo = { save: jest.fn(), create: jest.fn() };
+  const rxManager = {
+    createQueryBuilder: jest.fn(),
+    save: jest.fn(),
+  };
   const labManager = {
     createQueryBuilder: jest.fn(),
     save: jest.fn(),
@@ -67,6 +74,12 @@ describe('ClinicalService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    prescriptionsRepo.manager.transaction.mockImplementation(
+      (cb: (m: typeof rxManager) => unknown) => Promise.resolve(cb(rxManager)),
+    );
+    labOrdersRepo.manager.transaction.mockImplementation(
+      (cb: (m: typeof labManager) => unknown) => Promise.resolve(cb(labManager)),
+    );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ClinicalService,
@@ -163,10 +176,15 @@ describe('ClinicalService', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(order),
+      };
+      labManager.createQueryBuilder.mockReturnValue(qb);
+      labManager.save.mockResolvedValue(order);
       labOrdersRepo.findOne.mockResolvedValue(order);
-      labOrdersRepo.save.mockImplementation((row: typeof order) =>
-        Promise.resolve(row),
-      );
 
       const result = await service.updateLabOrderStatus(
         'hospital-a',
@@ -174,15 +192,10 @@ describe('ClinicalService', () => {
         actor,
       );
       expect(result.status).toBe('collected');
+      expect(qb.setLock).toHaveBeenCalledWith('pessimistic_write');
     });
 
     it('rejects completing via updateLabOrderStatus', async () => {
-      labOrdersRepo.findOne.mockResolvedValue({
-        id: 'lab-1',
-        hospitalId: 'hospital-a',
-        status: 'ordered',
-      });
-
       await expect(
         service.updateLabOrderStatus(
           'hospital-a',
@@ -190,6 +203,7 @@ describe('ClinicalService', () => {
           actor,
         ),
       ).rejects.toThrow('Use completeLabResult');
+      expect(labOrdersRepo.manager.transaction).not.toHaveBeenCalled();
     });
   });
 
@@ -204,9 +218,20 @@ describe('ClinicalService', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      prescriptionsRepo.findOne.mockResolvedValue(rx);
-      prescriptionsRepo.save.mockImplementation((row: typeof rx) =>
-        Promise.resolve(row),
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({ ...rx }),
+      };
+      rxManager.createQueryBuilder.mockReturnValue(qb);
+      rxManager.save.mockImplementation((row: typeof rx) => {
+        Object.assign(rx, row);
+        return Promise.resolve(rx);
+      });
+      prescriptionsRepo.findOne.mockImplementation(() =>
+        Promise.resolve({ ...rx }),
       );
 
       const result = await service.cancelPrescription(
@@ -215,15 +240,23 @@ describe('ClinicalService', () => {
         actor,
       );
       expect(result.status).toBe('cancelled');
+      expect(qb.setLock).toHaveBeenCalledWith('pessimistic_write');
     });
 
     it('rejects cancelling a dispensed prescription', async () => {
-      prescriptionsRepo.findOne.mockResolvedValue({
-        id: 'rx-1',
-        hospitalId: 'hospital-a',
-        status: 'dispensed',
-        items: [],
-      });
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          status: 'dispensed',
+          items: [],
+        }),
+      };
+      rxManager.createQueryBuilder.mockReturnValue(qb);
 
       await expect(
         service.cancelPrescription(

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -514,13 +514,6 @@ export class ClinicalService {
     input: UpdateLabOrderStatusInput,
     actor: AuthenticatedUser,
   ): Promise<LabOrderType> {
-    const order = await this.labOrdersRepo.findOne({
-      where: { id: input.labOrderId, hospitalId },
-      relations: ['patient', 'orderedBy'],
-    });
-    if (!order) throw new NotFoundException('Lab order not found');
-
-    assertLabTransition(order.status, input.status);
     // Completing requires a lab result via completeLabResult
     if (input.status === 'completed') {
       throw new BadRequestException(
@@ -528,8 +521,28 @@ export class ClinicalService {
       );
     }
 
-    order.status = input.status;
-    await this.labOrdersRepo.save(order);
+    const orderId = await this.labOrdersRepo.manager.transaction(
+      async (manager) => {
+        const order = await manager
+          .createQueryBuilder(LabOrder, 'order')
+          .setLock('pessimistic_write')
+          .where('order.id = :id', { id: input.labOrderId })
+          .andWhere('order.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!order) throw new NotFoundException('Lab order not found');
+
+        assertLabTransition(order.status, input.status);
+        order.status = input.status;
+        await manager.save(order);
+        return order.id;
+      },
+    );
+
+    const order = await this.labOrdersRepo.findOne({
+      where: { id: orderId, hospitalId },
+      relations: ['patient', 'orderedBy'],
+    });
+    if (!order) throw new NotFoundException('Lab order not found');
 
     await this.audit.log({
       actorId: actor.id,
@@ -548,15 +561,30 @@ export class ClinicalService {
     input: CancelPrescriptionInput,
     actor: AuthenticatedUser,
   ): Promise<PrescriptionType> {
+    const prescriptionId = await this.prescriptionsRepo.manager.transaction(
+      async (manager) => {
+        const prescription = await manager
+          .createQueryBuilder(Prescription, 'prescription')
+          .setLock('pessimistic_write')
+          .leftJoinAndSelect('prescription.items', 'items')
+          .where('prescription.id = :id', { id: input.prescriptionId })
+          .andWhere('prescription.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!prescription)
+          throw new NotFoundException('Prescription not found');
+
+        assertPrescriptionTransition(prescription.status, 'cancelled');
+        prescription.status = 'cancelled';
+        await manager.save(prescription);
+        return prescription.id;
+      },
+    );
+
     const prescription = await this.prescriptionsRepo.findOne({
-      where: { id: input.prescriptionId, hospitalId },
+      where: { id: prescriptionId, hospitalId },
       relations: ['items'],
     });
     if (!prescription) throw new NotFoundException('Prescription not found');
-
-    assertPrescriptionTransition(prescription.status, 'cancelled');
-    prescription.status = 'cancelled';
-    await this.prescriptionsRepo.save(prescription);
 
     await this.audit.log({
       actorId: actor.id,

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -115,6 +115,18 @@ export function validateEnv(config: Record<string, unknown>) {
     }
   }
 
+  if (config.NODE_ENV === 'production') {
+    if (
+      !config.CLERK_AUTHORIZED_PARTIES ||
+      typeof config.CLERK_AUTHORIZED_PARTIES !== 'string' ||
+      !config.CLERK_AUTHORIZED_PARTIES.trim()
+    ) {
+      throw new Error(
+        'CLERK_AUTHORIZED_PARTIES is required in production (comma-separated authorized party URLs for JWT azp checks).',
+      );
+    }
+  }
+
   if (
     config.CLERK_AUTHORIZED_PARTIES !== undefined &&
     config.CLERK_AUTHORIZED_PARTIES !== ''

--- a/apps/api/src/facility/facility.service.spec.ts
+++ b/apps/api/src/facility/facility.service.spec.ts
@@ -9,11 +9,20 @@ import { FacilityService } from './facility.service';
 describe('FacilityService', () => {
   let service: FacilityService;
 
+  const bedManager = {
+    createQueryBuilder: jest.fn(),
+    save: jest.fn(),
+  };
   const departmentsRepo = {};
   const wardsRepo = {};
   const bedsRepo = {
     findOne: jest.fn(),
     save: jest.fn(),
+    manager: {
+      transaction: jest.fn((cb: (m: typeof bedManager) => unknown) =>
+        Promise.resolve(cb(bedManager)),
+      ),
+    },
   };
   const audit = { log: jest.fn() };
 
@@ -30,6 +39,9 @@ describe('FacilityService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    bedsRepo.manager.transaction.mockImplementation(
+      (cb: (m: typeof bedManager) => unknown) => Promise.resolve(cb(bedManager)),
+    );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FacilityService,
@@ -43,7 +55,7 @@ describe('FacilityService', () => {
   });
 
   describe('updateBedStatus', () => {
-    it('sets available bed to maintenance', async () => {
+    it('sets available bed to maintenance under a row lock', async () => {
       const bed = {
         id: 'bed-1',
         hospitalId: 'hospital-a',
@@ -52,10 +64,15 @@ describe('FacilityService', () => {
         status: 'available',
         createdAt: new Date(),
       };
-      bedsRepo.findOne.mockResolvedValue(bed);
-      bedsRepo.save.mockImplementation((row: typeof bed) =>
-        Promise.resolve(row),
-      );
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({ ...bed }),
+      };
+      bedManager.createQueryBuilder.mockReturnValue(qb);
+      bedManager.save.mockResolvedValue(bed);
+      bedsRepo.findOne.mockResolvedValue({ ...bed, status: 'maintenance' });
 
       const result = await service.updateBedStatus(
         'hospital-a',
@@ -63,14 +80,21 @@ describe('FacilityService', () => {
         actor,
       );
       expect(result.status).toBe('maintenance');
+      expect(qb.setLock).toHaveBeenCalledWith('pessimistic_write');
     });
 
     it('rejects changing an occupied bed', async () => {
-      bedsRepo.findOne.mockResolvedValue({
-        id: 'bed-1',
-        hospitalId: 'hospital-a',
-        status: 'occupied',
-      });
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'bed-1',
+          hospitalId: 'hospital-a',
+          status: 'occupied',
+        }),
+      };
+      bedManager.createQueryBuilder.mockReturnValue(qb);
 
       await expect(
         service.updateBedStatus(

--- a/apps/api/src/facility/facility.service.spec.ts
+++ b/apps/api/src/facility/facility.service.spec.ts
@@ -40,7 +40,8 @@ describe('FacilityService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     bedsRepo.manager.transaction.mockImplementation(
-      (cb: (m: typeof bedManager) => unknown) => Promise.resolve(cb(bedManager)),
+      (cb: (m: typeof bedManager) => unknown) =>
+        Promise.resolve(cb(bedManager)),
     );
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/apps/api/src/facility/facility.service.ts
+++ b/apps/api/src/facility/facility.service.ts
@@ -290,14 +290,25 @@ export class FacilityService {
     input: UpdateBedStatusInput,
     actor: AuthenticatedUser,
   ): Promise<BedType> {
+    const bedId = await this.bedsRepo.manager.transaction(async (manager) => {
+      const bed = await manager
+        .createQueryBuilder(Bed, 'bed')
+        .setLock('pessimistic_write')
+        .where('bed.id = :id', { id: input.bedId })
+        .andWhere('bed.hospital_id = :hospitalId', { hospitalId })
+        .getOne();
+      if (!bed) throw new NotFoundException('Bed not found');
+
+      assertManualBedTransition(bed.status, input.status);
+      bed.status = input.status;
+      await manager.save(bed);
+      return bed.id;
+    });
+
     const bed = await this.bedsRepo.findOne({
-      where: { id: input.bedId, hospitalId },
+      where: { id: bedId, hospitalId },
     });
     if (!bed) throw new NotFoundException('Bed not found');
-
-    assertManualBedTransition(bed.status, input.status);
-    bed.status = input.status;
-    await this.bedsRepo.save(bed);
 
     await this.audit.log({
       actorId: actor.id,

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -126,16 +126,31 @@ export class PatientsService {
     page: number;
     limit: number;
   }> {
-    const where = search
-      ? [
-          { hospitalId, fullName: ILike(`%${search}%`) },
-          { hospitalId, email: ILike(`%${search}%`) },
-          { hospitalId, phone: ILike(`%${search}%`) },
-        ]
-      : { hospitalId };
+    if (search) {
+      const literal = search.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+      const pattern = `%${literal}%`;
+      const qb = this.patientsRepo
+        .createQueryBuilder('patient')
+        .where('patient.hospital_id = :hospitalId', { hospitalId })
+        .andWhere(
+          `(patient.full_name ILIKE :pattern ESCAPE '\\' OR patient.email ILIKE :pattern ESCAPE '\\' OR patient.phone ILIKE :pattern ESCAPE '\\')`,
+          { pattern },
+        )
+        .orderBy('patient.created_at', 'DESC')
+        .skip((page - 1) * limit)
+        .take(limit);
+
+      const [patients, total] = await qb.getManyAndCount();
+      return {
+        items: patients.map((p) => this.toPatientType(p)),
+        total,
+        page,
+        limit,
+      };
+    }
 
     const [patients, total] = await this.patientsRepo.findAndCount({
-      where,
+      where: { hospitalId },
       order: { createdAt: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,

--- a/apps/web/src/app/(dashboard)/appointments/page.tsx
+++ b/apps/web/src/app/(dashboard)/appointments/page.tsx
@@ -37,9 +37,11 @@ const statusVariant = (status: string) => {
 
 export default function AppointmentsPage() {
   const [selectedDate, setSelectedDate] = useState(todayDateString());
+  const [statusError, setStatusError] = useState('');
   const { data: meData } = useQuery(ME_QUERY);
   const me = meData?.me;
   const hospitalId = me?.hospitalId;
+  const canWriteAppointments = (me?.permissions ?? []).includes('appointments:write');
   const isDoctorOnly =
     Array.isArray(me?.roles) &&
     me.roles.includes('doctor') &&
@@ -66,13 +68,18 @@ export default function AppointmentsPage() {
   const appointments = data?.appointments ?? [];
 
   const handleStatus = async (id: string, status: string) => {
-    if (status === 'cancelled') {
-      await cancelAppointment({
-        variables: { input: { id }, hospitalId },
-      });
-      return;
+    setStatusError('');
+    try {
+      if (status === 'cancelled') {
+        await cancelAppointment({
+          variables: { input: { id }, hospitalId },
+        });
+        return;
+      }
+      await updateStatus({ variables: { id, status, hospitalId } });
+    } catch (err) {
+      setStatusError(err instanceof Error ? err.message : 'Failed to update appointment status');
     }
-    await updateStatus({ variables: { id, status, hospitalId } });
   };
 
   return (
@@ -96,13 +103,19 @@ export default function AppointmentsPage() {
             className="rounded-2xl border border-white/60 bg-clay-surface px-3 py-2 shadow-clay-inset"
           />
         </label>
-        <Link href="/appointments/new">
-          <ClayButton>
-            <Plus className="h-4 w-4" />
-            New Appointment
-          </ClayButton>
-        </Link>
+        {canWriteAppointments ? (
+          <Link href="/appointments/new">
+            <ClayButton>
+              <Plus className="h-4 w-4" />
+              New Appointment
+            </ClayButton>
+          </Link>
+        ) : null}
       </div>
+
+      {statusError ? (
+        <p className="mb-4 rounded-2xl bg-red-50 px-4 py-2 text-sm text-clay-error">{statusError}</p>
+      ) : null}
 
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
@@ -111,9 +124,11 @@ export default function AppointmentsPage() {
           <div className="px-6 py-12 text-center">
             <Calendar className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />
             <p className="text-clay-text-muted">No appointments scheduled for today.</p>
-            <Link href="/appointments/new" className="mt-3 inline-block text-sm text-clay-primary hover:underline">
-              Schedule one now
-            </Link>
+            {canWriteAppointments ? (
+              <Link href="/appointments/new" className="mt-3 inline-block text-sm text-clay-primary hover:underline">
+                Schedule one now
+              </Link>
+            ) : null}
           </div>
         ) : (
           <div className="divide-y divide-white/30">
@@ -145,7 +160,7 @@ export default function AppointmentsPage() {
                   <ClayBadge variant={statusVariant(appt.status)}>
                     {appt.status.replace(/_/g, ' ')}
                   </ClayBadge>
-                  {appt.status === 'scheduled' ? (
+                  {canWriteAppointments && appt.status === 'scheduled' ? (
                     <div className="flex gap-2">
                       <ClayButton
                         size="sm"
@@ -163,7 +178,7 @@ export default function AppointmentsPage() {
                       </ClayButton>
                     </div>
                   ) : null}
-                  {appt.status === 'checked_in' ? (
+                  {canWriteAppointments && appt.status === 'checked_in' ? (
                     <ClayButton size="sm" onClick={() => handleStatus(appt.id, 'completed')}>
                       Complete
                     </ClayButton>

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -13,6 +13,29 @@ import {
   PATIENTS_QUERY,
   STAFF_MEMBERS_QUERY,
 } from '@/lib/graphql/queries';
+import { canAccessRoute } from '@/lib/route-access';
+
+const QUICK_ACTIONS = [
+  { label: 'Register Patient', href: '/patients/new', anyPermissions: ['patients:write'] },
+  { label: 'Bulk Import Patients', href: '/patients/import', anyPermissions: ['patients:write'] },
+  { label: 'New Appointment', href: '/appointments/new', anyPermissions: ['appointments:write'] },
+  { label: 'View Appointments', href: '/appointments' },
+  { label: 'Admit Patient', href: '/admissions' },
+  { label: 'Add Staff Member', href: '/staff/new', anyPermissions: ['staff:write'] },
+  { label: 'View Staff Directory', href: '/staff' },
+  { label: 'Lab Queue', href: '/lab' },
+] as const;
+
+function canSeeQuickAction(
+  action: (typeof QUICK_ACTIONS)[number],
+  access: { roles: string[]; permissions: string[] },
+): boolean {
+  if (!canAccessRoute(action.href, access)) return false;
+  if ('anyPermissions' in action && action.anyPermissions) {
+    return action.anyPermissions.some((perm) => access.permissions.includes(perm));
+  }
+  return true;
+}
 
 function todayDateString() {
   return new Date().toISOString().slice(0, 10);
@@ -76,6 +99,12 @@ export default function DashboardPage() {
 
   const hasAppointments = typeof appointmentsToday === 'number' && appointmentsToday > 0;
 
+  const access = {
+    roles: me?.roles ?? [],
+    permissions: me?.permissions ?? [],
+  };
+  const visibleQuickActions = QUICK_ACTIONS.filter((action) => canSeeQuickAction(action, access));
+
   return (
     <div>
       <DashboardHeader
@@ -102,16 +131,7 @@ export default function DashboardPage() {
         <ClayCard>
           <h2 className="mb-4 text-lg font-semibold text-clay-text">Quick Actions</h2>
           <div className="grid gap-3 sm:grid-cols-2">
-            {[
-              { label: 'Register Patient', href: '/patients/new' },
-              { label: 'Bulk Import Patients', href: '/patients/import' },
-              { label: 'New Appointment', href: '/appointments/new' },
-              { label: 'View Appointments', href: '/appointments' },
-              { label: 'Admit Patient', href: '/admissions' },
-              { label: 'Add Staff Member', href: '/staff/new' },
-              { label: 'View Staff Directory', href: '/staff' },
-              { label: 'Lab Queue', href: '/lab' },
-            ].map((action) => (
+            {visibleQuickActions.map((action) => (
               <Link
                 key={action.label}
                 href={action.href}

--- a/apps/web/src/app/(dashboard)/doctor/page.tsx
+++ b/apps/web/src/app/(dashboard)/doctor/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useQuery } from '@apollo/client';
-import { Calendar, Clock, FileText, Pill, FlaskConical, Users } from 'lucide-react';
+import { Calendar, Clock, FileText, FlaskConical, Users } from 'lucide-react';
 import { ClayBadge, ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { APPOINTMENTS_QUERY, ME_QUERY } from '@/lib/graphql/queries';
@@ -37,7 +37,6 @@ export default function DoctorDashboardPage() {
     { label: 'Patients', href: '/patients', icon: Users },
     { label: 'Admissions', href: '/admissions', icon: FileText },
     { label: 'Order Lab', href: '/lab', icon: FlaskConical },
-    { label: 'Pharmacy Queue', href: '/pharmacy', icon: Pill },
   ];
 
   return (

--- a/apps/web/src/app/(dashboard)/finance/invoices/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/invoices/[id]/page.tsx
@@ -32,6 +32,7 @@ export default function InvoiceDetailPage() {
   });
 
   const invoice = data?.invoice;
+  const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
 
   if (loading) return <p className="text-clay-text-muted">Loading invoice...</p>;
   if (!invoice) return <p className="text-clay-error">Invoice not found</p>;
@@ -59,7 +60,7 @@ export default function InvoiceDetailPage() {
           <div className="flex items-center justify-between">
             <ClayBadge>{invoice.status}</ClayBadge>
             <div className="flex items-center gap-3">
-              {invoice.status !== 'void' && invoice.status !== 'paid' ? (
+              {canWriteBilling && invoice.status !== 'void' && invoice.status !== 'paid' ? (
                 <ClayButton
                   size="sm"
                   variant="ghost"
@@ -114,7 +115,7 @@ export default function InvoiceDetailPage() {
               </div>
             ),
           )}
-          {balance > 0 && invoice.status !== 'void' ? (
+          {canWriteBilling && balance > 0 && invoice.status !== 'void' ? (
             <form
               className="space-y-3 border-t border-white/40 pt-4"
               onSubmit={(e) => {

--- a/apps/web/src/app/(dashboard)/finance/invoices/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/invoices/page.tsx
@@ -30,6 +30,7 @@ export default function InvoicesPage() {
   });
 
   const invoices = data?.invoices ?? [];
+  const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
 
   return (
     <div>
@@ -38,14 +39,16 @@ export default function InvoicesPage() {
         subtitle="All billing invoices for your hospital"
       />
 
-      <div className="mb-6 flex justify-end">
-        <Link href="/finance/invoices/new">
-          <ClayButton>
-            <Plus className="mr-2 h-4 w-4" />
-            New Invoice
-          </ClayButton>
-        </Link>
-      </div>
+      {canWriteBilling ? (
+        <div className="mb-6 flex justify-end">
+          <Link href="/finance/invoices/new">
+            <ClayButton>
+              <Plus className="mr-2 h-4 w-4" />
+              New Invoice
+            </ClayButton>
+          </Link>
+        </div>
+      ) : null}
 
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
@@ -54,9 +57,11 @@ export default function InvoicesPage() {
           <div className="px-6 py-12 text-center">
             <FileText className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />
             <p className="text-clay-text-muted">No invoices yet.</p>
-            <Link href="/finance/invoices/new" className="mt-4 inline-block">
-              <ClayButton size="sm">Create First Invoice</ClayButton>
-            </Link>
+            {canWriteBilling ? (
+              <Link href="/finance/invoices/new" className="mt-4 inline-block">
+                <ClayButton size="sm">Create First Invoice</ClayButton>
+              </Link>
+            ) : null}
           </div>
         ) : (
           <div className="divide-y divide-white/30">

--- a/apps/web/src/app/(dashboard)/finance/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/page.tsx
@@ -28,6 +28,7 @@ export default function FinancePage() {
   ).length;
   const paid = invoices.filter((inv: { status: string }) => inv.status === 'paid').length;
   const revenueTotal = reportsData?.hospitalReports?.revenueTotal ?? 0;
+  const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
 
   return (
     <div>
@@ -36,14 +37,16 @@ export default function FinancePage() {
         subtitle="Billing overview and invoice management"
       />
 
-      <div className="mb-6 flex justify-end">
-        <Link href="/finance/invoices/new">
-          <ClayButton>
-            <Plus className="mr-2 h-4 w-4" />
-            New Invoice
-          </ClayButton>
-        </Link>
-      </div>
+      {canWriteBilling ? (
+        <div className="mb-6 flex justify-end">
+          <Link href="/finance/invoices/new">
+            <ClayButton>
+              <Plus className="mr-2 h-4 w-4" />
+              New Invoice
+            </ClayButton>
+          </Link>
+        </div>
+      ) : null}
 
       <div className="mb-8 grid gap-6 md:grid-cols-3">
         <ClayStatCard
@@ -60,7 +63,9 @@ export default function FinancePage() {
         <div className="grid gap-3 sm:grid-cols-2">
           {[
             { label: 'View All Invoices', href: '/finance/invoices' },
-            { label: 'Create Invoice', href: '/finance/invoices/new' },
+            ...(canWriteBilling
+              ? [{ label: 'Create Invoice', href: '/finance/invoices/new' }]
+              : []),
             { label: 'Reports Hub', href: '/reports' },
           ].map((action) => (
             <Link

--- a/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
@@ -58,6 +58,7 @@ export default function PatientDetailPage() {
   });
 
   const patient = data?.patient;
+  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
 
   const apiBase = (
     process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql'
@@ -160,55 +161,61 @@ export default function PatientDetailPage() {
             <ClayButton size="sm">Discharge</ClayButton>
           </Link>
         ) : null}
-        <select
-          aria-label="Update patient status"
-          className="rounded-2xl border border-white/60 bg-clay-surface px-3 py-2 text-sm shadow-clay-inset"
-          value={patient.status}
-          onChange={(e) =>
-            updateStatus({
-              variables: { id, status: e.target.value, hospitalId: meData?.me?.hospitalId },
-            })
-          }
-        >
-          {['registered', 'checked_in', 'admitted', 'discharged', 'inactive'].map((s) => (
-            <option key={s} value={s}>
-              {s.replace(/_/g, ' ')}
-            </option>
-          ))}
-        </select>
-        <ClayButton
-          size="sm"
-          variant="ghost"
-          onClick={() => {
-            const email =
-              window.prompt(
-                'Portal user email to link (defaults to patient email)',
-                patient.email ?? '',
-              ) ?? '';
-            linkAccount({
-              variables: {
-                patientId: id,
-                hospitalId: meData?.me?.hospitalId,
-                email: email || undefined,
-              },
-            });
-          }}
-        >
-          Link portal account
-        </ClayButton>
-        <ClayButton
-          size="sm"
-          variant="ghost"
-          onClick={async () => {
-            if (!confirm('Soft-delete this patient?')) return;
-            await deletePatient({
-              variables: { id, hospitalId: meData?.me?.hospitalId },
-            });
-            window.location.href = '/patients';
-          }}
-        >
-          Delete
-        </ClayButton>
+        {canWritePatients ? (
+          <select
+            aria-label="Update patient status"
+            className="rounded-2xl border border-white/60 bg-clay-surface px-3 py-2 text-sm shadow-clay-inset"
+            value={patient.status}
+            onChange={(e) =>
+              updateStatus({
+                variables: { id, status: e.target.value, hospitalId: meData?.me?.hospitalId },
+              })
+            }
+          >
+            {['registered', 'checked_in', 'admitted', 'discharged', 'inactive'].map((s) => (
+              <option key={s} value={s}>
+                {s.replace(/_/g, ' ')}
+              </option>
+            ))}
+          </select>
+        ) : null}
+        {canWritePatients ? (
+          <ClayButton
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              const email =
+                window.prompt(
+                  'Portal user email to link (defaults to patient email)',
+                  patient.email ?? '',
+                ) ?? '';
+              linkAccount({
+                variables: {
+                  patientId: id,
+                  hospitalId: meData?.me?.hospitalId,
+                  email: email || undefined,
+                },
+              });
+            }}
+          >
+            Link portal account
+          </ClayButton>
+        ) : null}
+        {canWritePatients ? (
+          <ClayButton
+            size="sm"
+            variant="ghost"
+            onClick={async () => {
+              if (!confirm('Soft-delete this patient?')) return;
+              await deletePatient({
+                variables: { id, hospitalId: meData?.me?.hospitalId },
+              });
+              window.location.href = '/patients';
+            }}
+          >
+            Delete
+          </ClayButton>
+        ) : null}
       </div>
 
       <div className="grid gap-6 lg:grid-cols-3">
@@ -283,29 +290,31 @@ export default function PatientDetailPage() {
         <ClayCard className="lg:col-span-3">
           <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
             <h2 className="text-lg font-semibold text-clay-text">Documents</h2>
-            <div className="flex flex-wrap items-center gap-3">
-              <select
-                value={documentType}
-                onChange={(e) => setDocumentType(e.target.value)}
-                className="rounded-2xl border border-white/60 bg-clay-surface px-4 py-2 text-sm text-clay-text shadow-clay-inset outline-none"
-              >
-                {DOCUMENT_TYPES.map((type) => (
-                  <option key={type.value} value={type.value}>
-                    {type.label}
-                  </option>
-                ))}
-              </select>
-              <label className="inline-flex cursor-pointer items-center gap-2 rounded-2xl bg-clay-surface px-4 py-2 text-sm font-medium text-clay-primary shadow-clay-sm hover:shadow-clay">
-                <Upload className="h-4 w-4" />
-                {uploading ? 'Uploading...' : 'Upload'}
-                <input
-                  type="file"
-                  className="hidden"
-                  disabled={uploading}
-                  onChange={(e) => e.target.files?.[0] && handleUpload(e.target.files[0])}
-                />
-              </label>
-            </div>
+            {canWritePatients ? (
+              <div className="flex flex-wrap items-center gap-3">
+                <select
+                  value={documentType}
+                  onChange={(e) => setDocumentType(e.target.value)}
+                  className="rounded-2xl border border-white/60 bg-clay-surface px-4 py-2 text-sm text-clay-text shadow-clay-inset outline-none"
+                >
+                  {DOCUMENT_TYPES.map((type) => (
+                    <option key={type.value} value={type.value}>
+                      {type.label}
+                    </option>
+                  ))}
+                </select>
+                <label className="inline-flex cursor-pointer items-center gap-2 rounded-2xl bg-clay-surface px-4 py-2 text-sm font-medium text-clay-primary shadow-clay-sm hover:shadow-clay">
+                  <Upload className="h-4 w-4" />
+                  {uploading ? 'Uploading...' : 'Upload'}
+                  <input
+                    type="file"
+                    className="hidden"
+                    disabled={uploading}
+                    onChange={(e) => e.target.files?.[0] && handleUpload(e.target.files[0])}
+                  />
+                </label>
+              </div>
+            ) : null}
           </div>
           {uploadError ? <p className="mb-4 text-sm text-clay-error">{uploadError}</p> : null}
           {patient.documents?.length ? (
@@ -323,21 +332,23 @@ export default function PatientDetailPage() {
                     <FileText className="h-5 w-5 shrink-0 text-clay-primary" />
                     <span className="truncate text-sm text-clay-text">{d.name}</span>
                   </button>
-                  <ClayButton
-                    size="sm"
-                    variant="ghost"
-                    onClick={() =>
-                      deleteDocument({
-                        variables: {
-                          id: d.id,
-                          patientId: id,
-                          hospitalId: meData?.me?.hospitalId,
-                        },
-                      })
-                    }
-                  >
-                    Delete
-                  </ClayButton>
+                  {canWritePatients ? (
+                    <ClayButton
+                      size="sm"
+                      variant="ghost"
+                      onClick={() =>
+                        deleteDocument({
+                          variables: {
+                            id: d.id,
+                            patientId: id,
+                            hospitalId: meData?.me?.hospitalId,
+                          },
+                        })
+                      }
+                    >
+                      Delete
+                    </ClayButton>
+                  ) : null}
                 </div>
               ))}
             </div>

--- a/apps/web/src/app/(dashboard)/patients/import/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/import/page.tsx
@@ -19,6 +19,7 @@ export default function ImportPatientsPage() {
     errors: { row: number; message: string }[];
     dryRun: boolean;
   } | null>(null);
+  const [importError, setImportError] = useState('');
   const { data: meData } = useQuery(ME_QUERY);
   const [importPatients, { loading }] = useMutation(IMPORT_PATIENTS_MUTATION);
 
@@ -29,16 +30,21 @@ export default function ImportPatientsPage() {
   };
 
   const runImport = async (dryRun: boolean) => {
-    const { data } = await importPatients({
-      variables: {
-        rows: preview,
-        dryRun,
-        hospitalId: meData?.me?.hospitalId,
-      },
-    });
-    setResult(data.importPatients);
-    if (!dryRun && data.importPatients.errorCount === 0) {
-      router.push('/patients');
+    setImportError('');
+    try {
+      const { data } = await importPatients({
+        variables: {
+          rows: preview,
+          dryRun,
+          hospitalId: meData?.me?.hospitalId,
+        },
+      });
+      setResult(data.importPatients);
+      if (!dryRun && data.importPatients.errorCount === 0) {
+        router.push('/patients');
+      }
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : 'Import failed');
     }
   };
 
@@ -105,6 +111,9 @@ export default function ImportPatientsPage() {
                   Import Patients
                 </ClayButton>
               </div>
+              {importError ? (
+                <p className="mt-4 text-sm text-clay-error">{importError}</p>
+              ) : null}
             </>
           )}
 

--- a/apps/web/src/app/(dashboard)/patients/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/page.tsx
@@ -24,6 +24,7 @@ export default function PatientsPage() {
 
   const patients = data?.patients?.items ?? [];
   const total = data?.patients?.total ?? 0;
+  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
 
   return (
     <div>
@@ -40,20 +41,22 @@ export default function PatientsPage() {
             className="w-full rounded-2xl border border-white/60 bg-clay-surface py-3 pl-11 pr-4 shadow-clay-inset outline-none focus:ring-2 focus:ring-clay-primary/30"
           />
         </div>
-        <div className="flex gap-3">
-          <Link href="/patients/import">
-            <ClayButton variant="secondary">
-              <Upload className="h-4 w-4" />
-              Bulk Import
-            </ClayButton>
-          </Link>
-          <Link href="/patients/new">
-            <ClayButton>
-              <Plus className="h-4 w-4" />
-              Add Patient
-            </ClayButton>
-          </Link>
-        </div>
+        {canWritePatients ? (
+          <div className="flex gap-3">
+            <Link href="/patients/import">
+              <ClayButton variant="secondary">
+                <Upload className="h-4 w-4" />
+                Bulk Import
+              </ClayButton>
+            </Link>
+            <Link href="/patients/new">
+              <ClayButton>
+                <Plus className="h-4 w-4" />
+                Add Patient
+              </ClayButton>
+            </Link>
+          </div>
+        ) : null}
       </div>
 
       <ClayCard padding="none" className="overflow-hidden">
@@ -75,8 +78,15 @@ export default function PatientsPage() {
             ) : patients.length === 0 ? (
               <tr>
                 <td colSpan={5} className="px-6 py-8 text-center text-clay-text-muted">
-                  No patients found.{' '}
-                  <Link href="/patients/new" className="text-clay-primary hover:underline">Register your first patient</Link>
+                  No patients found.
+                  {canWritePatients ? (
+                    <>
+                      {' '}
+                      <Link href="/patients/new" className="text-clay-primary hover:underline">
+                        Register your first patient
+                      </Link>
+                    </>
+                  ) : null}
                 </td>
               </tr>
             ) : (

--- a/apps/web/src/app/(dashboard)/staff/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/staff/new/page.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery } from '@apollo/client';
 import type { StaffInput } from '@careconnect/types';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { StaffForm } from '@/components/staff/staff-form';
 import { CREATE_STAFF_MUTATION, ME_QUERY } from '@/lib/graphql/queries';
 
@@ -16,6 +17,8 @@ export default function NewStaffPage() {
   const [copied, setCopied] = useState(false);
   const { data: meData } = useQuery(ME_QUERY);
   const [createStaff, { loading }] = useMutation(CREATE_STAFF_MUTATION);
+
+  const canWriteStaff = (meData?.me?.permissions ?? []).includes('staff:write');
 
   const handleSubmit = async (input: StaffInput) => {
     setError('');
@@ -44,6 +47,16 @@ export default function NewStaffPage() {
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
+
+  if (!meData?.me) {
+    return null;
+  }
+
+  if (!canWriteStaff) {
+    return (
+      <ForbiddenAccess message="You do not have permission to add staff members." />
+    );
+  }
 
   if (inviteUrl) {
     return (

--- a/apps/web/src/app/(dashboard)/staff/page.tsx
+++ b/apps/web/src/app/(dashboard)/staff/page.tsx
@@ -28,6 +28,12 @@ export default function StaffPage() {
   });
 
   const staff = data?.staffMembers ?? [];
+  const permissions = meData?.me?.permissions ?? [];
+  const roles = meData?.me?.roles ?? [];
+  const canWriteStaff = permissions.includes('staff:write');
+  const canDeactivateStaff =
+    canWriteStaff &&
+    (roles.includes('hospital_admin') || roles.includes('super_admin'));
 
   const handleDelete = async (id: string, name: string) => {
     if (!confirm(`Deactivate ${name}?`)) return;
@@ -43,12 +49,14 @@ export default function StaffPage() {
       <DashboardHeader title="Staff Management" subtitle="Manage your hospital team" />
 
       <div className="mb-6 flex justify-end">
-        <Link href="/staff/new">
-          <ClayButton>
-            <Plus className="h-4 w-4" />
-            Add Staff
-          </ClayButton>
-        </Link>
+        {canWriteStaff ? (
+          <Link href="/staff/new">
+            <ClayButton>
+              <Plus className="h-4 w-4" />
+              Add Staff
+            </ClayButton>
+          </Link>
+        ) : null}
       </div>
 
       <ClayCard padding="none" className="overflow-hidden">
@@ -75,10 +83,15 @@ export default function StaffPage() {
             ) : staff.length === 0 ? (
               <tr>
                 <td colSpan={8} className="px-6 py-8 text-center text-clay-text-muted">
-                  No staff members yet.{' '}
-                  <Link href="/staff/new" className="text-clay-primary hover:underline">
-                    Add your first team member
-                  </Link>
+                  No staff members yet.
+                  {canWriteStaff ? (
+                    <>
+                      {' '}
+                      <Link href="/staff/new" className="text-clay-primary hover:underline">
+                        Add your first team member
+                      </Link>
+                    </>
+                  ) : null}
                 </td>
               </tr>
             ) : (
@@ -111,29 +124,33 @@ export default function StaffPage() {
                     </ClayBadge>
                   </td>
                   <td className="px-6 py-4">
-                    <div className="flex justify-end gap-2">
-                      <Link href={`/staff/${member.id}/edit`}>
-                        <button className="flex h-8 w-8 items-center justify-center rounded-xl bg-clay-primary-light text-clay-primary hover:shadow-clay-sm">
-                          <Pencil className="h-4 w-4" />
-                        </button>
-                      </Link>
-                      {member.isActive ? (
-                        <button
-                          onClick={() => handleDelete(member.id, member.fullName)}
-                          className="flex h-8 w-8 items-center justify-center rounded-xl bg-red-50 text-clay-error hover:shadow-clay-sm"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      ) : (
-                        <button
-                          onClick={() => handleReactivate(member.id)}
-                          title="Reactivate"
-                          className="flex h-8 w-8 items-center justify-center rounded-xl bg-clay-primary-light text-clay-primary hover:shadow-clay-sm"
-                        >
-                          <RotateCcw className="h-4 w-4" />
-                        </button>
-                      )}
-                    </div>
+                    {canWriteStaff ? (
+                      <div className="flex justify-end gap-2">
+                        <Link href={`/staff/${member.id}/edit`}>
+                          <button className="flex h-8 w-8 items-center justify-center rounded-xl bg-clay-primary-light text-clay-primary hover:shadow-clay-sm">
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                        </Link>
+                        {member.isActive ? (
+                          canDeactivateStaff ? (
+                            <button
+                              onClick={() => handleDelete(member.id, member.fullName)}
+                              className="flex h-8 w-8 items-center justify-center rounded-xl bg-red-50 text-clay-error hover:shadow-clay-sm"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          ) : null
+                        ) : (
+                          <button
+                            onClick={() => handleReactivate(member.id)}
+                            title="Reactivate"
+                            className="flex h-8 w-8 items-center justify-center rounded-xl bg-clay-primary-light text-clay-primary hover:shadow-clay-sm"
+                          >
+                            <RotateCcw className="h-4 w-4" />
+                          </button>
+                        )}
+                      </div>
+                    ) : null}
                   </td>
                 </tr>
               ))

--- a/apps/web/src/app/(portal)/portal-layout-client.tsx
+++ b/apps/web/src/app/(portal)/portal-layout-client.tsx
@@ -5,13 +5,14 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import { useUser } from '@clerk/nextjs';
 import { COMPLETE_PATIENT_ONBOARDING, ME_QUERY } from '@/lib/graphql/queries';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { PortalSidebar } from '@/components/layout/portal-sidebar';
 
 export function PortalLayoutClient({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user } = useUser();
-  const { data, loading, refetch } = useQuery(ME_QUERY);
+  const { data, loading, error, refetch } = useQuery(ME_QUERY, { errorPolicy: 'all' });
   const [completePatientOnboarding] = useMutation(COMPLETE_PATIENT_ONBOARDING);
   const ran = useRef(false);
   const me = data?.me;
@@ -57,6 +58,17 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
     return (
       <div className="flex min-h-screen items-center justify-center bg-clay-bg text-clay-text-muted">
         Loading portal…
+      </div>
+    );
+  }
+
+  if (error && !me) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-clay-bg p-6">
+        <ForbiddenAccess
+          title="Unable to load portal"
+          message="We could not verify your account. Please sign in again or contact support."
+        />
       </div>
     );
   }

--- a/apps/web/src/components/auth/register-form.tsx
+++ b/apps/web/src/components/auth/register-form.tsx
@@ -40,8 +40,13 @@ export function RegisterForm() {
     if (type === 'patient') {
       try {
         await completePatientOnboarding({ variables: { fullName } });
-      } catch {
-        // User row may still be syncing; portal will surface errors if role missing
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to complete patient registration. Please try again or contact support.',
+        );
+        return;
       }
       router.push('/portal');
     } else {

--- a/apps/web/src/components/clinical/patient-clinical-actions.tsx
+++ b/apps/web/src/components/clinical/patient-clinical-actions.tsx
@@ -25,6 +25,7 @@ import {
   CREATE_LAB_ORDER_MUTATION,
   CREATE_PRESCRIPTION_MUTATION,
   CREATE_VITAL_SIGN_MUTATION,
+  ME_QUERY,
   STAFF_MEMBERS_QUERY,
   WARDS_QUERY,
 } from '@/lib/graphql/queries';
@@ -59,6 +60,25 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
   const [error, setError] = useState('');
   const [admitWardId, setAdmitWardId] = useState('');
   const [admitBedId, setAdmitBedId] = useState('');
+
+  const { data: meData } = useQuery(ME_QUERY);
+  const permissions = meData?.me?.permissions ?? [];
+  const canWritePatients = permissions.includes('patients:write');
+  const canWriteAppointments = permissions.includes('appointments:write');
+  const canWriteLabs =
+    permissions.includes('lab:write') || permissions.includes('patients:write');
+
+  const actionPermissions: Record<ActionKey, boolean> = {
+    appointment: canWriteAppointments,
+    admit: canWritePatients,
+    vitals: canWritePatients,
+    soap: canWritePatients,
+    diagnosis: canWritePatients,
+    prescription: canWritePatients,
+    lab: canWriteLabs,
+  };
+
+  const visibleActions = actions.filter(({ key }) => actionPermissions[key]);
 
   const [createAppointment, { loading: appointmentLoading }] = useMutation(CREATE_APPOINTMENT_MUTATION);
   const [admitPatient, { loading: admitLoading }] = useMutation(ADMIT_PATIENT_MUTATION);
@@ -271,6 +291,8 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
     rxLoading ||
     labLoading;
 
+  if (visibleActions.length === 0) return null;
+
   return (
     <ClayCard className="lg:col-span-3">
       <h2 className="mb-4 text-lg font-semibold text-clay-text">Clinical Actions</h2>
@@ -285,7 +307,7 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
       ) : null}
 
       <div className="space-y-3">
-        {actions.map(({ key, label, icon: Icon }) => (
+        {visibleActions.map(({ key, label, icon: Icon }) => (
           <div key={key} className="rounded-2xl bg-clay-primary-light/20">
             <button
               type="button"

--- a/apps/web/src/lib/route-access.ts
+++ b/apps/web/src/lib/route-access.ts
@@ -58,14 +58,19 @@ const SORTED_RULES = [...ROUTE_RULES].sort(
   (a, b) => b.prefix.length - a.prefix.length,
 );
 
+/** Routes any authenticated non-patient staff may open without a specific rule */
+const STAFF_PUBLIC_ROUTES = ['/dashboard'];
+
 export function canAccessRoute(pathname: string, ctx: AccessContext): boolean {
   if (ctx.roles.includes('super_admin')) return true;
   if (ctx.roles.includes('patient')) return false;
 
+  if (STAFF_PUBLIC_ROUTES.some((route) => pathname === route)) return true;
+
   const rule = SORTED_RULES.find(
     (r) => pathname === r.prefix || pathname.startsWith(`${r.prefix}/`),
   );
-  if (!rule) return true;
+  if (!rule) return false;
 
   if (rule.anyRoles?.some((role) => ctx.roles.includes(role))) return true;
   if (rule.anyPermissions?.some((perm) => ctx.permissions.includes(perm))) {

--- a/supabase/migrations/20240609000018_users_email_unique_lower.sql
+++ b/supabase/migrations/20240609000018_users_email_unique_lower.sql
@@ -1,0 +1,32 @@
+-- Enforce one canonical app user per email (case-insensitive).
+-- Keep the earliest row per LOWER(email); null out conflicting FKs on losers
+-- only where safe — duplicate emails should be rare after prior auth fixes.
+
+-- Prefer the row that already has a real (non-pending) Clerk auth_id, else oldest.
+WITH ranked AS (
+  SELECT
+    id,
+    LOWER(email) AS email_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY LOWER(email)
+      ORDER BY
+        CASE WHEN auth_id LIKE 'pending_%' THEN 1 ELSE 0 END ASC,
+        created_at ASC,
+        id ASC
+    ) AS rn
+  FROM users
+  WHERE deleted_at IS NULL
+),
+dupes AS (
+  SELECT id FROM ranked WHERE rn > 1
+)
+UPDATE users u
+SET
+  email = u.email || '+dup-' || LEFT(u.id::text, 8),
+  updated_at = NOW()
+FROM dupes d
+WHERE u.id = d.id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_users_email_lower
+  ON users (LOWER(email))
+  WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Summary
Rescan after P0–P2 (#49–#69) found **15 confirmed issues** (#73–#87). This PR fixes all of them without changing working happy-path flows (API remains the authority; UI now mirrors permissions).

### High
- **#73 / #85** — Unique `LOWER(users.email)`; login sync fails closed on collisions; patients/already-roled users cannot bootstrap `hospitalId`
- **#74 / #75** — Pessimistic locks on `cancelPrescription` and `updateLabOrderStatus`
- **#76 / #77** — Gate patient chart + appointment write UI on write permissions; surface appointment errors

### Medium
- **#78 / #79** — Lock bed status + appointment status/cancel
- **#80** — Escape LIKE wildcards in patient search (`ESCAPE '\'`)
- **#81** — Require `CLERK_AUTHORIZED_PARTIES` in production
- **#82 / #83** — Gate staff/finance/patients list write CTAs; filter dashboard quick actions; remove doctor→pharmacy dead link
- **#84 / #86** — Portal fail-closed on `me` error; signup onboarding errors; bulk import error handling

### Low
- **#87** — `canAccessRoute` allowlists `/dashboard` and fails closed on unmatched paths

## Test plan
- [ ] `pnpm test` in `apps/api` for clinical/facility/appointments/auth specs
- [ ] Lab tech: patient chart is read-only (no clinical write CTAs)
- [ ] Nurse: appointments list has no Check In/Cancel without `appointments:write`
- [ ] Pharmacist: finance invoices visible but no Void/Pay without `billing:write`
- [ ] Hospital manager: staff list has no Add without `staff:write`
- [ ] Patient signup failure stays on form (no silent `/portal` redirect)
- [ ] Production boot without `CLERK_AUTHORIZED_PARTIES` fails validation
- [ ] Apply migration `20240609000018_users_email_unique_lower.sql`


Made with [Cursor](https://cursor.com)