### PR TITLE
fix: rescan issues #126–#141

### DIFF
--- a/apps/api/src/admissions/admissions.resolver.ts
+++ b/apps/api/src/admissions/admissions.resolver.ts
@@ -1,10 +1,11 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { PERMISSIONS } from '@careconnect/types';
+import { PERMISSIONS, ROLES } from '@careconnect/types';
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
+import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { AdmissionsService } from './admissions.service';
 import {
@@ -62,6 +63,13 @@ export class AdmissionsResolver {
   }
 
   @Mutation(() => AdmissionType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async dischargeAdmission(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -250,6 +250,7 @@ export class AdmissionsService {
       where: { hospitalId, status: 'active' },
       relations: ['patient', 'attendingDoctor', 'ward', 'bed'],
       order: { admittedAt: 'DESC' },
+      take: 200,
     });
     return admissions.map((a) => this.toAdmissionType(a));
   }

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -13,6 +13,7 @@ describe('AppointmentsService status machine', () => {
   const apptManager = {
     createQueryBuilder: jest.fn(),
     save: jest.fn(),
+    findOne: jest.fn().mockResolvedValue(null),
   };
   const appointmentsRepo = {
     findOne: jest.fn(),
@@ -89,7 +90,13 @@ describe('AppointmentsService status machine', () => {
     mockLockedAppointment({
       id: 'appt-1',
       hospitalId: 'hospital-a',
+      patientId: 'patient-1',
       status: 'scheduled',
+    });
+    apptManager.findOne.mockResolvedValue({
+      id: 'patient-1',
+      hospitalId: 'hospital-a',
+      status: 'registered',
     });
     const result = await service.updateStatus(
       'appt-1',
@@ -98,6 +105,7 @@ describe('AppointmentsService status machine', () => {
       actor,
     );
     expect(result.status).toBe('checked_in');
+    expect(apptManager.save).toHaveBeenCalled();
   });
 
   it('rejects completed → scheduled', async () => {

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -209,6 +209,7 @@ export class AppointmentsService {
       where,
       relations: ['patient', 'doctor'],
       order: { scheduledAt: 'ASC' },
+      take: 200,
     });
 
     return appointments.map((a) => this.toAppointmentType(a));
@@ -265,6 +266,17 @@ export class AppointmentsService {
         assertTransition(appointment.status, status);
         appointment.status = status;
         await manager.save(appointment);
+
+        if (status === 'checked_in') {
+          const patient = await manager.findOne(Patient, {
+            where: { id: appointment.patientId, hospitalId },
+          });
+          if (patient && patient.status === 'registered') {
+            patient.status = 'checked_in';
+            await manager.save(patient);
+          }
+        }
+
         return appointment.id;
       },
     );

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -200,7 +200,7 @@ describe('AuthService', () => {
     it('takes an advisory lock and assigns hospital_admin when none exist', async () => {
       usersRepo.findOne.mockResolvedValue({
         id: 'user-1',
-        hospitalId: undefined,
+        hospitalId: 'hospital-a',
       });
       hospitalsRepo.findOne.mockResolvedValue({ id: 'hospital-a' });
       manager.findOne.mockResolvedValue({
@@ -230,7 +230,7 @@ describe('AuthService', () => {
     it('rejects bootstrap when an admin already exists under the lock', async () => {
       usersRepo.findOne.mockResolvedValue({
         id: 'user-1',
-        hospitalId: undefined,
+        hospitalId: 'hospital-a',
       });
       hospitalsRepo.findOne.mockResolvedValue({ id: 'hospital-a' });
       manager.findOne.mockResolvedValue({
@@ -260,6 +260,19 @@ describe('AuthService', () => {
           true,
         ),
       ).rejects.toThrow(/first-time registration/);
+      expect(usersRepo.manager.transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects bootstrap when caller is not bound to the hospital', async () => {
+      usersRepo.findOne.mockResolvedValue({
+        id: 'user-1',
+        hospitalId: undefined,
+      });
+      hospitalsRepo.findOne.mockResolvedValue({ id: 'hospital-a' });
+
+      await expect(
+        service.completeOnboarding(actor, 'Founder', 'hospital-a', true),
+      ).rejects.toThrow(/created this hospital/);
       expect(usersRepo.manager.transaction).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -178,6 +178,16 @@ export class AuthService {
           'Hospital bootstrap is only available during first-time registration',
         );
       }
+      // Caller must already be bound to this hospital via bootstrap createHospital
+      // (prevents a second registrant from claiming an orphan hospital).
+      if (!isSuperAdmin) {
+        const fresh = await this.usersRepo.findOne({ where: { id: user.id } });
+        if (!fresh?.hospitalId || fresh.hospitalId !== hospitalId) {
+          throw new ForbiddenException(
+            'Only the user who created this hospital can become its first administrator',
+          );
+        }
+      }
       try {
         await this.usersRepo.manager.transaction(async (manager) => {
           await manager.query(

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -216,6 +216,7 @@ export class BillingService {
     const invoices = await this.invoicesRepo.find({
       where: { hospitalId },
       relations: ['items', 'payments', 'patient'],
+      take: 200,
       order: { createdAt: 'DESC' },
     });
     return invoices.map((invoice) => this.toInvoiceType(invoice));

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -636,6 +636,7 @@ export class ClinicalService {
       where,
       relations: ['patient', 'orderedBy'],
       order: { createdAt: 'DESC' },
+      take: 200,
     });
     return orders.map((o) => this.toLabOrderType(o));
   }

--- a/apps/api/src/discharge/discharge.resolver.ts
+++ b/apps/api/src/discharge/discharge.resolver.ts
@@ -1,10 +1,11 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { PERMISSIONS } from '@careconnect/types';
+import { PERMISSIONS, ROLES } from '@careconnect/types';
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
+import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { DischargeService } from './discharge.service';
 import {
@@ -52,6 +53,13 @@ export class DischargeResolver {
   }
 
   @Mutation(() => DischargeType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async createDischarge(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -348,6 +348,7 @@ export class DischargeService {
       where,
       relations: ['patient', 'doctor'],
       order: { scheduledAt: 'ASC' },
+      take: 200,
     });
 
     return items.map((item) => this.toFollowUpType(item));

--- a/apps/api/src/facility/facility.service.ts
+++ b/apps/api/src/facility/facility.service.ts
@@ -1,11 +1,12 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { Bed, Department, Ward } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
@@ -18,6 +19,13 @@ import {
   UpdateBedStatusInput,
   WardType,
 } from './facility.types';
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error as QueryFailedError & { code?: string }).code === '23505'
+  );
+}
 
 /**
  * Manual bed status machine (admit/discharge own occupied transitions):
@@ -166,14 +174,33 @@ export class FacilityService {
     });
     if (!ward) throw new NotFoundException('Ward not found');
 
-    const bed = await this.bedsRepo.save(
-      this.bedsRepo.create({
-        hospitalId,
-        wardId: input.wardId,
-        label: input.label,
-        status: 'available',
-      }),
-    );
+    const existingLabel = await this.bedsRepo.findOne({
+      where: { wardId: input.wardId, label: input.label },
+    });
+    if (existingLabel) {
+      throw new ConflictException(
+        `A bed labeled "${input.label}" already exists in this ward`,
+      );
+    }
+
+    let bed: Bed;
+    try {
+      bed = await this.bedsRepo.save(
+        this.bedsRepo.create({
+          hospitalId,
+          wardId: input.wardId,
+          label: input.label,
+          status: 'available',
+        }),
+      );
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new ConflictException(
+          `A bed labeled "${input.label}" already exists in this ward`,
+        );
+      }
+      throw error;
+    }
 
     await this.audit.log({
       actorId: actor.id,

--- a/apps/api/src/hospitals/hospitals.module.ts
+++ b/apps/api/src/hospitals/hospitals.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Hospital } from '../database/entities';
+import { Hospital, User } from '../database/entities';
 import { HospitalsResolver } from './hospitals.resolver';
 import { HospitalsService } from './hospitals.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Hospital])],
+  imports: [TypeOrmModule.forFeature([Hospital, User])],
   providers: [HospitalsResolver, HospitalsService],
   exports: [HospitalsService],
 })

--- a/apps/api/src/hospitals/hospitals.resolver.ts
+++ b/apps/api/src/hospitals/hospitals.resolver.ts
@@ -61,7 +61,7 @@ export class HospitalsResolver {
       throw new ForbiddenException('Not allowed to create hospitals');
     }
 
-    const hospital = await this.hospitalsService.create(input);
+    const hospital = await this.hospitalsService.create(input, user);
     await this.audit.log({
       actorId: user.id,
       hospitalId: hospital.id,

--- a/apps/api/src/hospitals/hospitals.service.ts
+++ b/apps/api/src/hospitals/hospitals.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Hospital } from '../database/entities';
+import { Hospital, User } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { CreateHospitalInput, UpdateHospitalInput } from './hospitals.types';
 
@@ -14,6 +14,8 @@ export class HospitalsService {
   constructor(
     @InjectRepository(Hospital)
     private readonly hospitalsRepo: Repository<Hospital>,
+    @InjectRepository(User)
+    private readonly usersRepo: Repository<User>,
   ) {}
 
   private slugify(name: string): string {
@@ -23,7 +25,14 @@ export class HospitalsService {
       .replace(/(^-|-$)/g, '');
   }
 
-  async create(input: CreateHospitalInput): Promise<Hospital> {
+  /**
+   * Create a hospital. For bootstrap callers (no hospitalId yet), immediately
+   * bind the creator so only they can claim first-admin via completeOnboarding.
+   */
+  async create(
+    input: CreateHospitalInput,
+    actor?: AuthenticatedUser,
+  ): Promise<Hospital> {
     const baseSlug = this.slugify(input.name);
     let slug = baseSlug;
     let counter = 1;
@@ -32,8 +41,23 @@ export class HospitalsService {
       slug = `${baseSlug}-${counter++}`;
     }
 
-    const hospital = this.hospitalsRepo.create({ ...input, slug });
-    return this.hospitalsRepo.save(hospital);
+    return this.hospitalsRepo.manager.transaction(async (manager) => {
+      const hospitalsRepo = manager.getRepository(Hospital);
+      const usersRepo = manager.getRepository(User);
+
+      const hospital = await hospitalsRepo.save(
+        hospitalsRepo.create({ ...input, slug }),
+      );
+
+      if (actor && !actor.hospitalId && !actor.roles.includes('super_admin')) {
+        const user = await usersRepo.findOne({ where: { id: actor.id } });
+        if (user && !user.hospitalId) {
+          await usersRepo.update(user.id, { hospitalId: hospital.id });
+        }
+      }
+
+      return hospital;
+    });
   }
 
   async findById(id: string): Promise<Hospital | null> {

--- a/apps/api/src/inventory/inventory.service.ts
+++ b/apps/api/src/inventory/inventory.service.ts
@@ -1,10 +1,11 @@
 import {
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { InventoryItem } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
@@ -13,6 +14,13 @@ import {
   InventoryItemType,
   UpdateInventoryQuantityInput,
 } from './inventory.types';
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error as QueryFailedError & { code?: string }).code === '23505'
+  );
+}
 
 @Injectable()
 export class InventoryService {
@@ -61,16 +69,26 @@ export class InventoryService {
     input: CreateInventoryItemInput,
     actor: AuthenticatedUser,
   ): Promise<InventoryItemType> {
-    const item = await this.inventoryRepo.save(
-      this.inventoryRepo.create({
-        hospitalId,
-        name: input.name,
-        sku: input.sku,
-        quantity: (input.quantity ?? 0).toFixed(2),
-        unit: input.unit ?? 'each',
-        reorderLevel: (input.reorderLevel ?? 0).toFixed(2),
-      }),
-    );
+    let item: InventoryItem;
+    try {
+      item = await this.inventoryRepo.save(
+        this.inventoryRepo.create({
+          hospitalId,
+          name: input.name,
+          sku: input.sku,
+          quantity: (input.quantity ?? 0).toFixed(2),
+          unit: input.unit ?? 'each',
+          reorderLevel: (input.reorderLevel ?? 0).toFixed(2),
+        }),
+      );
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new ConflictException(
+          'An inventory item with this SKU already exists in this hospital',
+        );
+      }
+      throw error;
+    }
 
     await this.audit.log({
       actorId: actor.id,
@@ -88,6 +106,7 @@ export class InventoryService {
     const items = await this.inventoryRepo.find({
       where: { hospitalId },
       order: { name: 'ASC' },
+      take: 200,
     });
     return items.map((item) => this.toInventoryItemType(item));
   }

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -132,9 +132,23 @@ describe('PatientsService', () => {
         id: 'patient-1',
         hospitalId: 'hospital-1',
         fullName: 'Jane Doe',
+        userId: 'portal-1',
       };
       patientsRepo.findOne.mockResolvedValue(patient);
-      patientsRepo.softRemove.mockResolvedValue(patient);
+      admissionsRepo.findOne.mockResolvedValue(null);
+      patientsRepo.manager.transaction.mockImplementation(
+        (cb: (m: Record<string, unknown>) => unknown) => {
+          const manager = {
+            getRepository: () => ({
+              save: jest.fn().mockResolvedValue(patient),
+              find: jest.fn().mockResolvedValue([]),
+              remove: jest.fn(),
+              softRemove: jest.fn().mockResolvedValue(patient),
+            }),
+          };
+          return Promise.resolve(cb(manager));
+        },
+      );
 
       const result = await service.deletePatient(
         'patient-1',
@@ -143,7 +157,7 @@ describe('PatientsService', () => {
       );
 
       expect(result).toBe(true);
-      expect(patientsRepo.softRemove).toHaveBeenCalledWith(patient);
+      expect(patientsRepo.manager.transaction).toHaveBeenCalled();
       expect(audit.log).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'delete',

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -252,14 +252,20 @@ export class PatientsService {
     }
 
     if (fields.phone?.trim()) {
-      const qb = this.patientsRepo
-        .createQueryBuilder('p')
-        .where('p.hospital_id = :hospitalId', { hospitalId })
-        .andWhere('p.phone = :phone', { phone: fields.phone.trim() });
-      if (excludePatientId) {
-        qb.andWhere('p.id != :excludePatientId', { excludePatientId });
+      const phoneDigits = fields.phone.replace(/\D/g, '');
+      if (phoneDigits) {
+        const qb = this.patientsRepo
+          .createQueryBuilder('p')
+          .where('p.hospital_id = :hospitalId', { hospitalId })
+          .andWhere(
+            `regexp_replace(p.phone, '[^0-9]', '', 'g') = :phoneDigits`,
+            { phoneDigits },
+          );
+        if (excludePatientId) {
+          qb.andWhere('p.id != :excludePatientId', { excludePatientId });
+        }
+        if (await qb.getOne()) conflicts.push('phone');
       }
-      if (await qb.getOne()) conflicts.push('phone');
     }
 
     if (fields.identificationNumber?.trim()) {
@@ -420,21 +426,30 @@ export class PatientsService {
     // Soft-delete policy: soft-remove the patient row; hard-remove linked
     // document metadata and unlink PHI files from disk. Other related rows
     // remain for audit but are unreachable via patient queries.
-    // Clear portal binding so the unique user_id index frees the account.
     const previousUserId = patient.userId;
-    patient.userId = null as unknown as string | undefined;
-    await this.patientsRepo.save(patient);
+    const fileUrlsToUnlink: string[] = [];
 
-    const documents = await this.documentsRepo.find({
-      where: { patientId: id },
+    await this.patientsRepo.manager.transaction(async (manager) => {
+      const patientsRepo = manager.getRepository(Patient);
+      const documentsRepo = manager.getRepository(PatientDocument);
+
+      patient.userId = null as unknown as string | undefined;
+      await patientsRepo.save(patient);
+
+      const documents = await documentsRepo.find({
+        where: { patientId: id },
+      });
+      for (const document of documents) {
+        if (document.fileUrl) fileUrlsToUnlink.push(document.fileUrl);
+        await documentsRepo.remove(document);
+      }
+
+      await patientsRepo.softRemove(patient);
     });
-    for (const document of documents) {
-      const fileUrl = document.fileUrl;
-      await this.documentsRepo.remove(document);
+
+    for (const fileUrl of fileUrlsToUnlink) {
       this.unlinkStoredUpload(fileUrl);
     }
-
-    await this.patientsRepo.softRemove(patient);
 
     await this.audit.log({
       actorId: actor.id,
@@ -444,7 +459,7 @@ export class PatientsService {
       resourceId: patient.id,
       metadata: {
         fullName: patient.fullName,
-        documentsRemoved: documents.length,
+        documentsRemoved: fileUrlsToUnlink.length,
         previousUserId,
       },
     });
@@ -961,10 +976,7 @@ export class PatientsService {
     });
     if (!patient) throw new NotFoundException('Patient not found');
 
-    const safeFileUrl = await this.assertOwnedUploadFileUrl(
-      input.fileUrl,
-      hospitalId,
-    );
+    const safeFileUrl = await this.assertOwnedUploadFileUrl(input.fileUrl);
 
     return this.documentsRepo.save(
       this.documentsRepo.create({
@@ -980,12 +992,9 @@ export class PatientsService {
 
   /**
    * Only allow same-origin upload paths produced by POST /uploads/patient-documents.
-   * Rejects third-party URLs and files already attached under another hospital.
+   * Rejects third-party URLs and files already attached to any patient chart.
    */
-  private async assertOwnedUploadFileUrl(
-    fileUrl: string,
-    hospitalId: string,
-  ): Promise<string> {
+  private async assertOwnedUploadFileUrl(fileUrl: string): Promise<string> {
     const trimmed = fileUrl.trim();
     let pathname: string;
     try {
@@ -1032,15 +1041,10 @@ export class PatientsService {
       take: 20,
     });
 
-    for (const doc of existingDocs) {
-      const owner = await this.patientsRepo.findOne({
-        where: { id: doc.patientId },
-      });
-      if (owner && owner.hospitalId !== hospitalId) {
-        throw new BadRequestException(
-          'Upload file is already linked to another hospital',
-        );
-      }
+    if (existingDocs.length > 0) {
+      throw new BadRequestException(
+        'Upload file is already linked to a patient document',
+      );
     }
 
     // Store a stable relative path so clients always hit this API origin

--- a/apps/api/src/pharmacy/pharmacy.service.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.ts
@@ -100,6 +100,7 @@ export class PharmacyService {
     const stock = await this.pharmacyStockRepo.find({
       where: { hospitalId },
       order: { drugName: 'ASC' },
+      take: 200,
     });
     return stock.map((item) => this.toPharmacyStockType(item));
   }
@@ -183,6 +184,7 @@ export class PharmacyService {
       where: { hospitalId, status: 'pending' },
       relations: ['items', 'patient'],
       order: { createdAt: 'ASC' },
+      take: 200,
     });
     return prescriptions.map((prescription) =>
       this.toPendingPrescriptionType(prescription),

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -76,6 +76,7 @@ export class StaffService {
       where: { hospitalId },
       relations: ['user', 'user.userRoles', 'user.userRoles.role'],
       order: { createdAt: 'DESC' },
+      take: 200,
     });
   }
 

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -51,7 +51,7 @@ describe('UploadsService', () => {
       const qb = {
         where: jest.fn().mockReturnThis(),
         orWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(null),
+        getMany: jest.fn().mockResolvedValue([]),
       };
       return qb;
     });
@@ -151,7 +151,7 @@ describe('UploadsService', () => {
       documentsRepo.createQueryBuilder.mockImplementation(() => ({
         where: jest.fn().mockReturnThis(),
         orWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(doc),
+        getMany: jest.fn().mockResolvedValue(doc ? [doc] : []),
       }));
     };
 
@@ -262,10 +262,10 @@ describe('UploadsService', () => {
       documentsRepo.createQueryBuilder.mockImplementation(() => ({
         where: jest.fn().mockReturnThis(),
         orWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockImplementation(() => {
+        getMany: jest.fn().mockImplementation(() => {
           lookup += 1;
           // First UUID file = orphan; second = linked document
-          return Promise.resolve(lookup === 1 ? null : { id: 'doc-1' });
+          return Promise.resolve(lookup === 1 ? [] : [{ id: 'doc-1' }]);
         }),
       }));
 

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -207,7 +207,7 @@ export class UploadsService implements OnApplicationBootstrap {
 
     const suffix = `/uploads/${safe}`;
     // Exact suffix match via RIGHT — avoids LIKE metacharacters in user input
-    return this.documentsRepo
+    const matches = await this.documentsRepo
       .createQueryBuilder('doc')
       .where('doc.file_url = :relative', { relative: suffix })
       .orWhere('doc.file_url = :filename', { filename: safe })
@@ -215,6 +215,11 @@ export class UploadsService implements OnApplicationBootstrap {
         len: suffix.length,
         suffix,
       })
-      .getOne();
+      .getMany();
+
+    if (matches.length > 1) {
+      return null;
+    }
+    return matches[0] ?? null;
   }
 }

--- a/apps/web/src/app/(dashboard)/finance/invoices/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/invoices/page.tsx
@@ -24,7 +24,7 @@ export default function InvoicesPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
 
-  const { data, loading } = useQuery(INVOICES_QUERY, {
+  const { data, loading, error, refetch } = useQuery(INVOICES_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
@@ -53,6 +53,15 @@ export default function InvoicesPage() {
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">Loading invoices...</p>
+        ) : error ? (
+          <div className="space-y-3 px-6 py-12 text-center">
+            <p className="text-sm text-clay-error">
+              We could not load invoices. Please try again.
+            </p>
+            <ClayButton type="button" size="sm" onClick={() => void refetch()}>
+              Try again
+            </ClayButton>
+          </div>
         ) : invoices.length === 0 ? (
           <div className="px-6 py-12 text-center">
             <FileText className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />

--- a/apps/web/src/app/(dashboard)/reports/page.tsx
+++ b/apps/web/src/app/(dashboard)/reports/page.tsx
@@ -18,7 +18,7 @@ export default function ReportsPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
 
-  const { data, loading } = useQuery(HOSPITAL_REPORTS_QUERY, {
+  const { data, loading, error } = useQuery(HOSPITAL_REPORTS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
@@ -39,7 +39,23 @@ export default function ReportsPage() {
   const totalBeds = wards.reduce((sum, w) => sum + Number(w.totalBeds), 0);
   const occupiedBeds = wards.reduce((sum, w) => sum + Number(w.occupiedBeds), 0);
   const occupancyRate =
-    totalBeds > 0 ? Math.round((occupiedBeds / totalBeds) * 100) : 0;
+    occupancyQuery.error || !occupancyQuery.data
+      ? '—'
+      : totalBeds > 0
+        ? Math.round((occupiedBeds / totalBeds) * 100)
+        : 0;
+
+  const stat = (value: number | undefined) =>
+    error || value == null ? '—' : value;
+  const revenueDisplay =
+    error || reports?.revenueTotal == null
+      ? '—'
+      : `$${Number(reports.revenueTotal).toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })}`;
+  const occupancyDisplay =
+    occupancyRate === '—' ? '—' : `${occupancyRate}%`;
 
   const asOf = new Date().toLocaleString(undefined, {
     dateStyle: 'medium',
@@ -55,37 +71,41 @@ export default function ReportsPage() {
 
       {loading ? (
         <p className="text-clay-text-muted">Loading reports...</p>
+      ) : error ? (
+        <p className="text-sm text-clay-error">
+          We could not load hospital reports. Please try again.
+        </p>
       ) : (
         <>
           <div className="mb-6 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             <ClayStatCard
               title="Total Patients"
-              value={reports?.patientCount ?? 0}
+              value={stat(reports?.patientCount)}
               icon={<Users className="h-5 w-5" />}
             />
             <ClayStatCard
               title="Staff Members"
-              value={reports?.staffCount ?? 0}
+              value={stat(reports?.staffCount)}
               icon={<UserCog className="h-5 w-5" />}
             />
             <ClayStatCard
               title="Appointments Today"
-              value={reports?.appointmentsToday ?? 0}
+              value={stat(reports?.appointmentsToday)}
               icon={<Calendar className="h-5 w-5" />}
             />
             <ClayStatCard
               title="Active Admissions"
-              value={reports?.activeAdmissions ?? 0}
+              value={stat(reports?.activeAdmissions)}
               icon={<Activity className="h-5 w-5" />}
             />
             <ClayStatCard
               title="Bed Occupancy"
-              value={`${occupancyRate}%`}
+              value={occupancyDisplay}
               icon={<BedDouble className="h-5 w-5" />}
             />
             <ClayStatCard
               title="Total Revenue"
-              value={`$${(reports?.revenueTotal ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+              value={revenueDisplay}
               icon={<DollarSign className="h-5 w-5" />}
             />
           </div>

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -15,6 +15,7 @@ export default function SettingsPage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const canWriteHospital = (meData?.me?.permissions ?? []).includes('hospitals:write');
 
   const { data, loading: fetching } = useQuery(HOSPITAL_QUERY, {
     variables: { id: hospitalId },
@@ -107,6 +108,7 @@ export default function SettingsPage() {
         onSubmit={handleSubmit}
         isLoading={loading}
         submitLabel="Save Hospital Profile"
+        readOnly={!canWriteHospital}
       />
     </div>
   );

--- a/apps/web/src/app/(portal)/portal-layout-client.tsx
+++ b/apps/web/src/app/(portal)/portal-layout-client.tsx
@@ -20,18 +20,30 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
   const [onboardingRetrying, setOnboardingRetrying] = useState(false);
   const me = data?.me;
   const roles: string[] = me?.roles ?? [];
-  const isPatient = roles.includes('patient') || roles.includes('super_admin');
-  const isStaff =
-    roles.length > 0 &&
-    !roles.includes('patient') &&
-    me?.onboardingCompleted;
+  const isPatient = roles.includes('patient');
+  const isSuperAdmin = roles.includes('super_admin');
+  const accountType =
+    typeof user?.unsafeMetadata?.accountType === 'string'
+      ? user.unsafeMetadata.accountType
+      : undefined;
+  const isPatientOnboarding =
+    searchParams.get('completePatient') === '1' || accountType === 'patient';
+  const isStaffCompleted =
+    roles.length > 0 && !roles.includes('patient') && me?.onboardingCompleted;
+  const isIncompleteNonPatient =
+    !!me &&
+    !isPatient &&
+    !isSuperAdmin &&
+    !me.onboardingCompleted &&
+    !isPatientOnboarding;
 
   useEffect(() => {
-    // Staff/admin with completed onboarding must stay on the hospital dashboard
-    if (isStaff) {
+    if (isStaffCompleted) {
       router.replace('/dashboard');
+    } else if (isIncompleteNonPatient) {
+      router.replace('/onboarding');
     }
-  }, [isStaff, router]);
+  }, [isStaffCompleted, isIncompleteNonPatient, router]);
 
   const runPatientOnboarding = async (fullName: string) => {
     setOnboardingError(null);
@@ -54,7 +66,7 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
       (me &&
         !me.roles?.includes('patient') &&
         !me.onboardingCompleted &&
-        user?.unsafeMetadata?.accountType === 'patient');
+        accountType === 'patient');
 
     if (!needsComplete || ran.current || !user) return;
     ran.current = true;
@@ -66,7 +78,7 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
       'Patient';
 
     void runPatientOnboarding(fullName);
-  }, [searchParams, me, user]);
+  }, [searchParams, me, user, accountType]);
 
   if (loading && !me) {
     return (
@@ -82,22 +94,34 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
         <ForbiddenAccess
           title="Unable to load portal"
           message="We could not verify your account. Please sign in again or contact support."
+          homeHref="/login"
         />
       </div>
     );
   }
 
-  if (isStaff) {
+  // Fail closed when session exists but me never resolved.
+  if (!loading && !error && !me) {
+    return (
+      <ForbiddenAccess
+        title="Unable to load portal"
+        message="We could not verify your account. Please sign in again or contact support."
+        homeHref="/login"
+      />
+    );
+  }
+
+  if (isStaffCompleted || isIncompleteNonPatient) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-clay-bg text-clay-text-muted">
-        Redirecting to dashboard…
+        Redirecting…
       </div>
     );
   }
 
-  // Fail closed: non-patient authenticated users must not mount portal PHI pages.
-  if (me && !isPatient && me.onboardingCompleted) {
-    return <ForbiddenAccess />;
+  // Completed non-patients (and non–patient-onboarding) may not mount portal PHI pages.
+  if (me && !isPatient && !isSuperAdmin && me.onboardingCompleted) {
+    return <ForbiddenAccess homeHref="/dashboard" />;
   }
 
   if (onboardingError) {
@@ -120,6 +144,15 @@ export function PortalLayoutClient({ children }: { children: React.ReactNode }) 
             Try again
           </ClayButton>
         </ClayCard>
+      </div>
+    );
+  }
+
+  // Only verified patients (or super_admin) mount portal PHI pages.
+  if (!isPatient && !isSuperAdmin) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-clay-bg text-clay-text-muted">
+        Setting up your portal…
       </div>
     );
   }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -20,8 +20,8 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         <ClerkProvider
           signInUrl="/login"
           signUpUrl="/register"
-          signInFallbackRedirectUrl="/dashboard"
-          signUpFallbackRedirectUrl="/dashboard"
+          signInFallbackRedirectUrl="/onboarding"
+          signUpFallbackRedirectUrl="/onboarding"
         >
           <NextIntlClientProvider locale="en" messages={messages}>
             <Providers>{children}</Providers>

--- a/apps/web/src/components/auth/forbidden-access.tsx
+++ b/apps/web/src/components/auth/forbidden-access.tsx
@@ -1,22 +1,33 @@
 'use client';
 
 import Link from 'next/link';
+import { useQuery } from '@apollo/client';
 import { ClayButton, ClayCard } from '@careconnect/ui';
+import { ME_QUERY } from '@/lib/graphql/queries';
 
 export function ForbiddenAccess({
   title = 'Access denied',
   message = 'You do not have permission to view this page.',
+  homeHref,
 }: {
   title?: string;
   message?: string;
+  homeHref?: string;
 }) {
+  const { data } = useQuery(ME_QUERY, { errorPolicy: 'ignore' });
+  const roles: string[] = data?.me?.roles ?? [];
+  const href =
+    homeHref ??
+    (roles.includes('patient') ? '/portal' : '/dashboard');
+  const label = roles.includes('patient') ? 'Back to portal' : 'Back to dashboard';
+
   return (
     <div className="flex min-h-[50vh] items-center justify-center p-6">
       <ClayCard className="max-w-md space-y-4 p-8 text-center">
         <h1 className="text-xl font-bold text-clay-text">{title}</h1>
         <p className="text-sm text-clay-text-muted">{message}</p>
-        <Link href="/dashboard">
-          <ClayButton>Back to dashboard</ClayButton>
+        <Link href={href}>
+          <ClayButton>{homeHref === '/login' ? 'Sign in' : label}</ClayButton>
         </Link>
       </ClayCard>
     </div>

--- a/apps/web/src/components/auth/forgot-password-form.tsx
+++ b/apps/web/src/components/auth/forgot-password-form.tsx
@@ -63,7 +63,8 @@ export function ForgotPasswordForm() {
       });
       if (attempt.status === 'complete') {
         await setActive({ session: attempt.createdSessionId });
-        router.push('/dashboard');
+        // Role-aware landing happens in dashboard/portal layouts after me loads.
+        router.push('/onboarding');
         router.refresh();
       } else {
         setError('Reset incomplete. Please try again.');

--- a/apps/web/src/components/hospital/hospital-form.tsx
+++ b/apps/web/src/components/hospital/hospital-form.tsx
@@ -18,6 +18,7 @@ interface HospitalFormProps {
   onSubmit: (data: HospitalFormValues) => Promise<void>;
   submitLabel?: string;
   isLoading?: boolean;
+  readOnly?: boolean;
 }
 
 export function HospitalForm({
@@ -25,6 +26,7 @@ export function HospitalForm({
   onSubmit,
   submitLabel = 'Save Changes',
   isLoading,
+  readOnly = false,
 }: HospitalFormProps) {
   const {
     register,
@@ -43,19 +45,32 @@ export function HospitalForm({
         <ClayInput
           label="Hospital Name"
           error={errors.name?.message}
+          disabled={readOnly}
           {...register('name', { required: 'Hospital name is required' })}
         />
         <div className="grid gap-4 md:grid-cols-2">
-          <ClayInput label="Email" type="email" {...register('email')} />
-          <ClayInput label="Phone" type="tel" {...register('phone')} />
-          <ClayInput label="Address" className="md:col-span-2" {...register('address')} />
-          <ClayInput label="City" {...register('city')} />
-          <ClayInput label="Country" {...register('country')} />
-          <ClayInput label="Logo URL" className="md:col-span-2" {...register('logoUrl')} />
+          <ClayInput label="Email" type="email" disabled={readOnly} {...register('email')} />
+          <ClayInput label="Phone" type="tel" disabled={readOnly} {...register('phone')} />
+          <ClayInput
+            label="Address"
+            className="md:col-span-2"
+            disabled={readOnly}
+            {...register('address')}
+          />
+          <ClayInput label="City" disabled={readOnly} {...register('city')} />
+          <ClayInput label="Country" disabled={readOnly} {...register('country')} />
+          <ClayInput
+            label="Logo URL"
+            className="md:col-span-2"
+            disabled={readOnly}
+            {...register('logoUrl')}
+          />
         </div>
-        <ClayButton type="submit" isLoading={isLoading}>
-          {submitLabel}
-        </ClayButton>
+        {readOnly ? null : (
+          <ClayButton type="submit" isLoading={isLoading}>
+            {submitLabel}
+          </ClayButton>
+        )}
       </form>
     </ClayCard>
   );

--- a/apps/web/src/components/onboarding/onboarding-form.tsx
+++ b/apps/web/src/components/onboarding/onboarding-form.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@clerk/nextjs';
-import { useMutation } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
-import { COMPLETE_ONBOARDING_MUTATION, COMPLETE_PATIENT_ONBOARDING, CREATE_HOSPITAL_MUTATION } from '@/lib/graphql/queries';
+import {
+  COMPLETE_ONBOARDING_MUTATION,
+  COMPLETE_PATIENT_ONBOARDING,
+  CREATE_HOSPITAL_MUTATION,
+  ME_QUERY,
+} from '@/lib/graphql/queries';
 
 type ClerkMeta = { hospitalName?: string; fullName?: string; accountType?: string };
 
@@ -183,11 +188,31 @@ function OnboardingFormFields({
 
 export function OnboardingForm() {
   const { user, isLoaded } = useUser();
+  const router = useRouter();
+  const { data: meData, loading: meLoading } = useQuery(ME_QUERY);
 
-  if (!isLoaded) {
+  useEffect(() => {
+    const me = meData?.me;
+    if (!me?.onboardingCompleted) return;
+    if ((me.roles ?? []).includes('patient')) {
+      router.replace('/portal');
+    } else {
+      router.replace('/dashboard');
+    }
+  }, [meData?.me, router]);
+
+  if (!isLoaded || meLoading) {
     return (
       <ClayCard className="w-full max-w-lg">
         <p className="text-sm text-clay-text-muted">Loading...</p>
+      </ClayCard>
+    );
+  }
+
+  if (meData?.me?.onboardingCompleted) {
+    return (
+      <ClayCard className="w-full max-w-lg">
+        <p className="text-sm text-clay-text-muted">Redirecting…</p>
       </ClayCard>
     );
   }

--- a/supabase/migrations/20240609000024_patient_documents_file_url_unique.sql
+++ b/supabase/migrations/20240609000024_patient_documents_file_url_unique.sql
@@ -1,0 +1,8 @@
+-- Each stored upload may be linked to at most one patient document.
+-- Existing relative paths are /uploads/<filename>; also cover legacy absolute URLs
+-- by unique on the trailing filename expression is hard in PG without a generated
+-- column, so enforce uniqueness on the stored file_url value (API always stores
+-- relative /uploads/... now).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_patient_documents_file_url
+  ON patient_documents (file_url)
+  WHERE file_url IS NOT NULL AND file_url <> '';

--- a/supabase/migrations/20240609000025_patients_phone_digits_unique.sql
+++ b/supabase/migrations/20240609000025_patients_phone_digits_unique.sql
@@ -1,0 +1,9 @@
+-- Normalize phone uniqueness to digits-only so format variants collide.
+DROP INDEX IF EXISTS idx_patients_hospital_phone_unique;
+
+CREATE UNIQUE INDEX idx_patients_hospital_phone_unique
+  ON patients (hospital_id, (regexp_replace(phone, '[^0-9]', '', 'g')))
+  WHERE deleted_at IS NULL
+    AND phone IS NOT NULL
+    AND phone <> ''
+    AND regexp_replace(phone, '[^0-9]', '', 'g') <> '';

--- a/supabase/migrations/20240609000026_beds_consents_inventory_uniques.sql
+++ b/supabase/migrations/20240609000026_beds_consents_inventory_uniques.sql
@@ -1,0 +1,10 @@
+-- Integrity uniques for facility beds, consents, and inventory SKUs.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_beds_ward_label
+  ON beds (ward_id, label);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_patient_consents_type
+  ON patient_consents (patient_id, consent_type);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_inventory_items_hospital_sku
+  ON inventory_items (hospital_id, LOWER(sku))
+  WHERE sku IS NOT NULL AND sku <> '';


### PR DESCRIPTION
## Summary
- Rescan after #125 found **15 confirmed issues** (#126–#141; #128 closed as TypeORM soft-delete already excludes related patients)
- One commit per fix; CI must be green before merge

### High
| Issue | Fix |
|-------|-----|
| **#126** | Bootstrap `createHospital` binds creator; `assignHospitalAdmin` requires that binding |
| **#127** | One document per upload file (+ unique index); ambiguous download denied |

### Medium
| Issue | Fix |
|-------|-----|
| **#129** | Transactional `deletePatient` |
| **#130** | Discharge mutations require clinical/admin roles |
| **#131** | Hospital-wide lists capped at 200 |
| **#132–#135** | Portal fail-closed; onboarding redirect; reports false-zero; phone digits unique |

### Low
| Issue | Fix |
|-------|-----|
| **#136–#141** | Settings write gate; role-aware forbidden/reset; invoices errors; bed/consent/SKU uniques; appointment→patient checked_in; Clerk fallback `/onboarding` |

## Test plan
- [ ] `pnpm --filter api test` / lint green
- [ ] Apply migrations `20240609000024`–`26`
- [ ] User A creates hospital → User B cannot claim admin
- [ ] Same upload cannot attach to two patients
- [ ] Receptionist cannot discharge; doctor can
- [ ] Reports failure shows `—` not `0`
- [ ] Completed user visiting `/onboarding` redirects home


Made with [Cursor](https://cursor.com)