### PR TITLE
fix: rescan findings #89–#99 (invite reactivate, transactions, UI gates)

### DIFF
--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -160,31 +160,40 @@ export class BillingService {
       0,
     );
 
-    const invoice = await this.invoicesRepo.save(
-      this.invoicesRepo.create({
-        hospitalId,
-        patientId: input.patientId,
-        admissionId: input.admissionId,
-        status,
-        totalAmount: totalAmount.toFixed(2),
-        issuedAt: status === 'issued' ? new Date() : undefined,
-      }),
+    const invoiceId = await this.invoicesRepo.manager.transaction(
+      async (manager) => {
+        const invoice = await manager.save(
+          manager.create(Invoice, {
+            hospitalId,
+            patientId: input.patientId,
+            admissionId: input.admissionId,
+            status,
+            totalAmount: totalAmount.toFixed(2),
+            issuedAt: status === 'issued' ? new Date() : undefined,
+          }),
+        );
+
+        await manager.save(
+          input.items.map((item) =>
+            manager.create(InvoiceItem, {
+              invoiceId: invoice.id,
+              description: item.description,
+              quantity: item.quantity.toFixed(2),
+              unitPrice: item.unitPrice.toFixed(2),
+              amount: (item.quantity * item.unitPrice).toFixed(2),
+            }),
+          ),
+        );
+
+        return invoice.id;
+      },
     );
 
-    const items = await this.invoiceItemsRepo.save(
-      input.items.map((item) =>
-        this.invoiceItemsRepo.create({
-          invoiceId: invoice.id,
-          description: item.description,
-          quantity: item.quantity.toFixed(2),
-          unitPrice: item.unitPrice.toFixed(2),
-          amount: (item.quantity * item.unitPrice).toFixed(2),
-        }),
-      ),
-    );
-
-    invoice.items = items;
-    invoice.payments = [];
+    const invoice = await this.invoicesRepo.findOne({
+      where: { id: invoiceId, hospitalId },
+      relations: ['items', 'payments', 'patient'],
+    });
+    if (!invoice) throw new NotFoundException('Invoice not found');
 
     await this.audit.log({
       actorId: actor.id,

--- a/apps/api/src/billing/billing.types.ts
+++ b/apps/api/src/billing/billing.types.ts
@@ -1,6 +1,8 @@
 import { Field, Float, ID, InputType, ObjectType } from '@nestjs/graphql';
 import {
   IsArray,
+  ArrayMaxSize,
+  ArrayMinSize,
   IsIn,
   IsNumber,
   IsOptional,
@@ -129,6 +131,8 @@ export class CreateInvoiceInput {
 
   @Field(() => [CreateInvoiceItemInput])
   @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(100)
   @ValidateNested({ each: true })
   @Type(() => CreateInvoiceItemInput)
   items: CreateInvoiceItemInput[];

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -378,34 +378,48 @@ export class ClinicalService {
     input: CreatePrescriptionInput,
     actor: AuthenticatedUser,
   ): Promise<PrescriptionType> {
+    if (!input.items?.length) {
+      throw new BadRequestException('Prescription must have at least one item');
+    }
+
     await this.assertPatient(hospitalId, input.patientId);
     await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
-    const prescription = await this.prescriptionsRepo.save(
-      this.prescriptionsRepo.create({
-        hospitalId,
-        patientId: input.patientId,
-        admissionId: input.admissionId,
-        doctorId: actor.id,
-        notes: input.notes,
-        status: 'pending',
-      }),
+    const prescriptionId = await this.prescriptionsRepo.manager.transaction(
+      async (manager) => {
+        const prescription = await manager.save(
+          manager.create(Prescription, {
+            hospitalId,
+            patientId: input.patientId,
+            admissionId: input.admissionId,
+            doctorId: actor.id,
+            notes: input.notes,
+            status: 'pending',
+          }),
+        );
+
+        await manager.save(
+          input.items.map((item) =>
+            manager.create(PrescriptionItem, {
+              prescriptionId: prescription.id,
+              drugName: item.drugName,
+              dosage: item.dosage,
+              frequency: item.frequency,
+              duration: item.duration,
+              instructions: item.instructions,
+            }),
+          ),
+        );
+
+        return prescription.id;
+      },
     );
 
-    const items = await this.prescriptionItemsRepo.save(
-      input.items.map((item) =>
-        this.prescriptionItemsRepo.create({
-          prescriptionId: prescription.id,
-          drugName: item.drugName,
-          dosage: item.dosage,
-          frequency: item.frequency,
-          duration: item.duration,
-          instructions: item.instructions,
-        }),
-      ),
-    );
-
-    prescription.items = items;
+    const prescription = await this.prescriptionsRepo.findOne({
+      where: { id: prescriptionId, hospitalId },
+      relations: ['items'],
+    });
+    if (!prescription) throw new NotFoundException('Prescription not found');
 
     await this.audit.log({
       actorId: actor.id,
@@ -413,7 +427,10 @@ export class ClinicalService {
       action: 'create',
       resource: 'prescription',
       resourceId: prescription.id,
-      metadata: { patientId: prescription.patientId, itemCount: items.length },
+      metadata: {
+        patientId: prescription.patientId,
+        itemCount: prescription.items?.length ?? 0,
+      },
     });
 
     return this.toPrescriptionType(prescription);

--- a/apps/api/src/clinical/clinical.types.ts
+++ b/apps/api/src/clinical/clinical.types.ts
@@ -1,6 +1,8 @@
 import { Field, Float, ID, InputType, Int, ObjectType } from '@nestjs/graphql';
 import {
   IsArray,
+  ArrayMaxSize,
+  ArrayMinSize,
   IsBoolean,
   IsIn,
   IsInt,
@@ -397,6 +399,8 @@ export class CreatePrescriptionInput {
 
   @Field(() => [PrescriptionItemInput])
   @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(50)
   @ValidateNested({ each: true })
   @Type(() => PrescriptionItemInput)
   items: PrescriptionItemInput[];

--- a/apps/api/src/discharge/discharge.service.spec.ts
+++ b/apps/api/src/discharge/discharge.service.spec.ts
@@ -30,7 +30,21 @@ describe('DischargeService', () => {
     save: jest.fn(),
     create: jest.fn(),
   };
-  const followUpsRepo = { save: jest.fn(), create: jest.fn(), find: jest.fn() };
+  const followManager = {
+    createQueryBuilder: jest.fn(),
+    save: jest.fn(),
+  };
+  const followUpsRepo = {
+    save: jest.fn(),
+    create: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    manager: {
+      transaction: jest.fn((cb: (m: typeof followManager) => unknown) =>
+        Promise.resolve(cb(followManager)),
+      ),
+    },
+  };
   const patientsRepo = { findOne: jest.fn(), save: jest.fn() };
   const audit = { log: jest.fn() };
   const doctorValidator = {
@@ -50,6 +64,10 @@ describe('DischargeService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    followUpsRepo.manager.transaction.mockImplementation(
+      (cb: (m: typeof followManager) => unknown) =>
+        Promise.resolve(cb(followManager)),
+    );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DischargeService,
@@ -88,6 +106,60 @@ describe('DischargeService', () => {
       ).rejects.toThrow(
         'A discharge summary already exists for this admission',
       );
+    });
+  });
+
+  describe('updateFollowUpStatus', () => {
+    it('advances scheduled → completed under a row lock', async () => {
+      const row = {
+        id: 'fu-1',
+        hospitalId: 'hospital-a',
+        status: 'scheduled',
+      };
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(row),
+      };
+      followManager.createQueryBuilder.mockReturnValue(qb);
+      followManager.save.mockImplementation((r: typeof row) => {
+        Object.assign(row, r);
+        return Promise.resolve(row);
+      });
+      followUpsRepo.findOne.mockImplementation(() =>
+        Promise.resolve({ ...row, patient: null, doctor: null }),
+      );
+
+      const result = await service.updateFollowUpStatus(
+        'hospital-a',
+        { id: 'fu-1', status: 'completed' },
+        actor,
+      );
+      expect(result.status).toBe('completed');
+      expect(qb.setLock).toHaveBeenCalledWith('pessimistic_write');
+    });
+
+    it('rejects completed → scheduled', async () => {
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'fu-1',
+          hospitalId: 'hospital-a',
+          status: 'completed',
+        }),
+      };
+      followManager.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.updateFollowUpStatus(
+          'hospital-a',
+          { id: 'fu-1', status: 'scheduled' },
+          actor,
+        ),
+      ).rejects.toThrow(/Cannot transition follow-up/);
     });
   });
 });

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -31,6 +31,27 @@ function isUniqueViolation(error: unknown): boolean {
   );
 }
 
+/**
+ * Follow-up status machine:
+ *   scheduled → completed | missed
+ * Terminal: completed, missed (immutable)
+ */
+const FOLLOW_UP_TRANSITIONS: Record<string, readonly string[]> = {
+  scheduled: ['completed', 'missed'],
+  completed: [],
+  missed: [],
+};
+
+function assertFollowUpTransition(from: string, to: string) {
+  if (from === to) return;
+  const allowed = FOLLOW_UP_TRANSITIONS[from] ?? [];
+  if (!allowed.includes(to)) {
+    throw new BadRequestException(
+      `Cannot transition follow-up from "${from}" to "${to}"`,
+    );
+  }
+}
+
 @Injectable()
 export class DischargeService {
   constructor(
@@ -140,9 +161,12 @@ export class DischargeService {
               patient.status = 'discharged';
               await manager.save(patient);
             }
-          } else if (admission.status !== 'discharged') {
+          } else if (
+            admission.status !== 'discharged' &&
+            admission.status !== 'transferred'
+          ) {
             throw new BadRequestException(
-              'Only active or already-discharged admissions can receive a discharge summary',
+              'Only active, transferred, or already-discharged admissions can receive a discharge summary',
             );
           }
 
@@ -270,18 +294,31 @@ export class DischargeService {
     input: UpdateFollowUpStatusInput,
     actor: AuthenticatedUser,
   ): Promise<FollowUpType> {
-    const followUp = await this.followUpsRepo.findOne({
-      where: { id: input.id, hospitalId },
+    const followUpId = await this.followUpsRepo.manager.transaction(
+      async (manager) => {
+        const followUp = await manager
+          .createQueryBuilder(FollowUp, 'followUp')
+          .setLock('pessimistic_write')
+          .where('followUp.id = :id', { id: input.id })
+          .andWhere('followUp.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!followUp) throw new NotFoundException('Follow-up not found');
+
+        assertFollowUpTransition(followUp.status, input.status);
+        followUp.status = input.status;
+        if (input.notes !== undefined) {
+          followUp.notes = input.notes;
+        }
+        await manager.save(followUp);
+        return followUp.id;
+      },
+    );
+
+    const saved = await this.followUpsRepo.findOne({
+      where: { id: followUpId, hospitalId },
       relations: ['patient', 'doctor'],
     });
-    if (!followUp) throw new NotFoundException('Follow-up not found');
-
-    followUp.status = input.status;
-    if (input.notes !== undefined) {
-      followUp.notes = input.notes;
-    }
-
-    const saved = await this.followUpsRepo.save(followUp);
+    if (!saved) throw new NotFoundException('Follow-up not found');
 
     await this.audit.log({
       actorId: actor.id,

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -9,7 +9,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { existsSync, unlinkSync } from 'fs';
 import { basename, join } from 'path';
-import { ILike, Repository } from 'typeorm';
+import { ILike, EntityManager, Repository } from 'typeorm';
 import {
   Patient,
   PatientAllergy,
@@ -126,6 +126,8 @@ export class PatientsService {
     page: number;
     limit: number;
   }> {
+    const safePage = Math.max(1, Math.floor(page) || 1);
+    const safeLimit = Math.min(100, Math.max(1, Math.floor(limit) || 20));
     if (search) {
       const literal = search.replace(/[\\%_]/g, (ch) => `\\${ch}`);
       const pattern = `%${literal}%`;
@@ -137,30 +139,30 @@ export class PatientsService {
           { pattern },
         )
         .orderBy('patient.created_at', 'DESC')
-        .skip((page - 1) * limit)
-        .take(limit);
+        .skip((safePage - 1) * safeLimit)
+        .take(safeLimit);
 
       const [patients, total] = await qb.getManyAndCount();
       return {
         items: patients.map((p) => this.toPatientType(p)),
         total,
-        page,
-        limit,
+        page: safePage,
+        limit: safeLimit,
       };
     }
 
     const [patients, total] = await this.patientsRepo.findAndCount({
       where: { hospitalId },
       order: { createdAt: 'DESC' },
-      skip: (page - 1) * limit,
-      take: limit,
+      skip: (safePage - 1) * safeLimit,
+      take: safeLimit,
     });
 
     return {
       items: patients.map((p) => this.toPatientType(p)),
       total,
-      page,
-      limit,
+      page: safePage,
+      limit: safeLimit,
     };
   }
 
@@ -291,28 +293,35 @@ export class PatientsService {
       identificationNumber: input.identificationNumber,
     });
 
-    const patient = await this.patientsRepo.save(
-      this.patientsRepo.create({
-        hospitalId,
-        fullName: input.fullName,
-        email: input.email || undefined,
-        phone: input.phone,
-        dateOfBirth: input.dateOfBirth,
-        gender: input.gender,
-        bloodGroup: input.bloodGroup,
-        address: input.address,
-        city: input.city,
-        state: input.state,
-        zipCode: input.zipCode,
-        country: input.country,
-        occupation: input.occupation,
-        identificationType: input.identificationType,
-        identificationNumber: input.identificationNumber,
-        primaryCarePhysician: input.primaryCarePhysician,
-      }),
+    const patientId = await this.patientsRepo.manager.transaction(
+      async (manager) => {
+        const patient = await manager.save(
+          manager.create(Patient, {
+            hospitalId,
+            fullName: input.fullName,
+            email: input.email || undefined,
+            phone: input.phone,
+            dateOfBirth: input.dateOfBirth,
+            gender: input.gender,
+            bloodGroup: input.bloodGroup,
+            address: input.address,
+            city: input.city,
+            state: input.state,
+            zipCode: input.zipCode,
+            country: input.country,
+            occupation: input.occupation,
+            identificationType: input.identificationType,
+            identificationNumber: input.identificationNumber,
+            primaryCarePhysician: input.primaryCarePhysician,
+          }),
+        );
+
+        await this.saveRelatedRecords(patient.id, input, manager);
+        return patient.id;
+      },
     );
 
-    await this.saveRelatedRecords(patient.id, input);
+    const patient = await this.findPatientOrThrow(patientId, hospitalId);
 
     await this.audit.log({
       actorId: actor.id,
@@ -373,8 +382,13 @@ export class PatientsService {
         input.primaryCarePhysician ?? patient.primaryCarePhysician,
     });
 
-    const saved = await this.patientsRepo.save(patient);
-    await this.replaceRelatedRecords(saved.id, input);
+    const saved = await this.patientsRepo.manager.transaction(
+      async (manager) => {
+        const row = await manager.save(patient);
+        await this.replaceRelatedRecords(row.id, input, manager);
+        return row;
+      },
+    );
 
     await this.audit.log({
       actorId: actor.id,
@@ -596,11 +610,31 @@ export class PatientsService {
   private async saveRelatedRecords(
     patientId: string,
     input: PatientRelatedInput,
+    manager?: EntityManager,
   ) {
+    const emergencyRepo = manager
+      ? manager.getRepository(PatientEmergencyContact)
+      : this.emergencyRepo;
+    const insuranceRepo = manager
+      ? manager.getRepository(PatientInsurance)
+      : this.insuranceRepo;
+    const allergiesRepo = manager
+      ? manager.getRepository(PatientAllergy)
+      : this.allergiesRepo;
+    const medicationsRepo = manager
+      ? manager.getRepository(PatientMedication)
+      : this.medicationsRepo;
+    const historyRepo = manager
+      ? manager.getRepository(PatientMedicalHistory)
+      : this.historyRepo;
+    const consentsRepo = manager
+      ? manager.getRepository(PatientConsent)
+      : this.consentsRepo;
+
     if (input.emergencyContacts?.length) {
-      await this.emergencyRepo.save(
+      await emergencyRepo.save(
         input.emergencyContacts.map((c) =>
-          this.emergencyRepo.create({ patientId, ...c }),
+          emergencyRepo.create({ patientId, ...c }),
         ),
       );
     }
@@ -609,8 +643,8 @@ export class PatientsService {
       input.insurance &&
       (input.insurance.provider || input.insurance.policyNumber)
     ) {
-      await this.insuranceRepo.save(
-        this.insuranceRepo.create({
+      await insuranceRepo.save(
+        insuranceRepo.create({
           patientId,
           provider: input.insurance.provider,
           policyNumber: input.insurance.policyNumber,
@@ -620,33 +654,31 @@ export class PatientsService {
     }
 
     if (input.allergies?.length) {
-      await this.allergiesRepo.save(
-        input.allergies.map((a) =>
-          this.allergiesRepo.create({ patientId, ...a }),
-        ),
+      await allergiesRepo.save(
+        input.allergies.map((a) => allergiesRepo.create({ patientId, ...a })),
       );
     }
 
     if (input.medications?.length) {
-      await this.medicationsRepo.save(
+      await medicationsRepo.save(
         input.medications.map((m) =>
-          this.medicationsRepo.create({ patientId, ...m }),
+          medicationsRepo.create({ patientId, ...m }),
         ),
       );
     }
 
     if (input.medicalHistory?.length) {
-      await this.historyRepo.save(
+      await historyRepo.save(
         input.medicalHistory.map((h) =>
-          this.historyRepo.create({ patientId, ...h }),
+          historyRepo.create({ patientId, ...h }),
         ),
       );
     }
 
     if (input.consents?.length) {
-      await this.consentsRepo.save(
+      await consentsRepo.save(
         input.consents.map((c) =>
-          this.consentsRepo.create({
+          consentsRepo.create({
             patientId,
             consentType: c.consentType,
             granted: c.granted,
@@ -660,27 +692,47 @@ export class PatientsService {
   private async replaceRelatedRecords(
     patientId: string,
     input: UpdatePatientInput,
+    manager?: EntityManager,
   ) {
+    const emergencyRepo = manager
+      ? manager.getRepository(PatientEmergencyContact)
+      : this.emergencyRepo;
+    const insuranceRepo = manager
+      ? manager.getRepository(PatientInsurance)
+      : this.insuranceRepo;
+    const allergiesRepo = manager
+      ? manager.getRepository(PatientAllergy)
+      : this.allergiesRepo;
+    const medicationsRepo = manager
+      ? manager.getRepository(PatientMedication)
+      : this.medicationsRepo;
+    const historyRepo = manager
+      ? manager.getRepository(PatientMedicalHistory)
+      : this.historyRepo;
+    const consentsRepo = manager
+      ? manager.getRepository(PatientConsent)
+      : this.consentsRepo;
+
     if (input.emergencyContacts !== undefined) {
-      await this.emergencyRepo.delete({ patientId });
+      await emergencyRepo.delete({ patientId });
       if (input.emergencyContacts.length) {
-        await this.emergencyRepo.save(
+        await emergencyRepo.save(
           input.emergencyContacts.map((c) =>
-            this.emergencyRepo.create({ patientId, ...c }),
+            emergencyRepo.create({ patientId, ...c }),
           ),
         );
       }
     }
 
     if (input.insurance !== undefined) {
-      await this.insuranceRepo.delete({ patientId });
+      await insuranceRepo.delete({ patientId });
       if (
         input.insurance.provider ||
         input.insurance.policyNumber ||
         input.insurance.groupNumber
       ) {
-        await this.insuranceRepo.save(
-          this.insuranceRepo.create({
+        await insuranceRepo.save(
+          insuranceRepo.create({
             patientId,
             provider: input.insurance.provider,
             policyNumber: input.insurance.policyNumber,
@@ -691,44 +743,42 @@ export class PatientsService {
     }
 
     if (input.allergies !== undefined) {
-      await this.allergiesRepo.delete({ patientId });
+      await allergiesRepo.delete({ patientId });
       if (input.allergies.length) {
-        await this.allergiesRepo.save(
-          input.allergies.map((a) =>
-            this.allergiesRepo.create({ patientId, ...a }),
-          ),
+        await allergiesRepo.save(
+          input.allergies.map((a) => allergiesRepo.create({ patientId, ...a })),
         );
       }
     }
 
     if (input.medications !== undefined) {
-      await this.medicationsRepo.delete({ patientId });
+      await medicationsRepo.delete({ patientId });
       if (input.medications.length) {
-        await this.medicationsRepo.save(
+        await medicationsRepo.save(
           input.medications.map((m) =>
-            this.medicationsRepo.create({ patientId, ...m }),
+            medicationsRepo.create({ patientId, ...m }),
           ),
         );
       }
     }
 
     if (input.medicalHistory !== undefined) {
-      await this.historyRepo.delete({ patientId });
+      await historyRepo.delete({ patientId });
       if (input.medicalHistory.length) {
-        await this.historyRepo.save(
+        await historyRepo.save(
           input.medicalHistory.map((h) =>
-            this.historyRepo.create({ patientId, ...h }),
+            historyRepo.create({ patientId, ...h }),
           ),
         );
       }
     }
 
     if (input.consents !== undefined) {
-      await this.consentsRepo.delete({ patientId });
+      await consentsRepo.delete({ patientId });
       if (input.consents.length) {
-        await this.consentsRepo.save(
+        await consentsRepo.save(
           input.consents.map((c) =>
-            this.consentsRepo.create({
+            consentsRepo.create({
               patientId,
               consentType: c.consentType,
               granted: c.granted,
@@ -746,6 +796,11 @@ export class PatientsService {
     userId: string,
     dryRun = false,
   ) {
+    if (rows.length > 500) {
+      throw new BadRequestException(
+        'Bulk import is limited to 500 rows per request',
+      );
+    }
     const actor = { id: userId } as AuthenticatedUser;
     const errors: { row: number; message: string }[] = [];
     let successCount = 0;

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -43,10 +43,22 @@ describe('StaffService', () => {
     save: jest.fn(),
     create: jest.fn(),
     findOne: jest.fn(),
+    createQueryBuilder: jest.fn(() => {
+      const qb = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+      return qb;
+    }),
   };
   const clerkAdmin = {
     isConfigured: jest.fn().mockReturnValue(false),
     inviteStaffByEmail: jest.fn(),
+    deactivateUser: jest.fn(),
+    reactivateUser: jest.fn(),
   };
   const audit = { log: jest.fn() };
 
@@ -152,6 +164,57 @@ describe('StaffService', () => {
 
       expect(userRolesRepo.save).not.toHaveBeenCalled();
       expect(staffRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('acceptInvite — deactivated staff', () => {
+    it('rejects invite acceptance when staff profile is inactive', async () => {
+      invitesRepo.findOne.mockResolvedValue({
+        token: 'tok',
+        email: 'doc@example.com',
+        hospitalId: 'hospital-a',
+        staffProfileId: 'staff-1',
+        acceptedAt: null,
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      staffRepo.findOne.mockResolvedValue({
+        id: 'staff-1',
+        userId: 'user-1',
+        hospitalId: 'hospital-a',
+        isActive: false,
+        user: { email: 'doc@example.com', isActive: false },
+      });
+
+      await expect(
+        service.acceptInvite('tok', 'auth-new', 'doc@example.com'),
+      ).rejects.toThrow(ForbiddenException);
+      expect(usersRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove — invalidate invites', () => {
+    it('expires outstanding invites when staff is deactivated', async () => {
+      staffRepo.findOne.mockResolvedValue({
+        id: 'staff-1',
+        userId: 'user-1',
+        hospitalId: 'hospital-a',
+        isActive: true,
+        user: { email: 'doc@example.com', userRoles: [] },
+      });
+      staffRepo.save.mockImplementation((row: { isActive: boolean }) =>
+        Promise.resolve(row),
+      );
+      usersRepo.findOne.mockResolvedValue({
+        id: 'user-1',
+        authId: 'pending_abc',
+      });
+
+      await service.remove('staff-1', hospitalAdmin);
+
+      expect(invitesRepo.createQueryBuilder).toHaveBeenCalled();
+      expect(usersRepo.update).toHaveBeenCalledWith('user-1', {
+        isActive: false,
+      });
     });
   });
 });

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -244,6 +244,7 @@ export class StaffService {
     const saved = await this.staffRepo.save(staff);
     if (input.isActive === false) {
       await this.usersRepo.update(staff.userId, { isActive: false });
+      await this.invalidateOutstandingInvites(saved);
       await this.syncClerkActiveState(staff.userId, false);
     } else if (input.isActive === true) {
       await this.usersRepo.update(staff.userId, { isActive: true });
@@ -268,6 +269,7 @@ export class StaffService {
     staff.isActive = false;
     await this.staffRepo.save(staff);
     await this.usersRepo.update(staff.userId, { isActive: false });
+    await this.invalidateOutstandingInvites(staff);
     await this.syncClerkActiveState(staff.userId, false);
 
     await this.audit.log({
@@ -279,6 +281,30 @@ export class StaffService {
     });
 
     return true;
+  }
+
+  /** Expire unaccepted invites so deactivated staff cannot self-reactivate. */
+  private async invalidateOutstandingInvites(staff: StaffProfile) {
+    const now = new Date();
+    await this.invitesRepo
+      .createQueryBuilder()
+      .update(StaffInvite)
+      .set({ expiresAt: now })
+      .where('staff_profile_id = :staffId', { staffId: staff.id })
+      .andWhere('accepted_at IS NULL')
+      .execute();
+    if (staff.user?.email) {
+      await this.invitesRepo
+        .createQueryBuilder()
+        .update(StaffInvite)
+        .set({ expiresAt: now })
+        .where('LOWER(email) = LOWER(:email)', { email: staff.user.email })
+        .andWhere('hospital_id = :hospitalId', {
+          hospitalId: staff.hospitalId,
+        })
+        .andWhere('accepted_at IS NULL')
+        .execute();
+    }
   }
 
   private async syncClerkActiveState(userId: string, active: boolean) {
@@ -312,10 +338,20 @@ export class StaffService {
       ? await this.findById(invite.staffProfileId)
       : null;
     if (!staff) throw new NotFoundException('Staff profile missing for invite');
+    if (!staff.isActive) {
+      throw new ForbiddenException(
+        'This staff account has been deactivated; contact a hospital administrator',
+      );
+    }
 
     const invitee = await this.usersRepo.findOne({
       where: { id: staff.userId },
     });
+    if (invitee && invitee.isActive === false) {
+      throw new ForbiddenException(
+        'This account has been deactivated; contact a hospital administrator',
+      );
+    }
     if (invitee?.hospitalId && invitee.hospitalId !== invite.hospitalId) {
       throw new BadRequestException(
         'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',

--- a/apps/web/src/app/(dashboard)/admissions/page.tsx
+++ b/apps/web/src/app/(dashboard)/admissions/page.tsx
@@ -29,6 +29,7 @@ export default function AdmissionsPage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
 
   const { data, loading, refetch } = useQuery(ACTIVE_ADMISSIONS_QUERY, {
     variables: { hospitalId },
@@ -115,10 +116,12 @@ export default function AdmissionsPage() {
             Bed Occupancy
           </ClayButton>
         </Link>
+        {canWritePatients ? (
         <ClayButton onClick={() => setShowForm(!showForm)}>
           <Plus className="h-4 w-4" />
           {showForm ? 'Hide Form' : 'Admit Patient'}
         </ClayButton>
+        ) : null}
       </div>
 
       {showForm ? (
@@ -280,6 +283,7 @@ export default function AdmissionsPage() {
                       <ClayBadge variant="success">{adm.status}</ClayBadge>
                     </td>
                     <td className="px-6 py-4 text-right">
+                      {canWritePatients ? (
                       <ClayButton
                         size="sm"
                         variant="secondary"
@@ -290,6 +294,7 @@ export default function AdmissionsPage() {
                       >
                         Discharge
                       </ClayButton>
+                      ) : null}
                     </td>
                   </tr>
                 ),

--- a/apps/web/src/app/(dashboard)/appointments/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/appointments/new/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
 import { ClayTextarea } from '@/components/clinical/clay-textarea';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import {
   CREATE_APPOINTMENT_MUTATION,
@@ -40,6 +41,8 @@ function NewAppointmentForm() {
 
   const [createAppointment, { loading }] = useMutation(CREATE_APPOINTMENT_MUTATION);
 
+  const canWriteAppointments = (meData?.me?.permissions ?? []).includes('appointments:write');
+
   const doctors =
     staffData?.staffMembers?.filter(
       (s: { roleSlug: string; isActive: boolean }) =>
@@ -74,6 +77,16 @@ function NewAppointmentForm() {
       setError(err instanceof Error ? err.message : 'Failed to create appointment');
     }
   };
+
+  if (!meData?.me) {
+    return null;
+  }
+
+  if (!canWriteAppointments) {
+    return (
+      <ForbiddenAccess message="You do not have permission to create appointments." />
+    );
+  }
 
   return (
     <div>

--- a/apps/web/src/app/(dashboard)/doctor/page.tsx
+++ b/apps/web/src/app/(dashboard)/doctor/page.tsx
@@ -20,6 +20,7 @@ export default function DoctorDashboardPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
   const doctorId = meData?.me?.id;
+  const canWriteAppointments = (meData?.me?.permissions ?? []).includes('appointments:write');
 
   const { data, loading } = useQuery(APPOINTMENTS_QUERY, {
     variables: { hospitalId, date: today, doctorId },
@@ -33,7 +34,9 @@ export default function DoctorDashboardPage() {
 
   const quickLinks = [
     { label: 'All Appointments', href: '/appointments', icon: Calendar },
-    { label: 'New Appointment', href: '/appointments/new', icon: Calendar },
+    ...(canWriteAppointments
+      ? [{ label: 'New Appointment', href: '/appointments/new', icon: Calendar }]
+      : []),
     { label: 'Patients', href: '/patients', icon: Users },
     { label: 'Admissions', href: '/admissions', icon: FileText },
     { label: 'Order Lab', href: '/lab', icon: FlaskConical },

--- a/apps/web/src/app/(dashboard)/finance/invoices/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/invoices/new/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import {
   CREATE_INVOICE_MUTATION,
@@ -29,6 +30,7 @@ export default function NewInvoicePage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
 
   const { data: patientsData } = useQuery(PATIENTS_QUERY, {
     variables: { search: patientSearch, limit: 8, hospitalId },
@@ -91,6 +93,16 @@ export default function NewInvoicePage() {
       setError(err instanceof Error ? err.message : 'Failed to create invoice');
     }
   };
+
+  if (!meData?.me) {
+    return null;
+  }
+
+  if (!canWriteBilling) {
+    return (
+      <ForbiddenAccess message="You do not have permission to create invoices." />
+    );
+  }
 
   return (
     <div>

--- a/apps/web/src/app/(dashboard)/follow-ups/page.tsx
+++ b/apps/web/src/app/(dashboard)/follow-ups/page.tsx
@@ -39,6 +39,7 @@ const statusVariant = (status: string) => {
 export default function FollowUpsPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
   const [showForm, setShowForm] = useState(false);
   const [patientSearch, setPatientSearch] = useState('');
   const [patientId, setPatientId] = useState('');
@@ -73,7 +74,12 @@ export default function FollowUpsPage() {
   const followUps = data?.followUps ?? [];
 
   const handleStatus = async (id: string, status: string) => {
-    await updateStatus({ variables: { hospitalId, input: { id, status } } });
+    setError('');
+    try {
+      await updateStatus({ variables: { hospitalId, input: { id, status } } });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update follow-up status');
+    }
   };
 
   const handleCreate = async (e: React.FormEvent) => {
@@ -103,11 +109,17 @@ export default function FollowUpsPage() {
       />
 
       <div className="mb-6 flex justify-end">
+        {canWritePatients ? (
         <ClayButton onClick={() => setShowForm((v) => !v)}>
           <Plus className="mr-2 h-4 w-4" />
           {showForm ? 'Hide form' : 'Schedule follow-up'}
         </ClayButton>
+        ) : null}
       </div>
+
+      {error && !showForm ? (
+        <p className="mb-4 text-sm text-clay-error">{error}</p>
+      ) : null}
 
       {showForm ? (
         <ClayCard className="mb-6 max-w-xl space-y-4">
@@ -174,9 +186,11 @@ export default function FollowUpsPage() {
           <div className="px-6 py-12 text-center">
             <CalendarClock className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />
             <p className="text-clay-text-muted">No follow-ups scheduled.</p>
+            {canWritePatients ? (
             <ClayButton className="mt-4" size="sm" onClick={() => setShowForm(true)}>
               Schedule one
             </ClayButton>
+            ) : null}
           </div>
         ) : (
           <div className="divide-y divide-white/30">
@@ -208,7 +222,7 @@ export default function FollowUpsPage() {
                   <ClayBadge variant={statusVariant(item.status)}>
                     {item.status.replace(/_/g, ' ')}
                   </ClayBadge>
-                  {item.status === 'scheduled' ? (
+                  {item.status === 'scheduled' && canWritePatients ? (
                     <div className="flex gap-2">
                       <ClayButton size="sm" onClick={() => handleStatus(item.id, 'completed')}>
                         Complete

--- a/apps/web/src/app/(dashboard)/patients/[id]/discharge/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/discharge/page.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { ClayButton, ClayCard } from '@careconnect/ui';
 import { ClayTextarea } from '@/components/clinical/clay-textarea';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import {
   ACTIVE_ADMISSIONS_QUERY,
@@ -26,6 +27,7 @@ export default function PatientDischargePage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
 
   const { data: patientData, loading: patientLoading } = useQuery(PATIENT_QUERY, {
     variables: { id, hospitalId },
@@ -72,6 +74,16 @@ export default function PatientDischargePage() {
       setError(err instanceof Error ? err.message : 'Failed to create discharge');
     }
   };
+
+  if (!meData?.me) {
+    return null;
+  }
+
+  if (!canWritePatients) {
+    return (
+      <ForbiddenAccess message="You do not have permission to discharge patients." />
+    );
+  }
 
   if (patientLoading || admissionsLoading) {
     return <p className="text-clay-text-muted">Loading discharge form...</p>;

--- a/apps/web/src/app/(dashboard)/patients/[id]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import type { CreatePatientInput } from '@careconnect/types';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { PatientWizard } from '@/components/patients/patient-wizard';
 import { ME_QUERY, PATIENT_QUERY, UPDATE_PATIENT_MUTATION } from '@/lib/graphql/queries';
@@ -104,6 +105,8 @@ export default function EditPatientPage() {
 
   const [updatePatient, { loading }] = useMutation(UPDATE_PATIENT_MUTATION);
 
+  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
+
   const handleSubmit = async (input: CreatePatientInput) => {
     setError('');
     try {
@@ -115,6 +118,16 @@ export default function EditPatientPage() {
       setError(err instanceof Error ? err.message : 'Failed to update patient');
     }
   };
+
+  if (!meData?.me) {
+    return null;
+  }
+
+  if (!canWritePatients) {
+    return (
+      <ForbiddenAccess message="You do not have permission to edit patients." />
+    );
+  }
 
   if (fetching) {
     return <p className="text-clay-text-muted">Loading patient...</p>;

--- a/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
@@ -24,6 +24,7 @@ export default function PatientDetailPage() {
   const { getToken } = useAuth();
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState('');
+  const [mutationError, setMutationError] = useState('');
   const [documentType, setDocumentType] = useState('identification');
   const { data: meData } = useQuery(ME_QUERY);
   const { data, loading, refetch } = useQuery(PATIENT_QUERY, {
@@ -35,6 +36,68 @@ export default function PatientDetailPage() {
   const [updateStatus] = useMutation(UPDATE_PATIENT_STATUS, { onCompleted: () => refetch() });
   const [deletePatient] = useMutation(DELETE_PATIENT_MUTATION);
   const [linkAccount] = useMutation(LINK_PATIENT_ACCOUNT, { onCompleted: () => refetch() });
+
+  const handleStatusChange = async (newStatus: string) => {
+    setMutationError('');
+    try {
+      await updateStatus({
+        variables: { id, status: newStatus, hospitalId: meData?.me?.hospitalId },
+      });
+    } catch (err) {
+      setMutationError(err instanceof Error ? err.message : 'Failed to update patient status');
+      refetch();
+    }
+  };
+
+  const handleLinkAccount = async () => {
+    const patientEmail = data?.patient?.email;
+    const email =
+      window.prompt(
+        'Portal user email to link (defaults to patient email)',
+        patientEmail ?? '',
+      ) ?? '';
+    if (email === null && !patientEmail) return;
+    setMutationError('');
+    try {
+      await linkAccount({
+        variables: {
+          patientId: id,
+          hospitalId: meData?.me?.hospitalId,
+          email: email || undefined,
+        },
+      });
+    } catch (err) {
+      setMutationError(err instanceof Error ? err.message : 'Failed to link portal account');
+    }
+  };
+
+  const handleDeleteDocument = async (documentId: string) => {
+    setMutationError('');
+    try {
+      await deleteDocument({
+        variables: {
+          id: documentId,
+          patientId: id,
+          hospitalId: meData?.me?.hospitalId,
+        },
+      });
+    } catch (err) {
+      setMutationError(err instanceof Error ? err.message : 'Failed to delete document');
+    }
+  };
+
+  const handleDeletePatient = async () => {
+    if (!confirm('Soft-delete this patient?')) return;
+    setMutationError('');
+    try {
+      await deletePatient({
+        variables: { id, hospitalId: meData?.me?.hospitalId },
+      });
+      window.location.href = '/patients';
+    } catch (err) {
+      setMutationError(err instanceof Error ? err.message : 'Failed to delete patient');
+    }
+  };
 
   const vitalsQuery = useQuery(PATIENT_VITALS_QUERY, {
     variables: { patientId: id, hospitalId: meData?.me?.hospitalId },
@@ -145,18 +208,20 @@ export default function PatientDetailPage() {
         <ClayBadge>{patient.status}</ClayBadge>
         {patient.gender && <ClayBadge variant="info">{patient.gender}</ClayBadge>}
         {patient.bloodGroup && <ClayBadge variant="warning">{patient.bloodGroup}</ClayBadge>}
+        {canWritePatients ? (
         <Link href={`/patients/${id}/edit`}>
           <ClayButton variant="secondary" size="sm">
             Edit
           </ClayButton>
         </Link>
+        ) : null}
         <Link href={`/patients/${id}/history`}>
           <ClayButton variant="secondary" size="sm">
             <History className="h-4 w-4" />
             Full History
           </ClayButton>
         </Link>
-        {patient.status === 'admitted' ? (
+        {patient.status === 'admitted' && canWritePatients ? (
           <Link href={`/patients/${id}/discharge`}>
             <ClayButton size="sm">Discharge</ClayButton>
           </Link>
@@ -166,11 +231,7 @@ export default function PatientDetailPage() {
             aria-label="Update patient status"
             className="rounded-2xl border border-white/60 bg-clay-surface px-3 py-2 text-sm shadow-clay-inset"
             value={patient.status}
-            onChange={(e) =>
-              updateStatus({
-                variables: { id, status: e.target.value, hospitalId: meData?.me?.hospitalId },
-              })
-            }
+            onChange={(e) => handleStatusChange(e.target.value)}
           >
             {['registered', 'checked_in', 'admitted', 'discharged', 'inactive'].map((s) => (
               <option key={s} value={s}>
@@ -183,20 +244,7 @@ export default function PatientDetailPage() {
           <ClayButton
             size="sm"
             variant="ghost"
-            onClick={() => {
-              const email =
-                window.prompt(
-                  'Portal user email to link (defaults to patient email)',
-                  patient.email ?? '',
-                ) ?? '';
-              linkAccount({
-                variables: {
-                  patientId: id,
-                  hospitalId: meData?.me?.hospitalId,
-                  email: email || undefined,
-                },
-              });
-            }}
+            onClick={handleLinkAccount}
           >
             Link portal account
           </ClayButton>
@@ -205,18 +253,16 @@ export default function PatientDetailPage() {
           <ClayButton
             size="sm"
             variant="ghost"
-            onClick={async () => {
-              if (!confirm('Soft-delete this patient?')) return;
-              await deletePatient({
-                variables: { id, hospitalId: meData?.me?.hospitalId },
-              });
-              window.location.href = '/patients';
-            }}
+            onClick={handleDeletePatient}
           >
             Delete
           </ClayButton>
         ) : null}
       </div>
+
+      {mutationError ? (
+        <p className="mb-4 text-sm text-clay-error">{mutationError}</p>
+      ) : null}
 
       <div className="grid gap-6 lg:grid-cols-3">
         <ClayCard className="lg:col-span-2">
@@ -336,15 +382,7 @@ export default function PatientDetailPage() {
                     <ClayButton
                       size="sm"
                       variant="ghost"
-                      onClick={() =>
-                        deleteDocument({
-                          variables: {
-                            id: d.id,
-                            patientId: id,
-                            hospitalId: meData?.me?.hospitalId,
-                          },
-                        })
-                      }
+                      onClick={() => handleDeleteDocument(d.id)}
                     >
                       Delete
                     </ClayButton>

--- a/apps/web/src/app/(dashboard)/patients/import/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/import/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import { Download, Upload } from 'lucide-react';
 import { ClayButton, ClayCard, ClayBadge } from '@careconnect/ui';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { IMPORT_PATIENTS_MUTATION, ME_QUERY } from '@/lib/graphql/queries';
 import { getCsvTemplate, parsePatientCsv } from '@/lib/csv-parser';
@@ -22,6 +23,8 @@ export default function ImportPatientsPage() {
   const [importError, setImportError] = useState('');
   const { data: meData } = useQuery(ME_QUERY);
   const [importPatients, { loading }] = useMutation(IMPORT_PATIENTS_MUTATION);
+
+  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
 
   const handleFile = async (file: File) => {
     const text = await file.text();
@@ -57,6 +60,16 @@ export default function ImportPatientsPage() {
     a.click();
     URL.revokeObjectURL(url);
   };
+
+  if (!meData?.me) {
+    return null;
+  }
+
+  if (!canWritePatients) {
+    return (
+      <ForbiddenAccess message="You do not have permission to import patients." />
+    );
+  }
 
   return (
     <div>

--- a/apps/web/src/app/(dashboard)/patients/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/new/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import type { CreatePatientInput } from '@careconnect/types';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { PatientWizard } from '@/components/patients/patient-wizard';
 import { CREATE_PATIENT_MUTATION, ME_QUERY } from '@/lib/graphql/queries';
@@ -13,6 +14,8 @@ export default function NewPatientPage() {
   const [error, setError] = useState('');
   const { data: meData } = useQuery(ME_QUERY);
   const [createPatient, { loading }] = useMutation(CREATE_PATIENT_MUTATION);
+
+  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
 
   const handleSubmit = async (input: CreatePatientInput) => {
     setError('');
@@ -25,6 +28,16 @@ export default function NewPatientPage() {
       setError(err instanceof Error ? err.message : 'Failed to register patient');
     }
   };
+
+  if (!meData?.me) {
+    return null;
+  }
+
+  if (!canWritePatients) {
+    return (
+      <ForbiddenAccess message="You do not have permission to register patients." />
+    );
+  }
 
   return (
     <div>

--- a/apps/web/src/app/(dashboard)/staff/[id]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/staff/[id]/edit/page.tsx
@@ -5,9 +5,10 @@ import { useParams, useRouter } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import { gql } from '@apollo/client';
 import type { StaffInput } from '@careconnect/types';
+import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { StaffForm } from '@/components/staff/staff-form';
-import { UPDATE_STAFF_MUTATION } from '@/lib/graphql/queries';
+import { ME_QUERY, UPDATE_STAFF_MUTATION } from '@/lib/graphql/queries';
 
 const STAFF_MEMBER_QUERY = gql`
   query StaffMember($id: String!) {
@@ -28,11 +29,14 @@ export default function EditStaffPage() {
   const router = useRouter();
   const [error, setError] = useState('');
 
+  const { data: meData } = useQuery(ME_QUERY);
   const { data, loading: fetching } = useQuery(STAFF_MEMBER_QUERY, {
     variables: { id },
   });
 
   const [updateStaff, { loading }] = useMutation(UPDATE_STAFF_MUTATION);
+
+  const canWriteStaff = (meData?.me?.permissions ?? []).includes('staff:write');
 
   const handleSubmit = async (input: StaffInput) => {
     setError('');
@@ -54,6 +58,16 @@ export default function EditStaffPage() {
       setError(err instanceof Error ? err.message : 'Failed to update staff member');
     }
   };
+
+  if (!meData?.me) {
+    return null;
+  }
+
+  if (!canWriteStaff) {
+    return (
+      <ForbiddenAccess message="You do not have permission to edit staff members." />
+    );
+  }
 
   if (fetching) {
     return <p className="text-clay-text-muted">Loading...</p>;

--- a/apps/web/src/app/(dashboard)/staff/page.tsx
+++ b/apps/web/src/app/(dashboard)/staff/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useState } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
 import { Plus, Pencil, Trash2, RotateCcw } from 'lucide-react';
 import { ClayBadge, ClayButton, ClayCard } from '@careconnect/ui';
@@ -34,14 +35,25 @@ export default function StaffPage() {
   const canDeactivateStaff =
     canWriteStaff &&
     (roles.includes('hospital_admin') || roles.includes('super_admin'));
+  const [actionError, setActionError] = useState('');
 
   const handleDelete = async (id: string, name: string) => {
     if (!confirm(`Deactivate ${name}?`)) return;
-    await deleteStaff({ variables: { id } });
+    setActionError('');
+    try {
+      await deleteStaff({ variables: { id } });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to deactivate staff member');
+    }
   };
 
   const handleReactivate = async (id: string) => {
-    await updateStaff({ variables: { id, input: { isActive: true } } });
+    setActionError('');
+    try {
+      await updateStaff({ variables: { id, input: { isActive: true } } });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to reactivate staff member');
+    }
   };
 
   return (
@@ -58,6 +70,10 @@ export default function StaffPage() {
           </Link>
         ) : null}
       </div>
+
+      {actionError ? (
+        <p className="mb-4 text-sm text-clay-error">{actionError}</p>
+      ) : null}
 
       <ClayCard padding="none" className="overflow-hidden">
         <table className="w-full">

--- a/apps/web/src/app/(portal)/portal-layout-client.tsx
+++ b/apps/web/src/app/(portal)/portal-layout-client.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import { useUser } from '@clerk/nextjs';
+import { ClayButton, ClayCard } from '@careconnect/ui';
 import { COMPLETE_PATIENT_ONBOARDING, ME_QUERY } from '@/lib/graphql/queries';
 import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { PortalSidebar } from '@/components/layout/portal-sidebar';
@@ -15,6 +16,8 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
   const { data, loading, error, refetch } = useQuery(ME_QUERY, { errorPolicy: 'all' });
   const [completePatientOnboarding] = useMutation(COMPLETE_PATIENT_ONBOARDING);
   const ran = useRef(false);
+  const [onboardingError, setOnboardingError] = useState<string | null>(null);
+  const [onboardingRetrying, setOnboardingRetrying] = useState(false);
   const me = data?.me;
   const roles: string[] = me?.roles ?? [];
   const isPatient = roles.includes('patient') || roles.includes('super_admin');
@@ -29,6 +32,21 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
       router.replace('/dashboard');
     }
   }, [isStaff, router]);
+
+  const runPatientOnboarding = async (fullName: string) => {
+    setOnboardingError(null);
+    setOnboardingRetrying(true);
+    try {
+      await completePatientOnboarding({ variables: { fullName } });
+      await refetch();
+    } catch (err) {
+      setOnboardingError(
+        err instanceof Error ? err.message : 'Failed to complete patient setup',
+      );
+    } finally {
+      setOnboardingRetrying(false);
+    }
+  };
 
   useEffect(() => {
     const needsComplete =
@@ -47,12 +65,8 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
       user.primaryEmailAddress?.emailAddress?.split('@')[0] ||
       'Patient';
 
-    completePatientOnboarding({ variables: { fullName } })
-      .then(() => refetch())
-      .catch(() => {
-        ran.current = false;
-      });
-  }, [searchParams, me, user, completePatientOnboarding, refetch]);
+    void runPatientOnboarding(fullName);
+  }, [searchParams, me, user]);
 
   if (loading && !me) {
     return (
@@ -77,6 +91,30 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
     return (
       <div className="flex min-h-screen items-center justify-center bg-clay-bg text-clay-text-muted">
         Redirecting to dashboard…
+      </div>
+    );
+  }
+
+  if (onboardingError) {
+    const retryFullName =
+      (typeof user?.unsafeMetadata?.fullName === 'string' && user.unsafeMetadata.fullName) ||
+      user?.fullName ||
+      user?.primaryEmailAddress?.emailAddress?.split('@')[0] ||
+      'Patient';
+
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-clay-bg p-6">
+        <ClayCard className="max-w-md space-y-4 p-8 text-center">
+          <h1 className="text-xl font-bold text-clay-text">Setup failed</h1>
+          <p className="text-sm text-clay-error">{onboardingError}</p>
+          <ClayButton
+            type="button"
+            isLoading={onboardingRetrying}
+            onClick={() => void runPatientOnboarding(retryFullName)}
+          >
+            Try again
+          </ClayButton>
+        </ClayCard>
       </div>
     );
   }

--- a/apps/web/src/app/(portal)/portal/appointments/page.tsx
+++ b/apps/web/src/app/(portal)/portal/appointments/page.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@apollo/client';
 import { Calendar } from 'lucide-react';
 import { ClayBadge, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { PortalQueryError } from '@/components/portal/portal-query-error';
 import { PORTAL_PATIENT_RECORDS_QUERY } from '@/lib/graphql/queries';
 
 function formatDateTime(iso: string) {
@@ -31,7 +32,7 @@ const statusVariant = (status: string) => {
 };
 
 export default function PortalAppointmentsPage() {
-  const { data, loading } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
+  const { data, loading, error, refetch } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
   const appointments = data?.portalPatientRecords?.appointments ?? [];
   const patient = data?.portalPatientRecords?.patient;
 
@@ -45,6 +46,13 @@ export default function PortalAppointmentsPage() {
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">Loading appointments...</p>
+        ) : error ? (
+          <div className="px-6 py-8">
+            <PortalQueryError
+              message={error.message || 'We could not load your appointments.'}
+              onRetry={() => refetch()}
+            />
+          </div>
         ) : !patient ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">
             No linked patient record found.

--- a/apps/web/src/app/(portal)/portal/lab-results/page.tsx
+++ b/apps/web/src/app/(portal)/portal/lab-results/page.tsx
@@ -4,10 +4,11 @@ import { useQuery } from '@apollo/client';
 import { FlaskConical } from 'lucide-react';
 import { ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { PortalQueryError } from '@/components/portal/portal-query-error';
 import { PORTAL_PATIENT_RECORDS_QUERY } from '@/lib/graphql/queries';
 
 export default function PortalLabResultsPage() {
-  const { data, loading } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
+  const { data, loading, error, refetch } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
   const patient = data?.portalPatientRecords?.patient;
   const labResults = data?.portalPatientRecords?.labResults ?? [];
 
@@ -18,6 +19,13 @@ export default function PortalLabResultsPage() {
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">Loading lab results...</p>
+        ) : error ? (
+          <div className="px-6 py-8">
+            <PortalQueryError
+              message={error.message || 'We could not load your lab results.'}
+              onRetry={() => refetch()}
+            />
+          </div>
         ) : !patient ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">
             No linked patient record found.

--- a/apps/web/src/app/(portal)/portal/page.tsx
+++ b/apps/web/src/app/(portal)/portal/page.tsx
@@ -5,11 +5,12 @@ import { useQuery } from '@apollo/client';
 import { Calendar, FileText, FlaskConical, Pill } from 'lucide-react';
 import { ClayCard, ClayStatCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { PortalQueryError } from '@/components/portal/portal-query-error';
 import { ME_QUERY, PORTAL_PATIENT_RECORDS_QUERY } from '@/lib/graphql/queries';
 
 export default function PortalDashboardPage() {
   const { data: meData } = useQuery(ME_QUERY);
-  const { data, loading } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
+  const { data, loading, error, refetch } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
 
   const records = data?.portalPatientRecords;
   const patient = records?.patient;
@@ -55,6 +56,11 @@ export default function PortalDashboardPage() {
 
       {loading ? (
         <p className="text-clay-text-muted">Loading your health records...</p>
+      ) : error ? (
+        <PortalQueryError
+          message={error.message || 'We could not load your health records.'}
+          onRetry={() => refetch()}
+        />
       ) : !patient ? (
         <ClayCard>
           <p className="text-clay-text-muted">

--- a/apps/web/src/app/(portal)/portal/prescriptions/page.tsx
+++ b/apps/web/src/app/(portal)/portal/prescriptions/page.tsx
@@ -4,10 +4,11 @@ import { useQuery } from '@apollo/client';
 import { Pill } from 'lucide-react';
 import { ClayBadge, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { PortalQueryError } from '@/components/portal/portal-query-error';
 import { PORTAL_PATIENT_RECORDS_QUERY } from '@/lib/graphql/queries';
 
 export default function PortalPrescriptionsPage() {
-  const { data, loading } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
+  const { data, loading, error, refetch } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
   const patient = data?.portalPatientRecords?.patient;
   const prescriptions = data?.portalPatientRecords?.prescriptions ?? [];
 
@@ -21,6 +22,13 @@ export default function PortalPrescriptionsPage() {
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">Loading prescriptions...</p>
+        ) : error ? (
+          <div className="px-6 py-8">
+            <PortalQueryError
+              message={error.message || 'We could not load your prescriptions.'}
+              onRetry={() => refetch()}
+            />
+          </div>
         ) : !patient ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">
             No linked patient record found.

--- a/apps/web/src/app/(portal)/portal/profile/page.tsx
+++ b/apps/web/src/app/(portal)/portal/profile/page.tsx
@@ -3,11 +3,12 @@
 import { useQuery } from '@apollo/client';
 import { ClayBadge, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { PortalQueryError } from '@/components/portal/portal-query-error';
 import { ME_QUERY, PORTAL_PATIENT_RECORDS_QUERY } from '@/lib/graphql/queries';
 
 export default function PortalProfilePage() {
   const { data: meData } = useQuery(ME_QUERY);
-  const { data, loading } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
+  const { data, loading, error, refetch } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
   const patient = data?.portalPatientRecords?.patient;
 
   return (
@@ -38,6 +39,11 @@ export default function PortalProfilePage() {
           <h2 className="mb-4 text-lg font-semibold text-clay-text">Patient Record</h2>
           {loading ? (
             <p className="text-sm text-clay-text-muted">Loading profile...</p>
+          ) : error ? (
+            <PortalQueryError
+              message={error.message || 'We could not load your patient record.'}
+              onRetry={() => refetch()}
+            />
           ) : !patient ? (
             <p className="text-sm text-clay-text-muted">
               No patient record is linked to this account yet. Your hospital can link your profile

--- a/apps/web/src/app/(portal)/portal/records/page.tsx
+++ b/apps/web/src/app/(portal)/portal/records/page.tsx
@@ -4,10 +4,11 @@ import { useQuery } from '@apollo/client';
 import { FileText } from 'lucide-react';
 import { ClayBadge, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { PortalQueryError } from '@/components/portal/portal-query-error';
 import { PORTAL_PATIENT_RECORDS_QUERY } from '@/lib/graphql/queries';
 
 export default function PortalRecordsPage() {
-  const { data, loading } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
+  const { data, loading, error, refetch } = useQuery(PORTAL_PATIENT_RECORDS_QUERY);
   const patient = data?.portalPatientRecords?.patient;
   const appointments = data?.portalPatientRecords?.appointments ?? [];
   const prescriptions = data?.portalPatientRecords?.prescriptions ?? [];
@@ -22,6 +23,11 @@ export default function PortalRecordsPage() {
 
       {loading ? (
         <p className="text-clay-text-muted">Loading records...</p>
+      ) : error ? (
+        <PortalQueryError
+          message={error.message || 'We could not load your medical records.'}
+          onRetry={() => refetch()}
+        />
       ) : !patient ? (
         <ClayCard>
           <p className="text-clay-text-muted">No linked patient record found.</p>

--- a/apps/web/src/components/portal/portal-query-error.tsx
+++ b/apps/web/src/components/portal/portal-query-error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ClayButton, ClayCard } from '@careconnect/ui';
+
+export function PortalQueryError({
+  message = 'We could not load your health records. Please try again.',
+  onRetry,
+}: {
+  message?: string;
+  onRetry: () => void;
+}) {
+  return (
+    <ClayCard className="max-w-lg space-y-4 p-6 text-center">
+      <p className="text-sm text-clay-error">{message}</p>
+      <ClayButton type="button" onClick={onRetry}>
+        Try again
+      </ClayButton>
+    </ClayCard>
+  );
+}

--- a/apps/web/src/lib/route-access.ts
+++ b/apps/web/src/lib/route-access.ts
@@ -15,6 +15,21 @@ type RouteRule = {
   anyRoles?: string[];
 };
 
+/** Write/create/edit routes — checked before read rules (longest prefix first) */
+const WRITE_ROUTE_RULES: RouteRule[] = [
+  { prefix: '/finance/invoices/new', anyPermissions: ['billing:write'] },
+  { prefix: '/appointments/new', anyPermissions: ['appointments:write'] },
+  { prefix: '/patients/import', anyPermissions: ['patients:write'] },
+  { prefix: '/patients/new', anyPermissions: ['patients:write'] },
+  { prefix: '/staff/new', anyPermissions: ['staff:write'] },
+];
+
+const WRITE_ROUTE_PATTERNS: { pattern: RegExp; anyPermissions: string[] }[] = [
+  { pattern: /^\/patients\/[^/]+\/edit$/, anyPermissions: ['patients:write'] },
+  { pattern: /^\/patients\/[^/]+\/discharge$/, anyPermissions: ['patients:write'] },
+  { pattern: /^\/staff\/[^/]+\/edit$/, anyPermissions: ['staff:write'] },
+];
+
 const ROUTE_RULES: RouteRule[] = [
   { prefix: '/staff', anyPermissions: ['staff:read'] },
   { prefix: '/patients', anyPermissions: ['patients:read'] },
@@ -58,12 +73,38 @@ const SORTED_RULES = [...ROUTE_RULES].sort(
   (a, b) => b.prefix.length - a.prefix.length,
 );
 
+const SORTED_WRITE_RULES = [...WRITE_ROUTE_RULES].sort(
+  (a, b) => b.prefix.length - a.prefix.length,
+);
+
+function hasWriteAccess(anyPermissions: string[], ctx: AccessContext): boolean {
+  if (ctx.roles.includes('super_admin')) return true;
+  return anyPermissions.some((perm) => ctx.permissions.includes(perm));
+}
+
+function matchesWriteRoute(pathname: string, ctx: AccessContext): boolean | null {
+  for (const { pattern, anyPermissions } of WRITE_ROUTE_PATTERNS) {
+    if (pattern.test(pathname)) {
+      return hasWriteAccess(anyPermissions, ctx);
+    }
+  }
+
+  const writeRule = SORTED_WRITE_RULES.find(
+    (r) => pathname === r.prefix || pathname.startsWith(`${r.prefix}/`),
+  );
+  if (!writeRule?.anyPermissions) return null;
+  return hasWriteAccess(writeRule.anyPermissions, ctx);
+}
+
 /** Routes any authenticated non-patient staff may open without a specific rule */
 const STAFF_PUBLIC_ROUTES = ['/dashboard'];
 
 export function canAccessRoute(pathname: string, ctx: AccessContext): boolean {
   if (ctx.roles.includes('super_admin')) return true;
   if (ctx.roles.includes('patient')) return false;
+
+  const writeAccess = matchesWriteRoute(pathname, ctx);
+  if (writeAccess !== null) return writeAccess;
 
   if (STAFF_PUBLIC_ROUTES.some((route) => pathname === route)) return true;
 


### PR DESCRIPTION
## Summary
Second full rescan after #88 found **11 confirmed issues** (#89–#99). All fixed here without breaking working write flows for entitled roles.

### High
- **#89** — Deactivate expires outstanding invites; `acceptInvite` rejects inactive staff/users

### Medium
- **#90 / #97** — Discharge summaries allowed for transferred admissions; follow-up status machine + lock
- **#91** — Invoice, prescription, and patient create/update related rows are transactional
- **#92 / #98** — Bounded list/import sizes; empty prescriptions rejected
- **#93** — Write pages require matching `*:write` (ForbiddenAccess + route-access)
- **#94** — Admissions/follow-ups/doctor/patient-detail write CTAs gated
- **#95** — Visible errors for patient/staff/follow-up mutations
- **#96 / #99** — Portal query errors ≠ unlinked; auto-onboarding failure + retry

## Test plan
- [ ] Deactivate staff → outstanding invite acceptance fails
- [ ] Transfer-out admission → createDischarge succeeds
- [ ] Lab tech cannot open `/patients/new` (ForbiddenAccess)
- [ ] Nurse without `patients:write` sees no Admit/Discharge CTAs
- [ ] Portal GraphQL failure shows retry, not “unlinked”
- [ ] `pnpm test` staff/discharge/clinical/billing specs pass
- [ ] Import >500 rows rejected; empty Rx items rejected


Made with [Cursor](https://cursor.com)