### PR TITLE
fix: rescan issues #101–#124

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -246,25 +246,38 @@ export class AuthService {
   }
 
   /** Patient portal path: assign patient role and mark onboarding complete. */
-  async completePatientOnboarding(userId: string, fullName: string) {
-    await this.usersRepo.update(userId, {
+  async completePatientOnboarding(user: AuthenticatedUser, fullName: string) {
+    const staffRoles = (user.roles ?? []).filter((role) => role !== 'patient');
+    if (user.hospitalId || staffRoles.length > 0) {
+      throw new ForbiddenException(
+        'Only patient accounts without a hospital assignment can complete patient onboarding',
+      );
+    }
+
+    await this.usersRepo.update(user.id, {
       fullName,
       onboardingCompleted: true,
     });
 
-    const existingRoles = await this.userRolesRepo.find({ where: { userId } });
+    const existingRoles = await this.userRolesRepo.find({
+      where: { userId: user.id },
+    });
     if (existingRoles.length === 0) {
       const patientRole = await this.rolesRepo.findOne({
         where: { slug: 'patient' },
       });
       if (patientRole) {
-        await this.userRolesRepo.save(
-          this.userRolesRepo.create({
-            userId,
-            roleId: patientRole.id,
-            hospitalId: undefined,
-          }),
-        );
+        try {
+          await this.userRolesRepo.save(
+            this.userRolesRepo.create({
+              userId: user.id,
+              roleId: patientRole.id,
+              hospitalId: undefined,
+            }),
+          );
+        } catch (error) {
+          if (!isUniqueViolation(error)) throw error;
+        }
       }
     }
   }

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -135,6 +135,11 @@ export class BillingService {
         'Admission does not belong to the given patient',
       );
     }
+    if (admission.status !== 'active') {
+      throw new BadRequestException(
+        'Invoices can only be linked to an active admission',
+      );
+    }
   }
 
   async createInvoice(

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -146,6 +146,11 @@ export class ClinicalService {
         'Admission does not belong to the given patient',
       );
     }
+    if (admission.status !== 'active') {
+      throw new BadRequestException(
+        'Clinical records can only be linked to an active admission',
+      );
+    }
   }
 
   toVitalType(vital: VitalSign): VitalSignType {

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -497,7 +497,9 @@ export class ClinicalService {
         }
         assertLabTransition(order.status, 'completed');
 
-        const safeResultFileUrl = this.assertLocalUploadUrl(input.resultFileUrl);
+        const safeResultFileUrl = this.assertLocalUploadUrl(
+          input.resultFileUrl,
+        );
 
         const result = await manager.save(
           manager.create(LabResult, {

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -5,6 +5,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { existsSync } from 'fs';
+import { basename, join } from 'path';
 import { Repository } from 'typeorm';
 import {
   Admission,
@@ -495,6 +497,8 @@ export class ClinicalService {
         }
         assertLabTransition(order.status, 'completed');
 
+        const safeResultFileUrl = this.assertLocalUploadUrl(input.resultFileUrl);
+
         const result = await manager.save(
           manager.create(LabResult, {
             labOrderId: order.id,
@@ -502,7 +506,7 @@ export class ClinicalService {
             resultValue: input.resultValue,
             referenceRange: input.referenceRange,
             unit: input.unit,
-            resultFileUrl: input.resultFileUrl,
+            resultFileUrl: safeResultFileUrl,
             enteredById: actor.id,
             completedAt: new Date(),
           }),

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -690,4 +690,37 @@ export class ClinicalService {
     });
     return rows.map((p) => this.toPrescriptionType(p));
   }
+
+  /** Lab result attachments must use same-origin /uploads paths. */
+  private assertLocalUploadUrl(fileUrl?: string): string | undefined {
+    if (fileUrl == null || fileUrl.trim() === '') return undefined;
+    const trimmed = fileUrl.trim();
+    let pathname: string;
+    try {
+      if (trimmed.startsWith('/uploads/')) {
+        pathname = trimmed.split('?')[0] ?? trimmed;
+      } else {
+        pathname = new URL(trimmed).pathname;
+      }
+    } catch {
+      throw new BadRequestException(
+        'Lab result fileUrl must be a valid /uploads/... path from this API',
+      );
+    }
+    const match = pathname.match(/^\/uploads\/([^/]+)$/);
+    if (!match) {
+      throw new BadRequestException(
+        'Lab result fileUrl must be an /uploads/<filename> path from this API',
+      );
+    }
+    const filename = basename(match[1]);
+    if (!filename || filename !== match[1] || filename.includes('..')) {
+      throw new BadRequestException('Invalid upload filename');
+    }
+    const diskPath = join(process.cwd(), 'uploads', filename);
+    if (!existsSync(diskPath)) {
+      throw new BadRequestException('Upload file not found on server');
+    }
+    return `/uploads/${filename}`;
+  }
 }

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -145,9 +145,12 @@ export class DischargeService {
             await manager.save(admission);
 
             if (admission.bedId) {
-              const bed = await manager.findOne(Bed, {
-                where: { id: admission.bedId, hospitalId },
-              });
+              const bed = await manager
+                .createQueryBuilder(Bed, 'bed')
+                .setLock('pessimistic_write')
+                .where('bed.id = :id', { id: admission.bedId })
+                .andWhere('bed.hospital_id = :hospitalId', { hospitalId })
+                .getOne();
               if (bed) {
                 bed.status = 'available';
                 await manager.save(bed);

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -33,11 +33,13 @@ function isUniqueViolation(error: unknown): boolean {
 
 /**
  * Follow-up status machine:
- *   scheduled → completed | missed
+ *   scheduled → completed | missed | rescheduled
+ *   rescheduled → scheduled | completed | missed
  * Terminal: completed, missed (immutable)
  */
 const FOLLOW_UP_TRANSITIONS: Record<string, readonly string[]> = {
-  scheduled: ['completed', 'missed'],
+  scheduled: ['completed', 'missed', 'rescheduled'],
+  rescheduled: ['scheduled', 'completed', 'missed'],
   completed: [],
   missed: [],
 };

--- a/apps/api/src/inventory/inventory.service.ts
+++ b/apps/api/src/inventory/inventory.service.ts
@@ -97,20 +97,27 @@ export class InventoryService {
     input: UpdateInventoryQuantityInput,
     actor: AuthenticatedUser,
   ): Promise<InventoryItemType> {
-    const item = await this.inventoryRepo.findOne({
-      where: { id: input.id, hospitalId },
-    });
-    if (!item) throw new NotFoundException('Inventory item not found');
+    const saved = await this.inventoryRepo.manager.transaction(
+      async (manager) => {
+        const item = await manager
+          .createQueryBuilder(InventoryItem, 'item')
+          .setLock('pessimistic_write')
+          .where('item.id = :id', { id: input.id })
+          .andWhere('item.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!item) throw new NotFoundException('Inventory item not found');
 
-    item.quantity = input.quantity.toFixed(2);
-    const saved = await this.inventoryRepo.save(item);
+        item.quantity = input.quantity.toFixed(2);
+        return manager.save(item);
+      },
+    );
 
     await this.audit.log({
       actorId: actor.id,
       hospitalId,
       action: 'update',
       resource: 'inventory_item',
-      resourceId: item.id,
+      resourceId: saved.id,
       metadata: { quantity: input.quantity },
     });
 

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -38,6 +38,9 @@ describe('PatientsService', () => {
     create: jest.fn(),
     softRemove: jest.fn(),
     createQueryBuilder: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
 
   const relatedRepo = {
@@ -182,8 +185,24 @@ describe('PatientsService', () => {
         updatedAt: new Date(),
       };
 
-      patientsRepo.create.mockReturnValue(savedPatient);
-      patientsRepo.save.mockResolvedValue(savedPatient);
+      patientsRepo.manager.transaction.mockImplementation(
+        async (cb: (m: Record<string, unknown>) => unknown) => {
+          const manager = {
+            save: jest.fn(async (entity: unknown) =>
+              typeof entity === 'object' && entity && 'id' in (entity as object)
+                ? entity
+                : savedPatient,
+            ),
+            create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({
+              ...savedPatient,
+              ...data,
+            })),
+            getRepository: () => relatedRepo,
+          };
+          return cb(manager);
+        },
+      );
+      patientsRepo.findOne.mockResolvedValue(savedPatient);
 
       const result = await service.create(
         'hospital-1',
@@ -196,7 +215,6 @@ describe('PatientsService', () => {
       );
 
       expect(result.fullName).toBe('Jane Doe');
-      expect(patientsRepo.save).toHaveBeenCalled();
       expect(audit.log).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'create', resource: 'patient' }),
       );

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -186,20 +186,24 @@ describe('PatientsService', () => {
       };
 
       patientsRepo.manager.transaction.mockImplementation(
-        async (cb: (m: Record<string, unknown>) => unknown) => {
+        (cb: (m: Record<string, unknown>) => unknown) => {
           const manager = {
-            save: jest.fn(async (entity: unknown) =>
-              typeof entity === 'object' && entity && 'id' in (entity as object)
-                ? entity
-                : savedPatient,
+            save: jest.fn((entity: unknown) =>
+              Promise.resolve(
+                typeof entity === 'object' && entity && 'id' in entity
+                  ? entity
+                  : savedPatient,
+              ),
             ),
-            create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({
-              ...savedPatient,
-              ...data,
-            })),
+            create: jest.fn(
+              (_entity: unknown, data: Record<string, unknown>) => ({
+                ...savedPatient,
+                ...data,
+              }),
+            ),
             getRepository: () => relatedRepo,
           };
-          return cb(manager);
+          return Promise.resolve(cb(manager));
         },
       );
       patientsRepo.findOne.mockResolvedValue(savedPatient);

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -420,6 +420,11 @@ export class PatientsService {
     // Soft-delete policy: soft-remove the patient row; hard-remove linked
     // document metadata and unlink PHI files from disk. Other related rows
     // remain for audit but are unreachable via patient queries.
+    // Clear portal binding so the unique user_id index frees the account.
+    const previousUserId = patient.userId;
+    patient.userId = null as unknown as string | undefined;
+    await this.patientsRepo.save(patient);
+
     const documents = await this.documentsRepo.find({
       where: { patientId: id },
     });
@@ -440,6 +445,7 @@ export class PatientsService {
       metadata: {
         fullName: patient.fullName,
         documentsRemoved: documents.length,
+        previousUserId,
       },
     });
 

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -480,6 +480,18 @@ export class PatientsService {
       throw new BadRequestException(
         'Cannot mark patient admitted without an active admission',
       );
+    } else if (status === 'discharged') {
+      const priorDischarge = await this.admissionsRepo.findOne({
+        where: [
+          { patientId: id, hospitalId, status: 'discharged' },
+          { patientId: id, hospitalId, status: 'transferred' },
+        ],
+      });
+      if (!priorDischarge && patient.status !== 'discharged') {
+        throw new BadRequestException(
+          'Cannot mark patient discharged without a completed discharge or transfer',
+        );
+      }
     }
 
     patient.status = status;

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -558,6 +558,12 @@ export class PatientsService {
   ): Promise<PatientType> {
     const patient = await this.findPatientOrThrow(patientId, hospitalId);
 
+    if (patient.userId) {
+      throw new ConflictException(
+        'Patient chart is already linked to a portal account. Unlink or delete before re-linking.',
+      );
+    }
+
     let targetUserId = userId;
     const lookupEmail =
       email?.trim().toLowerCase() || patient.email?.toLowerCase();
@@ -598,8 +604,32 @@ export class PatientsService {
       );
     }
 
+    const existingLink = await this.patientsRepo.findOne({
+      where: { userId: targetUserId },
+    });
+    if (existingLink && existingLink.id !== patient.id) {
+      throw new ConflictException(
+        'That portal user is already linked to another patient chart',
+      );
+    }
+
+    const previousUserId = patient.userId;
     patient.userId = targetUserId;
-    const saved = await this.patientsRepo.save(patient);
+    let saved: Patient;
+    try {
+      saved = await this.patientsRepo.save(patient);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as { code?: string }).code === '23505'
+      ) {
+        throw new ConflictException(
+          'That portal user is already linked to another patient chart',
+        );
+      }
+      throw error;
+    }
 
     await this.audit.log({
       actorId: actor.id,
@@ -607,7 +637,11 @@ export class PatientsService {
       action: 'link_account',
       resource: 'patient',
       resourceId: saved.id,
-      metadata: { userId: targetUserId, email: lookupEmail },
+      metadata: {
+        userId: targetUserId,
+        previousUserId,
+        email: lookupEmail,
+      },
     });
 
     return this.toPatientType(saved);

--- a/apps/api/src/pharmacy/pharmacy.service.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.ts
@@ -114,31 +114,60 @@ export class PharmacyService {
       throw new BadRequestException('Drug name is required');
     }
 
-    const existing = await this.pharmacyStockRepo
-      .createQueryBuilder('stock')
-      .where('stock.hospital_id = :hospitalId', { hospitalId })
-      .andWhere('LOWER(stock.drug_name) = LOWER(:drugName)', { drugName })
-      .getOne();
+    const { stock, created } = await this.pharmacyStockRepo.manager.transaction(
+      async (manager) => {
+        const existing = await manager
+          .createQueryBuilder(PharmacyStock, 'stock')
+          .setLock('pessimistic_write')
+          .where('stock.hospital_id = :hospitalId', { hospitalId })
+          .andWhere('LOWER(stock.drug_name) = LOWER(:drugName)', { drugName })
+          .getOne();
 
-    const stock = existing
-      ? await this.pharmacyStockRepo.save({
-          ...existing,
-          quantity: input.quantity.toFixed(2),
-          unit: input.unit ?? existing.unit,
-        })
-      : await this.pharmacyStockRepo.save(
-          this.pharmacyStockRepo.create({
-            hospitalId,
-            drugName,
-            quantity: input.quantity.toFixed(2),
-            unit: input.unit ?? 'each',
-          }),
-        );
+        if (existing) {
+          existing.quantity = input.quantity.toFixed(2);
+          if (input.unit) existing.unit = input.unit;
+          return { stock: await manager.save(existing), created: false };
+        }
+
+        try {
+          const createdRow = await manager.save(
+            manager.create(PharmacyStock, {
+              hospitalId,
+              drugName,
+              quantity: input.quantity.toFixed(2),
+              unit: input.unit ?? 'each',
+            }),
+          );
+          return { stock: createdRow, created: true };
+        } catch (error) {
+          // Concurrent insert won the unique index — lock and update that row.
+          if (
+            !(
+              error instanceof Error &&
+              'code' in error &&
+              (error as { code?: string }).code === '23505'
+            )
+          ) {
+            throw error;
+          }
+          const raced = await manager
+            .createQueryBuilder(PharmacyStock, 'stock')
+            .setLock('pessimistic_write')
+            .where('stock.hospital_id = :hospitalId', { hospitalId })
+            .andWhere('LOWER(stock.drug_name) = LOWER(:drugName)', { drugName })
+            .getOne();
+          if (!raced) throw error;
+          raced.quantity = input.quantity.toFixed(2);
+          if (input.unit) raced.unit = input.unit;
+          return { stock: await manager.save(raced), created: false };
+        }
+      },
+    );
 
     await this.audit.log({
       actorId: actor.id,
       hospitalId,
-      action: existing ? 'update' : 'create',
+      action: created ? 'create' : 'update',
       resource: 'pharmacy_stock',
       resourceId: stock.id,
       metadata: { drugName: stock.drugName, quantity: input.quantity },

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -159,7 +159,7 @@ describe('StaffService', () => {
         authId: 'auth-1',
       };
       staffRepo.manager.transaction.mockImplementation(
-        async (cb: (m: Record<string, unknown>) => unknown) => {
+        (cb: (m: Record<string, unknown>) => unknown) => {
           const manager = {
             getRepository: (entity: unknown) => {
               if (entity === User) {
@@ -179,7 +179,7 @@ describe('StaffService', () => {
               return {};
             },
           };
-          return cb(manager);
+          return Promise.resolve(cb(manager));
         },
       );
 
@@ -218,7 +218,7 @@ describe('StaffService', () => {
         user: { email: 'doc@example.com', isActive: false },
       };
       invitesRepo.manager.transaction.mockImplementation(
-        async (cb: (m: Record<string, unknown>) => unknown) => {
+        (cb: (m: Record<string, unknown>) => unknown) => {
           const manager = {
             getRepository: (entity: unknown) => {
               if (entity === StaffInvite) {
@@ -240,7 +240,7 @@ describe('StaffService', () => {
               return {};
             },
           };
-          return cb(manager);
+          return Promise.resolve(cb(manager));
         },
       );
 

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -25,12 +25,16 @@ describe('StaffService', () => {
     findOne: jest.fn(),
     save: jest.fn(),
     create: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
   const usersRepo = {
     findOne: jest.fn(),
     save: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
   const rolesRepo = { findOne: jest.fn() };
   const userRolesRepo = {
@@ -49,10 +53,15 @@ describe('StaffService', () => {
         set: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setLock: jest.fn().mockReturnThis(),
+        getOne: jest.fn(),
         execute: jest.fn().mockResolvedValue({ affected: 1 }),
       };
       return qb;
     }),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
   const clerkAdmin = {
     isConfigured: jest.fn().mockReturnValue(false),
@@ -142,13 +151,37 @@ describe('StaffService', () => {
         id: 'role-doctor',
         slug: 'doctor',
       });
-      usersRepo.findOne.mockResolvedValue({
+      const existingUser = {
         id: 'user-1',
         email: 'doc@example.com',
         hospitalId: 'hospital-b',
         fullName: 'Existing Doc',
         authId: 'auth-1',
-      });
+      };
+      staffRepo.manager.transaction.mockImplementation(
+        async (cb: (m: Record<string, unknown>) => unknown) => {
+          const manager = {
+            getRepository: (entity: unknown) => {
+              if (entity === User) {
+                return {
+                  createQueryBuilder: () => ({
+                    where: jest.fn().mockReturnThis(),
+                    getOne: jest.fn().mockResolvedValue(existingUser),
+                  }),
+                  update: usersRepo.update,
+                  save: usersRepo.save,
+                  create: usersRepo.create,
+                };
+              }
+              if (entity === UserRole) return userRolesRepo;
+              if (entity === StaffProfile) return staffRepo;
+              if (entity === StaffInvite) return invitesRepo;
+              return {};
+            },
+          };
+          return cb(manager);
+        },
+      );
 
       await expect(
         service.create(
@@ -169,21 +202,47 @@ describe('StaffService', () => {
 
   describe('acceptInvite — deactivated staff', () => {
     it('rejects invite acceptance when staff profile is inactive', async () => {
-      invitesRepo.findOne.mockResolvedValue({
+      const invite = {
         token: 'tok',
         email: 'doc@example.com',
         hospitalId: 'hospital-a',
         staffProfileId: 'staff-1',
         acceptedAt: null,
         expiresAt: new Date(Date.now() + 86400000),
-      });
-      staffRepo.findOne.mockResolvedValue({
+      };
+      const inactiveStaff = {
         id: 'staff-1',
         userId: 'user-1',
         hospitalId: 'hospital-a',
         isActive: false,
         user: { email: 'doc@example.com', isActive: false },
-      });
+      };
+      invitesRepo.manager.transaction.mockImplementation(
+        async (cb: (m: Record<string, unknown>) => unknown) => {
+          const manager = {
+            getRepository: (entity: unknown) => {
+              if (entity === StaffInvite) {
+                return {
+                  createQueryBuilder: () => ({
+                    setLock: jest.fn().mockReturnThis(),
+                    where: jest.fn().mockReturnThis(),
+                    getOne: jest.fn().mockResolvedValue(invite),
+                  }),
+                  save: invitesRepo.save,
+                };
+              }
+              if (entity === User) return usersRepo;
+              if (entity === StaffProfile) {
+                return {
+                  findOne: jest.fn().mockResolvedValue(inactiveStaff),
+                };
+              }
+              return {};
+            },
+          };
+          return cb(manager);
+        },
+      );
 
       await expect(
         service.acceptInvite('tok', 'auth-new', 'doc@example.com'),

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -7,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomBytes, randomUUID } from 'crypto';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import {
   Role,
   StaffInvite,
@@ -19,6 +20,13 @@ import type { AuthenticatedUser } from '../auth/auth.types';
 import { ClerkAdminService } from '../clerk/clerk-admin.service';
 import { AuditService } from '../audit/audit.service';
 import { CreateStaffInput, UpdateStaffInput } from './staff.types';
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error as QueryFailedError & { code?: string }).code === '23505'
+  );
+}
 
 const ASSIGNABLE_STAFF_ROLES = new Set([
   'hospital_manager',
@@ -115,87 +123,127 @@ export class StaffService {
       authId = `pending_${randomUUID()}`;
     }
 
-    const existingByEmail = await this.usersRepo.findOne({
-      where: { email: input.email },
-    });
-    let user: User;
-    if (existingByEmail) {
-      user = existingByEmail;
-      // Single-hospital policy: a user may belong to at most one hospital.
-      // Never attach foreign roles/staff profiles while hospitalId stays elsewhere.
-      if (user.hospitalId && user.hospitalId !== hospitalId) {
-        throw new BadRequestException(
-          'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
+    const email = input.email.trim();
+    const token = randomBytes(32).toString('hex');
+
+    let staffId: string;
+    try {
+      staffId = await this.staffRepo.manager.transaction(async (manager) => {
+        const usersRepo = manager.getRepository(User);
+        const userRolesRepo = manager.getRepository(UserRole);
+        const staffRepo = manager.getRepository(StaffProfile);
+        const invitesRepo = manager.getRepository(StaffInvite);
+
+        const existingByEmail = await usersRepo
+          .createQueryBuilder('user')
+          .where('LOWER(user.email) = LOWER(:email)', { email })
+          .getOne();
+
+        let user: User;
+        if (existingByEmail) {
+          user = existingByEmail;
+          if (user.hospitalId && user.hospitalId !== hospitalId) {
+            throw new BadRequestException(
+              'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
+            );
+          }
+          if (!user.hospitalId) {
+            await usersRepo.update(user.id, {
+              hospitalId,
+              fullName: input.fullName,
+              authId,
+            });
+            user.hospitalId = hospitalId;
+            user.authId = authId;
+          }
+        } else {
+          user = await usersRepo.save(
+            usersRepo.create({
+              authId,
+              email,
+              fullName: input.fullName,
+              hospitalId,
+              onboardingCompleted: true,
+            }),
+          );
+        }
+
+        const existingProfile = await staffRepo.findOne({
+          where: { userId: user.id, hospitalId },
+        });
+        if (existingProfile) {
+          throw new ConflictException(
+            'A staff profile already exists for this user at this hospital',
+          );
+        }
+
+        const existingRole = await userRolesRepo.findOne({
+          where: { userId: user.id, roleId: role.id, hospitalId },
+        });
+        if (!existingRole) {
+          await userRolesRepo.save(
+            userRolesRepo.create({
+              userId: user.id,
+              roleId: role.id,
+              hospitalId,
+            }),
+          );
+        }
+
+        // Expire any prior pending invite for this email so the unique index allows a new one.
+        await invitesRepo
+          .createQueryBuilder()
+          .update(StaffInvite)
+          .set({ expiresAt: new Date() })
+          .where('hospital_id = :hospitalId', { hospitalId })
+          .andWhere('LOWER(email) = LOWER(:email)', { email })
+          .andWhere('accepted_at IS NULL')
+          .execute();
+
+        const staff = await staffRepo.save(
+          staffRepo.create({
+            userId: user.id,
+            hospitalId,
+            phone: input.phone,
+            department: input.department,
+            specialization: input.specialization,
+            employeeId: input.employeeId,
+          }),
+        );
+
+        await invitesRepo.save(
+          invitesRepo.create({
+            hospitalId,
+            email,
+            fullName: input.fullName,
+            roleSlug: input.roleSlug,
+            token,
+            staffProfileId: staff.id,
+            expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+          }),
+        );
+
+        return staff.id;
+      });
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new ConflictException(
+          'Staff profile or pending invite already exists for this email',
         );
       }
-      if (!user.hospitalId) {
-        await this.usersRepo.update(user.id, {
-          hospitalId,
-          fullName: input.fullName,
-          authId,
-        });
-        user.hospitalId = hospitalId;
-        user.authId = authId;
-      }
-    } else {
-      user = await this.usersRepo.save(
-        this.usersRepo.create({
-          authId,
-          email: input.email,
-          fullName: input.fullName,
-          hospitalId,
-          onboardingCompleted: true,
-        }),
-      );
+      throw error;
     }
-
-    const existingRole = await this.userRolesRepo.findOne({
-      where: { userId: user.id, roleId: role.id, hospitalId },
-    });
-    if (!existingRole) {
-      await this.userRolesRepo.save(
-        this.userRolesRepo.create({
-          userId: user.id,
-          roleId: role.id,
-          hospitalId,
-        }),
-      );
-    }
-
-    const staff = await this.staffRepo.save(
-      this.staffRepo.create({
-        userId: user.id,
-        hospitalId,
-        phone: input.phone,
-        department: input.department,
-        specialization: input.specialization,
-        employeeId: input.employeeId,
-      }),
-    );
-
-    const token = randomBytes(32).toString('hex');
-    await this.invitesRepo.save(
-      this.invitesRepo.create({
-        hospitalId,
-        email: input.email,
-        fullName: input.fullName,
-        roleSlug: input.roleSlug,
-        token,
-        staffProfileId: staff.id,
-        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-      }),
-    );
 
     await this.audit.log({
       actorId: actor.id,
       hospitalId,
       action: 'create',
       resource: 'staff',
-      resourceId: staff.id,
-      metadata: { email: input.email, roleSlug: input.roleSlug },
+      resourceId: staffId,
+      metadata: { email, roleSlug: input.roleSlug },
     });
 
-    // Attach invite token for GraphQL response (not persisted on entity)
+    const staff = (await this.findById(staffId))!;
     (staff as StaffProfile & { inviteToken?: string }).inviteToken = token;
     return staff;
   }
@@ -322,54 +370,69 @@ export class StaffService {
     authId: string,
     email: string,
   ): Promise<StaffProfile> {
-    const invite = await this.invitesRepo.findOne({ where: { token } });
-    if (!invite) throw new NotFoundException('Invite not found');
-    if (invite.acceptedAt)
-      throw new UnauthorizedException('Invite already accepted');
-    if (invite.expiresAt < new Date())
-      throw new UnauthorizedException('Invite expired');
-    if (invite.email.toLowerCase() !== email.toLowerCase()) {
-      throw new ForbiddenException(
-        'Invite email does not match signed-in user',
-      );
-    }
+    const staffId = await this.invitesRepo.manager.transaction(async (manager) => {
+      const invitesRepo = manager.getRepository(StaffInvite);
+      const usersRepo = manager.getRepository(User);
+      const staffRepo = manager.getRepository(StaffProfile);
 
-    const staff = invite.staffProfileId
-      ? await this.findById(invite.staffProfileId)
-      : null;
-    if (!staff) throw new NotFoundException('Staff profile missing for invite');
-    if (!staff.isActive) {
-      throw new ForbiddenException(
-        'This staff account has been deactivated; contact a hospital administrator',
-      );
-    }
+      const invite = await invitesRepo
+        .createQueryBuilder('invite')
+        .setLock('pessimistic_write')
+        .where('invite.token = :token', { token })
+        .getOne();
+      if (!invite) throw new NotFoundException('Invite not found');
+      if (invite.acceptedAt)
+        throw new UnauthorizedException('Invite already accepted');
+      if (invite.expiresAt < new Date())
+        throw new UnauthorizedException('Invite expired');
+      if (invite.email.toLowerCase() !== email.toLowerCase()) {
+        throw new ForbiddenException(
+          'Invite email does not match signed-in user',
+        );
+      }
 
-    const invitee = await this.usersRepo.findOne({
-      where: { id: staff.userId },
+      const staff = invite.staffProfileId
+        ? await staffRepo.findOne({
+            where: { id: invite.staffProfileId },
+            relations: ['user', 'user.userRoles', 'user.userRoles.role'],
+          })
+        : null;
+      if (!staff) throw new NotFoundException('Staff profile missing for invite');
+      if (!staff.isActive) {
+        throw new ForbiddenException(
+          'This staff account has been deactivated; contact a hospital administrator',
+        );
+      }
+
+      const invitee = await usersRepo.findOne({
+        where: { id: staff.userId },
+      });
+      if (invitee && invitee.isActive === false) {
+        throw new ForbiddenException(
+          'This account has been deactivated; contact a hospital administrator',
+        );
+      }
+      if (invitee?.hospitalId && invitee.hospitalId !== invite.hospitalId) {
+        throw new BadRequestException(
+          'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
+        );
+      }
+
+      await usersRepo.update(staff.userId, {
+        authId,
+        onboardingCompleted: true,
+        hospitalId: invite.hospitalId,
+        isActive: true,
+      });
+
+      invite.acceptedAt = new Date();
+      await invitesRepo.save(invite);
+      return staff.id;
     });
-    if (invitee && invitee.isActive === false) {
-      throw new ForbiddenException(
-        'This account has been deactivated; contact a hospital administrator',
-      );
-    }
-    if (invitee?.hospitalId && invitee.hospitalId !== invite.hospitalId) {
-      throw new BadRequestException(
-        'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
-      );
-    }
 
-    await this.usersRepo.update(staff.userId, {
-      authId,
-      onboardingCompleted: true,
-      hospitalId: invite.hospitalId,
-      isActive: true,
-    });
-
-    invite.acceptedAt = new Date();
-    await this.invitesRepo.save(invite);
-
-    return (await this.findById(staff.id))!;
+    return (await this.findById(staffId))!;
   }
+
 
   toStaffType(staff: StaffProfile & { inviteToken?: string }) {
     const roleSlug = staff.user?.userRoles?.[0]?.role?.slug ?? 'staff';

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -370,69 +370,71 @@ export class StaffService {
     authId: string,
     email: string,
   ): Promise<StaffProfile> {
-    const staffId = await this.invitesRepo.manager.transaction(async (manager) => {
-      const invitesRepo = manager.getRepository(StaffInvite);
-      const usersRepo = manager.getRepository(User);
-      const staffRepo = manager.getRepository(StaffProfile);
+    const staffId = await this.invitesRepo.manager.transaction(
+      async (manager) => {
+        const invitesRepo = manager.getRepository(StaffInvite);
+        const usersRepo = manager.getRepository(User);
+        const staffRepo = manager.getRepository(StaffProfile);
 
-      const invite = await invitesRepo
-        .createQueryBuilder('invite')
-        .setLock('pessimistic_write')
-        .where('invite.token = :token', { token })
-        .getOne();
-      if (!invite) throw new NotFoundException('Invite not found');
-      if (invite.acceptedAt)
-        throw new UnauthorizedException('Invite already accepted');
-      if (invite.expiresAt < new Date())
-        throw new UnauthorizedException('Invite expired');
-      if (invite.email.toLowerCase() !== email.toLowerCase()) {
-        throw new ForbiddenException(
-          'Invite email does not match signed-in user',
-        );
-      }
+        const invite = await invitesRepo
+          .createQueryBuilder('invite')
+          .setLock('pessimistic_write')
+          .where('invite.token = :token', { token })
+          .getOne();
+        if (!invite) throw new NotFoundException('Invite not found');
+        if (invite.acceptedAt)
+          throw new UnauthorizedException('Invite already accepted');
+        if (invite.expiresAt < new Date())
+          throw new UnauthorizedException('Invite expired');
+        if (invite.email.toLowerCase() !== email.toLowerCase()) {
+          throw new ForbiddenException(
+            'Invite email does not match signed-in user',
+          );
+        }
 
-      const staff = invite.staffProfileId
-        ? await staffRepo.findOne({
-            where: { id: invite.staffProfileId },
-            relations: ['user', 'user.userRoles', 'user.userRoles.role'],
-          })
-        : null;
-      if (!staff) throw new NotFoundException('Staff profile missing for invite');
-      if (!staff.isActive) {
-        throw new ForbiddenException(
-          'This staff account has been deactivated; contact a hospital administrator',
-        );
-      }
+        const staff = invite.staffProfileId
+          ? await staffRepo.findOne({
+              where: { id: invite.staffProfileId },
+              relations: ['user', 'user.userRoles', 'user.userRoles.role'],
+            })
+          : null;
+        if (!staff)
+          throw new NotFoundException('Staff profile missing for invite');
+        if (!staff.isActive) {
+          throw new ForbiddenException(
+            'This staff account has been deactivated; contact a hospital administrator',
+          );
+        }
 
-      const invitee = await usersRepo.findOne({
-        where: { id: staff.userId },
-      });
-      if (invitee && invitee.isActive === false) {
-        throw new ForbiddenException(
-          'This account has been deactivated; contact a hospital administrator',
-        );
-      }
-      if (invitee?.hospitalId && invitee.hospitalId !== invite.hospitalId) {
-        throw new BadRequestException(
-          'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
-        );
-      }
+        const invitee = await usersRepo.findOne({
+          where: { id: staff.userId },
+        });
+        if (invitee && invitee.isActive === false) {
+          throw new ForbiddenException(
+            'This account has been deactivated; contact a hospital administrator',
+          );
+        }
+        if (invitee?.hospitalId && invitee.hospitalId !== invite.hospitalId) {
+          throw new BadRequestException(
+            'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
+          );
+        }
 
-      await usersRepo.update(staff.userId, {
-        authId,
-        onboardingCompleted: true,
-        hospitalId: invite.hospitalId,
-        isActive: true,
-      });
+        await usersRepo.update(staff.userId, {
+          authId,
+          onboardingCompleted: true,
+          hospitalId: invite.hospitalId,
+          isActive: true,
+        });
 
-      invite.acceptedAt = new Date();
-      await invitesRepo.save(invite);
-      return staff.id;
-    });
+        invite.acceptedAt = new Date();
+        await invitesRepo.save(invite);
+        return staff.id;
+      },
+    );
 
     return (await this.findById(staffId))!;
   }
-
 
   toStaffType(staff: StaffProfile & { inviteToken?: string }) {
     const roleSlug = staff.user?.userRoles?.[0]?.role?.slug ?? 'staff';

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -76,11 +76,14 @@ export class UploadsController {
     this.uploadsService.assertCanUpload(req.user);
 
     if (!file) throw new BadRequestException('file is required');
-    const base =
-      process.env.API_PUBLIC_URL?.replace(/\/$/, '') ||
-      `${req.protocol}://${req.get('host')}`;
+    // Prefer configured public base; otherwise return a stable relative path
+    // so client-controlled Host headers cannot poison stored document URLs.
+    const configured = process.env.API_PUBLIC_URL?.replace(/\/$/, '');
+    const url = configured
+      ? `${configured}/uploads/${file.filename}`
+      : `/uploads/${file.filename}`;
     return {
-      url: `${base}/uploads/${file.filename}`,
+      url,
       fileName: file.originalname,
       fileType: file.mimetype,
       size: file.size,

--- a/apps/api/src/users/users.resolver.ts
+++ b/apps/api/src/users/users.resolver.ts
@@ -60,7 +60,7 @@ export class UsersResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('fullName') fullName: string,
   ): Promise<UserType> {
-    await this.authService.completePatientOnboarding(user.id, fullName);
+    await this.authService.completePatientOnboarding(user, fullName);
     const refreshed = await this.authService.syncAndGetUser(
       user.authId,
       user.email,

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -53,19 +53,18 @@ export default function DashboardPage() {
       ['hospital_admin', 'hospital_manager', 'super_admin', 'receptionist', 'nurse'].includes(r),
     );
 
-  const { data: staffData } = useQuery(STAFF_MEMBERS_QUERY, {
+  const { data: staffData, error: staffError } = useQuery(STAFF_MEMBERS_QUERY, {
     variables: { hospitalId },
-    skip: !hospitalId,
+    skip: !hospitalId || !(me?.permissions ?? []).includes('staff:read'),
   });
-  const { data: patientsData } = useQuery(PATIENTS_QUERY, {
+  const { data: patientsData, error: patientsError } = useQuery(PATIENTS_QUERY, {
     variables: { page: 1, limit: 1, hospitalId },
-    skip: !hospitalId,
+    skip: !hospitalId || !(me?.permissions ?? []).includes('patients:read'),
   });
 
-  const { data: statsData } = useQuery(DASHBOARD_STATS_QUERY, {
+  const { data: statsData, error: statsError } = useQuery(DASHBOARD_STATS_QUERY, {
     variables: { hospitalId },
-    skip: !hospitalId,
-    errorPolicy: 'ignore',
+    skip: !hospitalId || !(me?.permissions ?? []).includes('reports:read'),
   });
 
   const { data: appointmentsData } = useQuery(APPOINTMENTS_QUERY, {
@@ -75,29 +74,43 @@ export default function DashboardPage() {
       ...(isDoctorOnly && me?.id ? { doctorId: me.id } : {}),
     },
     skip: !hospitalId || !!statsData?.dashboardStats,
-    errorPolicy: 'ignore',
   });
 
   const { data: admissionsData } = useQuery(ACTIVE_ADMISSIONS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId || !!statsData?.dashboardStats,
-    errorPolicy: 'ignore',
   });
 
-  const staffCount = staffData?.staffMembers?.length ?? 0;
-  const patientCount = patientsData?.patients?.total ?? 0;
+  const canReadStaff = (me?.permissions ?? []).includes('staff:read');
+  const canReadPatients = (me?.permissions ?? []).includes('patients:read');
+  const staffCount = canReadStaff
+    ? staffError
+      ? '—'
+      : (staffData?.staffMembers?.length ?? 0)
+    : '—';
+  const patientCount = canReadPatients
+    ? patientsError
+      ? '—'
+      : (patientsData?.patients?.total ?? 0)
+    : '—';
 
   const appointmentsToday =
-    statsData?.dashboardStats?.appointmentsToday ??
-    appointmentsData?.appointments?.length ??
-    '—';
+    statsError && !appointmentsData
+      ? '—'
+      : (statsData?.dashboardStats?.appointmentsToday ??
+        appointmentsData?.appointments?.length ??
+        '—');
 
   const activeAdmissions =
-    statsData?.dashboardStats?.activeAdmissions ??
-    admissionsData?.activeAdmissions?.length ??
-    '—';
+    statsError && !admissionsData
+      ? '—'
+      : (statsData?.dashboardStats?.activeAdmissions ??
+        admissionsData?.activeAdmissions?.length ??
+        '—');
 
   const hasAppointments = typeof appointmentsToday === 'number' && appointmentsToday > 0;
+  const hasStaff = typeof staffCount === 'number' && staffCount > 0;
+  const hasPatients = typeof patientCount === 'number' && patientCount > 0;
 
   const access = {
     roles: me?.roles ?? [],
@@ -148,8 +161,8 @@ export default function DashboardPage() {
           <ul className="space-y-3">
             {[
               { done: !!meData?.me?.onboardingCompleted, text: 'Complete onboarding' },
-              { done: staffCount > 0, text: 'Add your first staff member' },
-              { done: patientCount > 0, text: 'Register your first patient' },
+              { done: hasStaff, text: 'Add your first staff member' },
+              { done: hasPatients, text: 'Register your first patient' },
               { done: hasAppointments, text: 'Set up appointment scheduling (Phase 3)' },
             ].map((item) => (
               <li key={item.text} className="flex items-center gap-3 text-sm">

--- a/apps/web/src/app/(dashboard)/finance/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/page.tsx
@@ -16,10 +16,9 @@ export default function FinancePage() {
     skip: !hospitalId,
   });
 
-  const { data: reportsData } = useQuery(HOSPITAL_REPORTS_QUERY, {
+  const { data: reportsData, error: reportsError } = useQuery(HOSPITAL_REPORTS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
-    errorPolicy: 'ignore',
   });
 
   const invoices = invoicesData?.invoices ?? [];
@@ -27,7 +26,14 @@ export default function FinancePage() {
     (inv: { status: string }) => inv.status === 'draft' || inv.status === 'issued',
   ).length;
   const paid = invoices.filter((inv: { status: string }) => inv.status === 'paid').length;
-  const revenueTotal = reportsData?.hospitalReports?.revenueTotal ?? 0;
+  const revenueTotal = reportsData?.hospitalReports?.revenueTotal;
+  const revenueDisplay =
+    reportsError || revenueTotal == null
+      ? '—'
+      : `$${Number(revenueTotal).toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })}`;
   const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
 
   return (
@@ -51,7 +57,7 @@ export default function FinancePage() {
       <div className="mb-8 grid gap-6 md:grid-cols-3">
         <ClayStatCard
           title="Total Revenue"
-          value={`$${revenueTotal.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+          value={revenueDisplay}
           icon={<DollarSign className="h-5 w-5" />}
         />
         <ClayStatCard title="Outstanding Invoices" value={outstanding} icon={<FileText className="h-5 w-5" />} />

--- a/apps/web/src/app/(dashboard)/inventory/page.tsx
+++ b/apps/web/src/app/(dashboard)/inventory/page.tsx
@@ -23,6 +23,7 @@ export default function InventoryPage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canWrite = (meData?.me?.permissions ?? []).includes('patients:write');
 
   const { data, loading, refetch } = useQuery(INVENTORY_ITEMS_QUERY, {
     variables: { hospitalId },
@@ -91,16 +92,18 @@ export default function InventoryPage() {
       />
 
       <div className="mb-6 flex justify-end">
-        <ClayButton onClick={() => setShowForm(!showForm)}>
-          {showForm ? 'Hide Form' : 'Add Item'}
-        </ClayButton>
+        {canWrite ? (
+          <ClayButton onClick={() => setShowForm(!showForm)}>
+            {showForm ? 'Hide Form' : 'Add Item'}
+          </ClayButton>
+        ) : null}
       </div>
 
       {error ? (
         <p className="mb-4 rounded-2xl bg-red-50 px-4 py-2 text-sm text-clay-error">{error}</p>
       ) : null}
 
-      {showForm ? (
+      {showForm && canWrite ? (
         <ClayCard className="mb-6 max-w-2xl">
           <h2 className="mb-4 text-lg font-semibold text-clay-text">Add Inventory Item</h2>
           <form onSubmit={handleCreate} className="space-y-4">
@@ -180,24 +183,26 @@ export default function InventoryPage() {
                     <ClayBadge variant={lowStock ? 'warning' : 'success'}>
                       {item.quantity} {item.unit}
                     </ClayBadge>
-                    <div className="flex gap-1">
-                      <ClayButton
-                        size="sm"
-                        variant="secondary"
-                        disabled={updating}
-                        onClick={() => handleAdjust(item.id, item.quantity, -1)}
-                      >
-                        −
-                      </ClayButton>
-                      <ClayButton
-                        size="sm"
-                        variant="secondary"
-                        disabled={updating}
-                        onClick={() => handleAdjust(item.id, item.quantity, 1)}
-                      >
-                        +
-                      </ClayButton>
-                    </div>
+                    {canWrite ? (
+                      <div className="flex gap-1">
+                        <ClayButton
+                          size="sm"
+                          variant="secondary"
+                          disabled={updating}
+                          onClick={() => handleAdjust(item.id, item.quantity, -1)}
+                        >
+                          −
+                        </ClayButton>
+                        <ClayButton
+                          size="sm"
+                          variant="secondary"
+                          disabled={updating}
+                          onClick={() => handleAdjust(item.id, item.quantity, 1)}
+                        >
+                          +
+                        </ClayButton>
+                      </div>
+                    ) : null}
                   </div>
                 );
               },

--- a/apps/web/src/app/(dashboard)/lab/page.tsx
+++ b/apps/web/src/app/(dashboard)/lab/page.tsx
@@ -43,6 +43,7 @@ export default function LabPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
   const canCreateOrders = (meData?.me?.permissions ?? []).includes('patients:write');
+  const canWriteLab = (meData?.me?.permissions ?? []).includes('lab:write');
 
   const { data, loading, refetch } = useQuery(LAB_ORDERS_QUERY, {
     variables: { hospitalId, status: undefined },
@@ -242,6 +243,7 @@ export default function LabPage() {
           )}
         </ClayCard>
 
+        {canWriteLab ? (
         <ClayCard>
           <h2 className="mb-4 text-lg font-semibold text-clay-text">Enter Result</h2>
           {selectedOrderId ? (
@@ -278,6 +280,7 @@ export default function LabPage() {
             </p>
           )}
         </ClayCard>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/pharmacy/page.tsx
+++ b/apps/web/src/app/(dashboard)/pharmacy/page.tsx
@@ -21,6 +21,7 @@ export default function PharmacyPage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canWrite = (meData?.me?.permissions ?? []).includes('patients:write');
 
   const { data: rxData, loading: rxLoading, refetch: refetchRx } = useQuery(
     PENDING_PRESCRIPTIONS_QUERY,
@@ -129,13 +130,15 @@ export default function PharmacyPage() {
                         ))}
                       </ul>
                     </div>
-                    <ClayButton
-                      size="sm"
-                      isLoading={dispensing}
-                      onClick={() => handleDispense(rx.id)}
-                    >
-                      Dispense
-                    </ClayButton>
+                    {canWrite ? (
+                      <ClayButton
+                        size="sm"
+                        isLoading={dispensing}
+                        onClick={() => handleDispense(rx.id)}
+                      >
+                        Dispense
+                      </ClayButton>
+                    ) : null}
                   </div>
                 ),
               )}
@@ -144,6 +147,7 @@ export default function PharmacyPage() {
         </ClayCard>
 
         <div className="space-y-6">
+          {canWrite ? (
           <ClayCard>
             <h2 className="mb-4 text-lg font-semibold text-clay-text">Update Stock</h2>
             <form onSubmit={handleStockSubmit} className="space-y-4">
@@ -174,6 +178,7 @@ export default function PharmacyPage() {
               </ClayButton>
             </form>
           </ClayCard>
+          ) : null}
 
           <ClayCard padding="none" className="overflow-hidden">
             <div className="border-b border-white/40 bg-clay-primary-light/30 px-6 py-4">

--- a/apps/web/src/app/(dashboard)/settings/facility/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/facility/page.tsx
@@ -42,6 +42,7 @@ interface Bed {
 export default function FacilitySettingsPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canWriteFacility = (meData?.me?.permissions ?? []).includes('hospitals:write');
 
   const [selectedWardId, setSelectedWardId] = useState<string | null>(null);
   const [deptName, setDeptName] = useState('');
@@ -224,6 +225,7 @@ export default function FacilitySettingsPage() {
             <h2 className="text-lg font-semibold text-clay-text">Departments</h2>
           </div>
 
+          {canWriteFacility ? (
           <form onSubmit={handleCreateDept} className="mb-4 space-y-3">
             <ClayInput
               label="Name *"
@@ -243,6 +245,7 @@ export default function FacilitySettingsPage() {
               Add Department
             </ClayButton>
           </form>
+          ) : null}
 
           <div className="space-y-2">
             {departmentsQuery.loading ? (
@@ -261,6 +264,8 @@ export default function FacilitySettingsPage() {
                       <p className="text-xs text-clay-text-muted">{d.description}</p>
                     ) : null}
                   </div>
+                  {canWriteFacility ? (
+
                   <ClayButton
                     type="button"
                     size="sm"
@@ -274,6 +279,8 @@ export default function FacilitySettingsPage() {
                   >
                     <Trash2 className="h-4 w-4 text-clay-error" />
                   </ClayButton>
+
+                  ) : null}
                 </div>
               ))
             )}
@@ -286,6 +293,7 @@ export default function FacilitySettingsPage() {
             <h2 className="text-lg font-semibold text-clay-text">Wards</h2>
           </div>
 
+          {canWriteFacility ? (
           <form onSubmit={handleCreateWard} className="mb-4 space-y-3">
             <ClayInput
               label="Name *"
@@ -323,6 +331,7 @@ export default function FacilitySettingsPage() {
               Add Ward
             </ClayButton>
           </form>
+          ) : null}
 
           <div className="space-y-2">
             {wardsQuery.loading ? (
@@ -351,6 +360,8 @@ export default function FacilitySettingsPage() {
                         <p className="text-xs text-clay-text-muted">Floor {w.floor}</p>
                       ) : null}
                     </button>
+                    {canWriteFacility ? (
+
                     <ClayButton
                       type="button"
                       size="sm"
@@ -364,6 +375,8 @@ export default function FacilitySettingsPage() {
                     >
                       <Trash2 className="h-4 w-4 text-clay-error" />
                     </ClayButton>
+
+                    ) : null}
                   </div>
                 );
               })
@@ -378,7 +391,8 @@ export default function FacilitySettingsPage() {
           </div>
 
           {selectedWardId ? (
-            <form onSubmit={handleCreateBed} className="mb-4 space-y-3">
+            {canWriteFacility ? (
+          <form onSubmit={handleCreateBed} className="mb-4 space-y-3">
               <ClayInput
                 label="Label *"
                 value={bedLabel}
@@ -391,6 +405,7 @@ export default function FacilitySettingsPage() {
                 Add Bed
               </ClayButton>
             </form>
+          ) : null}
           ) : (
             <p className="mb-4 rounded-2xl bg-clay-primary-light/20 px-3 py-2 text-sm text-clay-text-muted">
               <DoorClosed className="mr-1 inline-block h-4 w-4 align-text-bottom" />
@@ -427,6 +442,8 @@ export default function FacilitySettingsPage() {
                       {b.status}
                     </ClayBadge>
                     {b.status !== 'occupied' ? (
+                      {canWriteFacility ? (
+
                       <ClayButton
                         type="button"
                         size="sm"
@@ -440,6 +457,8 @@ export default function FacilitySettingsPage() {
                       >
                         <Trash2 className="h-4 w-4 text-clay-error" />
                       </ClayButton>
+
+                      ) : null}
                     ) : null}
                   </div>
                 </div>

--- a/apps/web/src/app/(dashboard)/settings/facility/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/facility/page.tsx
@@ -391,8 +391,8 @@ export default function FacilitySettingsPage() {
           </div>
 
           {selectedWardId ? (
-            {canWriteFacility ? (
-          <form onSubmit={handleCreateBed} className="mb-4 space-y-3">
+            canWriteFacility ? (
+              <form onSubmit={handleCreateBed} className="mb-4 space-y-3">
               <ClayInput
                 label="Label *"
                 value={bedLabel}
@@ -405,7 +405,7 @@ export default function FacilitySettingsPage() {
                 Add Bed
               </ClayButton>
             </form>
-          ) : null}
+            ) : null
           ) : (
             <p className="mb-4 rounded-2xl bg-clay-primary-light/20 px-3 py-2 text-sm text-clay-text-muted">
               <DoorClosed className="mr-1 inline-block h-4 w-4 align-text-bottom" />
@@ -441,9 +441,7 @@ export default function FacilitySettingsPage() {
                     >
                       {b.status}
                     </ClayBadge>
-                    {b.status !== 'occupied' ? (
-                      {canWriteFacility ? (
-
+                    {b.status !== 'occupied' && canWriteFacility ? (
                       <ClayButton
                         type="button"
                         size="sm"
@@ -457,8 +455,6 @@ export default function FacilitySettingsPage() {
                       >
                         <Trash2 className="h-4 w-4 text-clay-error" />
                       </ClayButton>
-
-                      ) : null}
                     ) : null}
                   </div>
                 </div>

--- a/apps/web/src/app/(dashboard)/wards/page.tsx
+++ b/apps/web/src/app/(dashboard)/wards/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 
+/** Legacy /wards route — send users to occupancy they can actually access. */
 export default function WardsPage() {
-  redirect('/settings/facility');
+  redirect('/admissions/occupancy');
 }

--- a/apps/web/src/app/(portal)/portal-layout-client.tsx
+++ b/apps/web/src/app/(portal)/portal-layout-client.tsx
@@ -95,6 +95,11 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
     );
   }
 
+  // Fail closed: non-patient authenticated users must not mount portal PHI pages.
+  if (me && !isPatient && me.onboardingCompleted) {
+    return <ForbiddenAccess />;
+  }
+
   if (onboardingError) {
     const retryFullName =
       (typeof user?.unsafeMetadata?.fullName === 'string' && user.unsafeMetadata.fullName) ||
@@ -129,12 +134,6 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
       </a>
       <PortalSidebar />
       <main id="portal-main" className="flex-1 overflow-auto">
-        {!isPatient && me?.onboardingCompleted ? (
-          <p className="mb-4 rounded-2xl bg-clay-warning/10 p-4 text-sm text-clay-text">
-            Your account is not a patient portal user. If you are hospital staff, use the
-            dashboard instead.
-          </p>
-        ) : null}
         {children}
       </main>
     </div>

--- a/apps/web/src/app/(portal)/portal/appointments/page.tsx
+++ b/apps/web/src/app/(portal)/portal/appointments/page.tsx
@@ -49,8 +49,7 @@ export default function PortalAppointmentsPage() {
         ) : error ? (
           <div className="px-6 py-8">
             <PortalQueryError
-              message={error.message || 'We could not load your appointments.'}
-              onRetry={() => refetch()}
+      onRetry={() => refetch()}
             />
           </div>
         ) : !patient ? (

--- a/apps/web/src/app/(portal)/portal/lab-results/page.tsx
+++ b/apps/web/src/app/(portal)/portal/lab-results/page.tsx
@@ -22,8 +22,7 @@ export default function PortalLabResultsPage() {
         ) : error ? (
           <div className="px-6 py-8">
             <PortalQueryError
-              message={error.message || 'We could not load your lab results.'}
-              onRetry={() => refetch()}
+      onRetry={() => refetch()}
             />
           </div>
         ) : !patient ? (

--- a/apps/web/src/app/(portal)/portal/page.tsx
+++ b/apps/web/src/app/(portal)/portal/page.tsx
@@ -58,8 +58,7 @@ export default function PortalDashboardPage() {
         <p className="text-clay-text-muted">Loading your health records...</p>
       ) : error ? (
         <PortalQueryError
-          message={error.message || 'We could not load your health records.'}
-          onRetry={() => refetch()}
+      onRetry={() => refetch()}
         />
       ) : !patient ? (
         <ClayCard>

--- a/apps/web/src/app/(portal)/portal/prescriptions/page.tsx
+++ b/apps/web/src/app/(portal)/portal/prescriptions/page.tsx
@@ -25,8 +25,7 @@ export default function PortalPrescriptionsPage() {
         ) : error ? (
           <div className="px-6 py-8">
             <PortalQueryError
-              message={error.message || 'We could not load your prescriptions.'}
-              onRetry={() => refetch()}
+      onRetry={() => refetch()}
             />
           </div>
         ) : !patient ? (

--- a/apps/web/src/app/(portal)/portal/profile/page.tsx
+++ b/apps/web/src/app/(portal)/portal/profile/page.tsx
@@ -41,8 +41,7 @@ export default function PortalProfilePage() {
             <p className="text-sm text-clay-text-muted">Loading profile...</p>
           ) : error ? (
             <PortalQueryError
-              message={error.message || 'We could not load your patient record.'}
-              onRetry={() => refetch()}
+      onRetry={() => refetch()}
             />
           ) : !patient ? (
             <p className="text-sm text-clay-text-muted">

--- a/apps/web/src/app/(portal)/portal/records/page.tsx
+++ b/apps/web/src/app/(portal)/portal/records/page.tsx
@@ -25,8 +25,7 @@ export default function PortalRecordsPage() {
         <p className="text-clay-text-muted">Loading records...</p>
       ) : error ? (
         <PortalQueryError
-          message={error.message || 'We could not load your medical records.'}
-          onRetry={() => refetch()}
+      onRetry={() => refetch()}
         />
       ) : !patient ? (
         <ClayCard>

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -9,6 +9,7 @@ import { useSignIn } from '@clerk/nextjs';
 import { loginSchema, type LoginInput } from '@careconnect/types';
 import { useTranslations } from 'next-intl';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
+import { safeInternalPath } from '@/lib/safe-redirect';
 
 export function LoginForm() {
   const t = useTranslations('auth');
@@ -18,7 +19,7 @@ export function LoginForm() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  const redirectTo = searchParams.get('redirect') ?? '/dashboard';
+  const redirectTo = safeInternalPath(searchParams.get('redirect'), '/dashboard');
 
   const {
     register,

--- a/apps/web/src/components/auth/register-form.tsx
+++ b/apps/web/src/components/auth/register-form.tsx
@@ -10,6 +10,7 @@ import { useMutation } from '@apollo/client';
 import { registerSchema, type RegisterInput } from '@careconnect/types';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
 import { COMPLETE_PATIENT_ONBOARDING } from '@/lib/graphql/queries';
+import { safeInternalPath } from '@/lib/safe-redirect';
 
 export function RegisterForm() {
   const router = useRouter();
@@ -21,7 +22,8 @@ export function RegisterForm() {
   const [code, setCode] = useState('');
   const [completePatientOnboarding] = useMutation(COMPLETE_PATIENT_ONBOARDING);
 
-  const redirectTo = searchParams.get('redirect') ?? '/onboarding';
+  const redirectTo = safeInternalPath(searchParams.get('redirect'), '/onboarding');
+  const isStaffInviteFlow = redirectTo.startsWith('/invite/');
 
   const {
     register,
@@ -31,12 +33,20 @@ export function RegisterForm() {
     formState: { errors },
   } = useForm<RegisterInput>({
     resolver: zodResolver(registerSchema),
-    defaultValues: { accountType: 'hospital' },
+    defaultValues: {
+      accountType: 'hospital',
+      hospitalName: isStaffInviteFlow ? 'Staff invite' : undefined,
+    },
   });
 
   const accountType = watch('accountType');
 
   const finishSignup = async (fullName: string, type: RegisterInput['accountType']) => {
+    if (isStaffInviteFlow) {
+      router.push(redirectTo);
+      router.refresh();
+      return;
+    }
     if (type === 'patient') {
       try {
         await completePatientOnboarding({ variables: { fullName } });
@@ -110,7 +120,7 @@ export function RegisterForm() {
     if (!isLoaded) return;
     setError('');
     try {
-      const type = getValues('accountType');
+      const type = isStaffInviteFlow ? 'hospital' : getValues('accountType');
       const fullName = getValues('fullName');
       // Persist account type before OAuth so post-login can finish patient onboarding
       await signUp.create({
@@ -120,14 +130,15 @@ export function RegisterForm() {
           hospitalName: getValues('hospitalName'),
         },
       });
-      const dest =
-        type === 'patient'
+      const dest = isStaffInviteFlow
+        ? redirectTo
+        : type === 'patient'
           ? '/portal?completePatient=1'
           : '/onboarding';
       await signUp.authenticateWithRedirect({
         strategy: 'oauth_google',
         redirectUrl: '/auth/callback',
-        redirectUrlComplete: dest,
+        redirectUrlComplete: safeInternalPath(dest, '/onboarding'),
       });
     } catch (err) {
       setError(extractClerkError(err));
@@ -167,13 +178,22 @@ export function RegisterForm() {
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
           <label className="text-sm font-medium text-clay-text">Account Type</label>
-          <select
-            className="w-full rounded-2xl border border-white/60 bg-clay-surface px-4 py-3 text-clay-text shadow-clay-inset outline-none focus:ring-2 focus:ring-clay-primary/30"
-            {...register('accountType')}
-          >
-            <option value="hospital">Hospital Administrator</option>
-            <option value="patient">Patient</option>
-          </select>
+          {isStaffInviteFlow ? (
+            <>
+              <input type="hidden" {...register('accountType')} value="hospital" />
+              <p className="rounded-2xl bg-clay-surface px-4 py-3 text-sm text-clay-text">
+                Staff invite — you will return to accept your hospital invitation after signup.
+              </p>
+            </>
+          ) : (
+            <select
+              className="w-full rounded-2xl border border-white/60 bg-clay-surface px-4 py-3 text-clay-text shadow-clay-inset outline-none focus:ring-2 focus:ring-clay-primary/30"
+              {...register('accountType')}
+            >
+              <option value="hospital">Hospital Administrator</option>
+              <option value="patient">Patient</option>
+            </select>
+          )}
           <p className="text-xs text-clay-text-muted">
             Hospital staff join with an invite link from your administrator — not via public
             signup.
@@ -187,7 +207,7 @@ export function RegisterForm() {
           {...register('fullName')}
         />
 
-        {accountType === 'hospital' ? (
+        {accountType === 'hospital' && !isStaffInviteFlow ? (
           <ClayInput
             label="Hospital Name"
             placeholder="City General Hospital"

--- a/apps/web/src/lib/safe-redirect.ts
+++ b/apps/web/src/lib/safe-redirect.ts
@@ -1,0 +1,22 @@
+/**
+ * Validate post-auth redirect targets to prevent open redirects.
+ * Only same-origin relative paths are allowed (no protocol-relative //evil).
+ */
+export function safeInternalPath(
+  raw: string | null | undefined,
+  fallback: string,
+): string {
+  if (!raw) return fallback;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('/')) return fallback;
+  if (trimmed.startsWith('//') || trimmed.startsWith('/\\')) return fallback;
+  if (trimmed.includes('://') || trimmed.includes('\\')) return fallback;
+  // Block encoded tricks like /%2F%2Fevil.com
+  try {
+    const decoded = decodeURIComponent(trimmed);
+    if (decoded.startsWith('//') || decoded.includes('://')) return fallback;
+  } catch {
+    return fallback;
+  }
+  return trimmed;
+}

--- a/supabase/migrations/20240609000019_patients_user_id_soft_delete.sql
+++ b/supabase/migrations/20240609000019_patients_user_id_soft_delete.sql
@@ -1,0 +1,14 @@
+-- Soft-deleted patients must not reserve portal user bindings.
+-- Clear any leftover user_id on already soft-deleted rows, then replace
+-- the unique index so only active charts participate.
+
+UPDATE patients
+SET user_id = NULL
+WHERE deleted_at IS NOT NULL
+  AND user_id IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_patients_user_id;
+
+CREATE UNIQUE INDEX idx_patients_user_id
+  ON patients (user_id)
+  WHERE user_id IS NOT NULL AND deleted_at IS NULL;

--- a/supabase/migrations/20240609000020_hospital_manager_staff_write.sql
+++ b/supabase/migrations/20240609000020_hospital_manager_staff_write.sql
@@ -1,0 +1,8 @@
+-- hospital_manager is allowed on staff write resolvers but lacked staff:write.
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.slug = 'hospital_manager'
+  AND p.slug = 'staff:write'
+ON CONFLICT DO NOTHING;

--- a/supabase/migrations/20240609000021_user_roles_platform_unique.sql
+++ b/supabase/migrations/20240609000021_user_roles_platform_unique.sql
@@ -1,0 +1,5 @@
+-- Prevent duplicate platform-scoped roles (NULL hospital_id is distinct in
+-- UNIQUE (user_id, role_id, hospital_id)).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_user_roles_platform_role
+  ON user_roles (user_id, role_id)
+  WHERE hospital_id IS NULL;

--- a/supabase/migrations/20240609000022_lab_results_one_per_order.sql
+++ b/supabase/migrations/20240609000022_lab_results_one_per_order.sql
@@ -1,0 +1,3 @@
+-- One lab result per lab order at the database layer.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_lab_results_one_per_order
+  ON lab_results (lab_order_id);

--- a/supabase/migrations/20240609000023_staff_invites_pending_unique.sql
+++ b/supabase/migrations/20240609000023_staff_invites_pending_unique.sql
@@ -1,0 +1,4 @@
+-- At most one pending staff invite per hospital + email.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_staff_invites_pending_email
+  ON staff_invites (hospital_id, LOWER(email))
+  WHERE accepted_at IS NULL;


### PR DESCRIPTION
## Summary
- Rescan after #100 found **24 confirmed issues** (#101–#124)
- One commit per fix; all land in this PR against `main`
- Covers portal re-link hijack, discharge bed locks, soft-delete portal binding, open redirects, RBAC seed/UI gaps, transactional staff invite flows, and related integrity checks

### Critical / High
| Issue | Fix |
|-------|-----|
| **#101** | Reject portal re-link when chart or user already linked |
| **#102** | Pessimistic bed lock during discharge |
| **#103** | Clear `user_id` on soft-delete + partial unique index |
| **#104** | Safe internal redirect validation on login/register |
| **#105** | Grant `staff:write` to `hospital_manager` |

### Medium / Low
|#106–#124| Patient onboarding guard, staff email case + transactions, active-admission checks, follow-up rescheduled transitions, lab/upload URL hardening, pharmacy/inventory locks, portal fail-closed + generic errors, dashboard/finance false-zero stats, invite signup path, DB uniqueness backstops, `/wards` redirect, write CTA UI gates |

## Test plan
- [ ] API unit tests green (`pnpm --filter api test`)
- [ ] Apply migrations `20240609000019`–`20240609000023` in deployed envs
- [ ] Smoke: discharge frees bed safely; soft-delete then re-link portal user
- [ ] Smoke: `/login?redirect=https://evil.com` stays internal
- [ ] Smoke: staff invite register returns to `/invite/{token}` (no patient bootstrap)
- [ ] Smoke: hospital_manager can invite staff
- [ ] Smoke: accountant dashboard shows `—` not `0` for forbidden counts


Made with [Cursor](https://cursor.com)