### PR TITLE
fix: rescan issues #143–#162 (RBAC, auth redirects, fail-closed UI)

### DIFF
--- a/apps/api/src/admissions/admissions.resolver.ts
+++ b/apps/api/src/admissions/admissions.resolver.ts
@@ -106,6 +106,13 @@ export class AdmissionsResolver {
   }
 
   @Mutation(() => AdmissionType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async transferOutAdmission(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/clinical/clinical.resolver.ts
+++ b/apps/api/src/clinical/clinical.resolver.ts
@@ -121,6 +121,7 @@ export class ClinicalResolver {
   }
 
   @Mutation(() => VitalSignType, { name: 'createVitalSign' })
+  @Roles(...CLINICAL_AUTHOR_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async createVital(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/discharge/discharge.resolver.ts
+++ b/apps/api/src/discharge/discharge.resolver.ts
@@ -78,6 +78,14 @@ export class DischargeResolver {
   }
 
   @Mutation(() => FollowUpType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async createFollowUp(
     @CurrentUser() user: AuthenticatedUser,
@@ -96,6 +104,14 @@ export class DischargeResolver {
   }
 
   @Mutation(() => FollowUpType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async updateFollowUpStatus(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -189,12 +189,21 @@ export class DischargeService {
           );
 
           if (input.followUpScheduledAt) {
+            const followUpDoctorId =
+              input.followUpDoctorId ?? admission.attendingDoctorId;
+            if (followUpDoctorId) {
+              await this.doctorValidator.assertHospitalDoctor(
+                hospitalId,
+                followUpDoctorId,
+                'Follow-up doctor',
+              );
+            }
             await manager.save(
               manager.create(FollowUp, {
                 hospitalId,
                 patientId: admission.patientId,
                 dischargeId: discharge.id,
-                doctorId: input.followUpDoctorId ?? admission.attendingDoctorId,
+                doctorId: followUpDoctorId,
                 scheduledAt: new Date(input.followUpScheduledAt),
                 type: input.followUpType ?? 'post_discharge',
                 status: 'scheduled',

--- a/apps/api/src/hospitals/hospitals.resolver.ts
+++ b/apps/api/src/hospitals/hospitals.resolver.ts
@@ -40,7 +40,7 @@ export class HospitalsResolver {
     return this.hospitalsService.findByIdForUser(id, user);
   }
 
-  /** Bootstrap: only unassigned non-patient/non-staff users may create a hospital during admin onboarding. */
+  /** Bootstrap: only unassigned non-patient/non-staff users, or super_admin. */
   @Mutation(() => HospitalType)
   async createHospital(
     @CurrentUser() user: AuthenticatedUser,
@@ -53,11 +53,10 @@ export class HospitalsResolver {
     const hasStaffRole = user.roles.some((role) => STAFF_ROLES.includes(role));
 
     const canBootstrap = !user.hospitalId && !hasStaffRole;
-    const canWrite =
-      user.roles.includes('super_admin') ||
-      user.permissions.includes(PERMISSIONS.HOSPITALS_WRITE);
+    const isSuperAdmin = user.roles.includes('super_admin');
 
-    if (!canBootstrap && !canWrite) {
+    // hospitals:write alone must not mint a second/orphan tenant (#145).
+    if (!canBootstrap && !isSuperAdmin) {
       throw new ForbiddenException('Not allowed to create hospitals');
     }
 

--- a/apps/api/src/patients/patients.resolver.ts
+++ b/apps/api/src/patients/patients.resolver.ts
@@ -1,10 +1,11 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { PERMISSIONS } from '@careconnect/types';
+import { PERMISSIONS, ROLES } from '@careconnect/types';
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
+import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { PatientsService } from './patients.service';
 import {
@@ -94,6 +95,7 @@ export class PatientsResolver {
   }
 
   @Mutation(() => Boolean)
+  @Roles(ROLES.HOSPITAL_ADMIN, ROLES.HOSPITAL_MANAGER, ROLES.SUPER_ADMIN)
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async deletePatient(
     @CurrentUser() user: AuthenticatedUser,
@@ -197,6 +199,7 @@ export class PatientsResolver {
   }
 
   @Mutation(() => PatientType)
+  @Roles(ROLES.HOSPITAL_ADMIN, ROLES.HOSPITAL_MANAGER, ROLES.SUPER_ADMIN)
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async linkPatientAccount(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/pharmacy/pharmacy.resolver.ts
+++ b/apps/api/src/pharmacy/pharmacy.resolver.ts
@@ -27,6 +27,7 @@ export class PharmacyResolver {
   constructor(private readonly pharmacyService: PharmacyService) {}
 
   @Query(() => [PharmacyStockType])
+  @Roles(...PHARMACY_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async pharmacyStock(
     @CurrentUser() user: AuthenticatedUser,
@@ -40,6 +41,7 @@ export class PharmacyResolver {
   }
 
   @Query(() => [PendingPrescriptionType])
+  @Roles(...PHARMACY_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async pendingPrescriptions(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -146,7 +146,9 @@ describe('StaffService', () => {
   });
 
   describe('create — cross-hospital invite', () => {
-    function mockCreateTransaction(existingUser: Record<string, unknown> | null) {
+    function mockCreateTransaction(
+      existingUser: Record<string, unknown> | null,
+    ) {
       staffRepo.manager.transaction.mockImplementation(
         (cb: (m: Record<string, unknown>) => unknown) => {
           const manager = {
@@ -245,18 +247,16 @@ describe('StaffService', () => {
       staffRepo.save.mockResolvedValue({ id: 'staff-1' });
       invitesRepo.create.mockImplementation((row: unknown) => row);
       invitesRepo.save.mockResolvedValue({});
-      staffRepo.findOne
-        .mockResolvedValueOnce(null)
-        .mockResolvedValue({
-          id: 'staff-1',
-          userId: 'user-1',
-          hospitalId: 'hospital-a',
-          user: {
-            fullName: 'Existing User',
-            email: 'free@example.com',
-            userRoles: [{ role: { slug: 'doctor' } }],
-          },
-        });
+      staffRepo.findOne.mockResolvedValueOnce(null).mockResolvedValue({
+        id: 'staff-1',
+        userId: 'user-1',
+        hospitalId: 'hospital-a',
+        user: {
+          fullName: 'Existing User',
+          email: 'free@example.com',
+          userRoles: [{ role: { slug: 'doctor' } }],
+        },
+      });
       mockCreateTransaction({
         id: 'user-1',
         email: 'free@example.com',

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -146,18 +146,7 @@ describe('StaffService', () => {
   });
 
   describe('create — cross-hospital invite', () => {
-    it('rejects inviting a user who already belongs to another hospital', async () => {
-      rolesRepo.findOne.mockResolvedValue({
-        id: 'role-doctor',
-        slug: 'doctor',
-      });
-      const existingUser = {
-        id: 'user-1',
-        email: 'doc@example.com',
-        hospitalId: 'hospital-b',
-        fullName: 'Existing Doc',
-        authId: 'auth-1',
-      };
+    function mockCreateTransaction(existingUser: Record<string, unknown> | null) {
       staffRepo.manager.transaction.mockImplementation(
         (cb: (m: Record<string, unknown>) => unknown) => {
           const manager = {
@@ -165,6 +154,7 @@ describe('StaffService', () => {
               if (entity === User) {
                 return {
                   createQueryBuilder: () => ({
+                    leftJoinAndSelect: jest.fn().mockReturnThis(),
                     where: jest.fn().mockReturnThis(),
                     getOne: jest.fn().mockResolvedValue(existingUser),
                   }),
@@ -182,6 +172,21 @@ describe('StaffService', () => {
           return Promise.resolve(cb(manager));
         },
       );
+    }
+
+    it('rejects inviting a user who already belongs to another hospital', async () => {
+      rolesRepo.findOne.mockResolvedValue({
+        id: 'role-doctor',
+        slug: 'doctor',
+      });
+      mockCreateTransaction({
+        id: 'user-1',
+        email: 'doc@example.com',
+        hospitalId: 'hospital-b',
+        fullName: 'Existing Doc',
+        authId: 'auth-1',
+        userRoles: [],
+      });
 
       await expect(
         service.create(
@@ -196,6 +201,36 @@ describe('StaffService', () => {
       ).rejects.toThrow(BadRequestException);
 
       expect(userRolesRepo.save).not.toHaveBeenCalled();
+      expect(staffRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects inviting a patient portal user as staff', async () => {
+      rolesRepo.findOne.mockResolvedValue({
+        id: 'role-doctor',
+        slug: 'doctor',
+      });
+      mockCreateTransaction({
+        id: 'user-1',
+        email: 'patient@example.com',
+        hospitalId: null,
+        fullName: 'Portal Patient',
+        authId: 'user_live',
+        userRoles: [{ role: { slug: 'patient' } }],
+      });
+
+      await expect(
+        service.create(
+          'hospital-a',
+          {
+            email: 'patient@example.com',
+            fullName: 'Portal Patient',
+            roleSlug: 'doctor',
+          },
+          hospitalAdmin,
+        ),
+      ).rejects.toThrow(/patient portal account/i);
+
+      expect(usersRepo.update).not.toHaveBeenCalled();
       expect(staffRepo.save).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -233,6 +233,55 @@ describe('StaffService', () => {
       expect(usersRepo.update).not.toHaveBeenCalled();
       expect(staffRepo.save).not.toHaveBeenCalled();
     });
+
+    it('preserves a live Clerk authId when inviting a hospital-less user', async () => {
+      rolesRepo.findOne.mockResolvedValue({
+        id: 'role-doctor',
+        slug: 'doctor',
+      });
+      staffRepo.findOne.mockResolvedValue(null);
+      userRolesRepo.findOne.mockResolvedValue(null);
+      staffRepo.create.mockImplementation((row: unknown) => row);
+      staffRepo.save.mockResolvedValue({ id: 'staff-1' });
+      invitesRepo.create.mockImplementation((row: unknown) => row);
+      invitesRepo.save.mockResolvedValue({});
+      staffRepo.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({
+          id: 'staff-1',
+          userId: 'user-1',
+          hospitalId: 'hospital-a',
+          user: {
+            fullName: 'Existing User',
+            email: 'free@example.com',
+            userRoles: [{ role: { slug: 'doctor' } }],
+          },
+        });
+      mockCreateTransaction({
+        id: 'user-1',
+        email: 'free@example.com',
+        hospitalId: null,
+        fullName: 'Existing User',
+        authId: 'user_live_clerk',
+        userRoles: [],
+      });
+
+      await service.create(
+        'hospital-a',
+        {
+          email: 'free@example.com',
+          fullName: 'Existing User',
+          roleSlug: 'doctor',
+        },
+        hospitalAdmin,
+      );
+
+      expect(usersRepo.update).toHaveBeenCalledWith('user-1', {
+        hospitalId: 'hospital-a',
+        fullName: 'Existing User',
+        authId: 'user_live_clerk',
+      });
+    });
   });
 
   describe('acceptInvite — deactivated staff', () => {

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -159,13 +159,18 @@ export class StaffService {
             );
           }
           if (!user.hospitalId) {
+            // Preserve a live Clerk identity; only set authId when missing or still pending.
+            const nextAuthId =
+              !user.authId || user.authId.startsWith('pending_')
+                ? authId
+                : user.authId;
             await usersRepo.update(user.id, {
               hospitalId,
               fullName: input.fullName,
-              authId,
+              authId: nextAuthId,
             });
             user.hospitalId = hospitalId;
-            user.authId = authId;
+            user.authId = nextAuthId;
           }
         } else {
           user = await usersRepo.save(

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -137,6 +137,8 @@ export class StaffService {
 
         const existingByEmail = await usersRepo
           .createQueryBuilder('user')
+          .leftJoinAndSelect('user.userRoles', 'userRoles')
+          .leftJoinAndSelect('userRoles.role', 'role')
           .where('LOWER(user.email) = LOWER(:email)', { email })
           .getOne();
 
@@ -146,6 +148,14 @@ export class StaffService {
           if (user.hospitalId && user.hospitalId !== hospitalId) {
             throw new BadRequestException(
               'This user already belongs to another hospital. CareConnect users can only be staff at one hospital.',
+            );
+          }
+          const hasPatientRole = (user.userRoles ?? []).some(
+            (ur) => ur.role?.slug === 'patient',
+          );
+          if (hasPatientRole) {
+            throw new BadRequestException(
+              'This email belongs to a patient portal account and cannot be invited as staff. Use a different email.',
             );
           }
           if (!user.hospitalId) {

--- a/apps/web/src/app/(dashboard)/admissions/occupancy/page.tsx
+++ b/apps/web/src/app/(dashboard)/admissions/occupancy/page.tsx
@@ -4,13 +4,18 @@ import Link from 'next/link';
 import { useQuery } from '@apollo/client';
 import { ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { QueryError } from '@/components/query-error';
 import { BED_OCCUPANCY_QUERY, ME_QUERY } from '@/lib/graphql/queries';
+import { canAccessRoute } from '@/lib/route-access';
 
 export default function BedOccupancyPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const roles: string[] = meData?.me?.roles ?? [];
+  const permissions: string[] = meData?.me?.permissions ?? [];
+  const canManageFacility = canAccessRoute('/settings', { roles, permissions });
 
-  const { data, loading } = useQuery(BED_OCCUPANCY_QUERY, {
+  const { data, loading, error, refetch } = useQuery(BED_OCCUPANCY_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
@@ -39,7 +44,9 @@ export default function BedOccupancyPage() {
           { label: 'Occupied', value: summary.occupied },
         ].map((stat) => (
           <ClayCard key={stat.label} className="text-center">
-            <p className="text-2xl font-bold text-clay-text">{loading ? '—' : stat.value}</p>
+            <p className="text-2xl font-bold text-clay-text">
+              {loading || error ? '—' : stat.value}
+            </p>
             <p className="text-sm text-clay-text-muted">{stat.label}</p>
           </ClayCard>
         ))}
@@ -62,16 +69,29 @@ export default function BedOccupancyPage() {
                   Loading...
                 </td>
               </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={4} className="px-6 py-8">
+                  <QueryError
+                    message="We could not load bed occupancy. Please try again."
+                    onRetry={() => void refetch()}
+                  />
+                </td>
+              </tr>
             ) : wards.length === 0 ? (
               <tr>
                 <td colSpan={4} className="px-6 py-8 text-center text-clay-text-muted">
                   <p>No wards configured yet.</p>
-                  <Link
-                    href="/settings/facility"
-                    className="mt-2 inline-block text-sm text-clay-primary hover:underline"
-                  >
-                    Set up departments, wards, and beds →
-                  </Link>
+                  {canManageFacility ? (
+                    <Link
+                      href="/settings/facility"
+                      className="mt-2 inline-block text-sm text-clay-primary hover:underline"
+                    >
+                      Set up departments, wards, and beds →
+                    </Link>
+                  ) : (
+                    <p className="mt-2 text-sm">Ask an administrator to configure wards and beds.</p>
+                  )}
                 </td>
               </tr>
             ) : (

--- a/apps/web/src/app/(dashboard)/admissions/page.tsx
+++ b/apps/web/src/app/(dashboard)/admissions/page.tsx
@@ -16,6 +16,9 @@ import {
   PATIENTS_QUERY,
   WARDS_QUERY,
 } from '@/lib/graphql/queries';
+import { canDischargePatients } from '@/lib/clinical-access';
+import { canAccessRoute } from '@/lib/route-access';
+import { QueryError } from '@/components/query-error';
 
 export default function AdmissionsPage() {
   const router = useRouter();
@@ -29,9 +32,13 @@ export default function AdmissionsPage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
-  const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
+  const roles: string[] = meData?.me?.roles ?? [];
+  const permissions: string[] = meData?.me?.permissions ?? [];
+  const canWritePatients = permissions.includes('patients:write');
+  const canDischarge = canWritePatients && canDischargePatients(roles);
+  const canManageFacility = canAccessRoute('/settings', { roles, permissions });
 
-  const { data, loading, refetch } = useQuery(ACTIVE_ADMISSIONS_QUERY, {
+  const { data, loading, error: listError, refetch } = useQuery(ACTIVE_ADMISSIONS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
@@ -183,12 +190,18 @@ export default function AdmissionsPage() {
                   ))}
                 </select>
                 {wards.length === 0 ? (
-                  <Link
-                    href="/settings/facility"
-                    className="text-xs text-clay-primary hover:underline"
-                  >
-                    No wards yet — set them up →
-                  </Link>
+                  canManageFacility ? (
+                    <Link
+                      href="/settings/facility"
+                      className="text-xs text-clay-primary hover:underline"
+                    >
+                      No wards yet — set them up →
+                    </Link>
+                  ) : (
+                    <p className="text-xs text-clay-text-muted">
+                      No wards yet — ask an administrator to set them up.
+                    </p>
+                  )
                 ) : null}
               </div>
               <div className="flex flex-col gap-2">
@@ -249,6 +262,15 @@ export default function AdmissionsPage() {
                   Loading admissions...
                 </td>
               </tr>
+            ) : listError ? (
+              <tr>
+                <td colSpan={6} className="px-6 py-8">
+                  <QueryError
+                    message="We could not load admissions. Please try again."
+                    onRetry={() => void refetch()}
+                  />
+                </td>
+              </tr>
             ) : admissions.length === 0 ? (
               <tr>
                 <td colSpan={6} className="px-6 py-12 text-center">
@@ -283,7 +305,7 @@ export default function AdmissionsPage() {
                       <ClayBadge variant="success">{adm.status}</ClayBadge>
                     </td>
                     <td className="px-6 py-4 text-right">
-                      {canWritePatients ? (
+                      {canDischarge ? (
                       <ClayButton
                         size="sm"
                         variant="secondary"

--- a/apps/web/src/app/(dashboard)/appointments/page.tsx
+++ b/apps/web/src/app/(dashboard)/appointments/page.tsx
@@ -12,6 +12,7 @@ import {
   ME_QUERY,
   UPDATE_APPOINTMENT_STATUS_MUTATION,
 } from '@/lib/graphql/queries';
+import { QueryError } from '@/components/query-error';
 
 function todayDateString() {
   return new Date().toISOString().slice(0, 10);
@@ -49,7 +50,7 @@ export default function AppointmentsPage() {
       ['hospital_admin', 'hospital_manager', 'super_admin', 'receptionist', 'nurse'].includes(r),
     );
 
-  const { data, loading, refetch } = useQuery(APPOINTMENTS_QUERY, {
+  const { data, loading, error, refetch } = useQuery(APPOINTMENTS_QUERY, {
     variables: {
       hospitalId,
       date: selectedDate,
@@ -120,6 +121,13 @@ export default function AppointmentsPage() {
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">Loading appointments...</p>
+        ) : error ? (
+          <div className="px-6 py-8">
+            <QueryError
+              message="We could not load appointments. Please try again."
+              onRetry={() => void refetch()}
+            />
+          </div>
         ) : appointments.length === 0 ? (
           <div className="px-6 py-12 text-center">
             <Calendar className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -20,7 +20,7 @@ const QUICK_ACTIONS = [
   { label: 'Bulk Import Patients', href: '/patients/import', anyPermissions: ['patients:write'] },
   { label: 'New Appointment', href: '/appointments/new', anyPermissions: ['appointments:write'] },
   { label: 'View Appointments', href: '/appointments' },
-  { label: 'Admit Patient', href: '/admissions' },
+  { label: 'Admit Patient', href: '/admissions', anyPermissions: ['patients:write'] },
   { label: 'Add Staff Member', href: '/staff/new', anyPermissions: ['staff:write'] },
   { label: 'View Staff Directory', href: '/staff' },
   { label: 'Lab Queue', href: '/lab' },

--- a/apps/web/src/app/(dashboard)/doctor/page.tsx
+++ b/apps/web/src/app/(dashboard)/doctor/page.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@apollo/client';
 import { Calendar, Clock, FileText, FlaskConical, Users } from 'lucide-react';
 import { ClayBadge, ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { QueryError } from '@/components/query-error';
 import { APPOINTMENTS_QUERY, ME_QUERY } from '@/lib/graphql/queries';
 
 function todayDateString() {
@@ -22,7 +23,7 @@ export default function DoctorDashboardPage() {
   const doctorId = meData?.me?.id;
   const canWriteAppointments = (meData?.me?.permissions ?? []).includes('appointments:write');
 
-  const { data, loading } = useQuery(APPOINTMENTS_QUERY, {
+  const { data, loading, error, refetch } = useQuery(APPOINTMENTS_QUERY, {
     variables: { hospitalId, date: today, doctorId },
     skip: !hospitalId || !doctorId,
   });
@@ -51,16 +52,22 @@ export default function DoctorDashboardPage() {
 
       <div className="mb-8 grid gap-4 sm:grid-cols-3">
         <ClayCard className="text-center">
-          <p className="text-3xl font-bold text-clay-primary">{loading ? '—' : appointments.length}</p>
+          <p className="text-3xl font-bold text-clay-primary">
+            {loading || error ? '—' : appointments.length}
+          </p>
           <p className="text-sm text-clay-text-muted">Appointments Today</p>
         </ClayCard>
         <ClayCard className="text-center">
-          <p className="text-3xl font-bold text-clay-warning">{loading ? '—' : pending.length}</p>
+          <p className="text-3xl font-bold text-clay-warning">
+            {loading || error ? '—' : pending.length}
+          </p>
           <p className="text-sm text-clay-text-muted">Pending / In Progress</p>
         </ClayCard>
         <ClayCard className="text-center">
           <p className="text-3xl font-bold text-clay-success">
-            {loading ? '—' : appointments.filter((a: { status: string }) => a.status === 'completed').length}
+            {loading || error
+              ? '—'
+              : appointments.filter((a: { status: string }) => a.status === 'completed').length}
           </p>
           <p className="text-sm text-clay-text-muted">Completed</p>
         </ClayCard>
@@ -71,6 +78,11 @@ export default function DoctorDashboardPage() {
           <h2 className="mb-4 text-lg font-semibold text-clay-text">Today&apos;s Appointments</h2>
           {loading ? (
             <p className="text-sm text-clay-text-muted">Loading...</p>
+          ) : error ? (
+            <QueryError
+              message="We could not load appointments. Please try again."
+              onRetry={() => void refetch()}
+            />
           ) : appointments.length === 0 ? (
             <p className="text-sm text-clay-text-muted">No appointments today.</p>
           ) : (

--- a/apps/web/src/app/(dashboard)/finance/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/page.tsx
@@ -11,7 +11,7 @@ export default function FinancePage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
 
-  const { data: invoicesData } = useQuery(INVOICES_QUERY, {
+  const { data: invoicesData, error: invoicesError } = useQuery(INVOICES_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
@@ -22,10 +22,14 @@ export default function FinancePage() {
   });
 
   const invoices = invoicesData?.invoices ?? [];
-  const outstanding = invoices.filter(
-    (inv: { status: string }) => inv.status === 'draft' || inv.status === 'issued',
-  ).length;
-  const paid = invoices.filter((inv: { status: string }) => inv.status === 'paid').length;
+  const outstanding = invoicesError
+    ? null
+    : invoices.filter(
+        (inv: { status: string }) => inv.status === 'draft' || inv.status === 'issued',
+      ).length;
+  const paid = invoicesError
+    ? null
+    : invoices.filter((inv: { status: string }) => inv.status === 'paid').length;
   const revenueTotal = reportsData?.hospitalReports?.revenueTotal;
   const revenueDisplay =
     reportsError || revenueTotal == null
@@ -34,6 +38,8 @@ export default function FinancePage() {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
         })}`;
+  const invoiceCountDisplay = (value: number | null) =>
+    value == null ? '—' : value;
   const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
 
   return (
@@ -60,8 +66,16 @@ export default function FinancePage() {
           value={revenueDisplay}
           icon={<DollarSign className="h-5 w-5" />}
         />
-        <ClayStatCard title="Outstanding Invoices" value={outstanding} icon={<FileText className="h-5 w-5" />} />
-        <ClayStatCard title="Paid Invoices" value={paid} icon={<FileText className="h-5 w-5" />} />
+        <ClayStatCard
+          title="Outstanding Invoices"
+          value={invoiceCountDisplay(outstanding)}
+          icon={<FileText className="h-5 w-5" />}
+        />
+        <ClayStatCard
+          title="Paid Invoices"
+          value={invoiceCountDisplay(paid)}
+          icon={<FileText className="h-5 w-5" />}
+        />
       </div>
 
       <ClayCard>

--- a/apps/web/src/app/(dashboard)/follow-ups/page.tsx
+++ b/apps/web/src/app/(dashboard)/follow-ups/page.tsx
@@ -12,6 +12,7 @@ import {
   PATIENTS_QUERY,
   UPDATE_FOLLOW_UP_STATUS_MUTATION,
 } from '@/lib/graphql/queries';
+import { QueryError } from '@/components/query-error';
 
 function formatDateTime(iso: string) {
   return new Date(iso).toLocaleString(undefined, {
@@ -47,7 +48,7 @@ export default function FollowUpsPage() {
   const [type, setType] = useState('outpatient');
   const [error, setError] = useState('');
 
-  const { data, loading, refetch } = useQuery(FOLLOW_UPS_QUERY, {
+  const { data, loading, error: listError, refetch } = useQuery(FOLLOW_UPS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
@@ -182,6 +183,13 @@ export default function FollowUpsPage() {
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">Loading follow-ups...</p>
+        ) : listError ? (
+          <div className="px-6 py-8">
+            <QueryError
+              message="We could not load follow-ups. Please try again."
+              onRetry={() => void refetch()}
+            />
+          </div>
         ) : followUps.length === 0 ? (
           <div className="px-6 py-12 text-center">
             <CalendarClock className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />

--- a/apps/web/src/app/(dashboard)/inventory/page.tsx
+++ b/apps/web/src/app/(dashboard)/inventory/page.tsx
@@ -11,6 +11,7 @@ import {
   ME_QUERY,
   UPDATE_INVENTORY_QUANTITY_MUTATION,
 } from '@/lib/graphql/queries';
+import { QueryError } from '@/components/query-error';
 
 export default function InventoryPage() {
   const [showForm, setShowForm] = useState(false);
@@ -25,7 +26,7 @@ export default function InventoryPage() {
   const hospitalId = meData?.me?.hospitalId;
   const canWrite = (meData?.me?.permissions ?? []).includes('patients:write');
 
-  const { data, loading, refetch } = useQuery(INVENTORY_ITEMS_QUERY, {
+  const { data, loading, error: listError, refetch } = useQuery(INVENTORY_ITEMS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
@@ -154,6 +155,13 @@ export default function InventoryPage() {
       <ClayCard padding="none" className="overflow-hidden">
         {loading ? (
           <p className="px-6 py-8 text-center text-clay-text-muted">Loading inventory...</p>
+        ) : listError ? (
+          <div className="px-6 py-8">
+            <QueryError
+              message="We could not load inventory. Please try again."
+              onRetry={() => void refetch()}
+            />
+          </div>
         ) : items.length === 0 ? (
           <div className="px-6 py-12 text-center">
             <Package className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />

--- a/apps/web/src/app/(dashboard)/lab/page.tsx
+++ b/apps/web/src/app/(dashboard)/lab/page.tsx
@@ -13,6 +13,7 @@ import {
   ME_QUERY,
   PATIENTS_QUERY,
 } from '@/lib/graphql/queries';
+import { QueryError } from '@/components/query-error';
 
 const statusVariant = (status: string) => {
   switch (status) {
@@ -45,7 +46,7 @@ export default function LabPage() {
   const canCreateOrders = (meData?.me?.permissions ?? []).includes('patients:write');
   const canWriteLab = (meData?.me?.permissions ?? []).includes('lab:write');
 
-  const { data, loading, refetch } = useQuery(LAB_ORDERS_QUERY, {
+  const { data, loading, error: listError, refetch } = useQuery(LAB_ORDERS_QUERY, {
     variables: { hospitalId, status: undefined },
     skip: !hospitalId,
   });
@@ -203,6 +204,13 @@ export default function LabPage() {
           </div>
           {loading ? (
             <p className="px-6 py-8 text-center text-clay-text-muted">Loading orders...</p>
+          ) : listError ? (
+            <div className="px-6 py-8">
+              <QueryError
+                message="We could not load lab orders. Please try again."
+                onRetry={() => void refetch()}
+              />
+            </div>
           ) : orders.length === 0 ? (
             <div className="px-6 py-12 text-center">
               <FlaskConical className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />

--- a/apps/web/src/app/(dashboard)/nurse/page.tsx
+++ b/apps/web/src/app/(dashboard)/nurse/page.tsx
@@ -5,13 +5,14 @@ import { useQuery } from '@apollo/client';
 import { Activity, HeartPulse, BedDouble, Users } from 'lucide-react';
 import { ClayBadge, ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { QueryError } from '@/components/query-error';
 import { ACTIVE_ADMISSIONS_QUERY, ME_QUERY } from '@/lib/graphql/queries';
 
 export default function NurseDashboardPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
 
-  const { data, loading } = useQuery(ACTIVE_ADMISSIONS_QUERY, {
+  const { data, loading, error, refetch } = useQuery(ACTIVE_ADMISSIONS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
@@ -34,12 +35,14 @@ export default function NurseDashboardPage() {
 
       <div className="mb-8 grid gap-4 sm:grid-cols-2">
         <ClayCard className="text-center">
-          <p className="text-3xl font-bold text-clay-primary">{loading ? '—' : admissions.length}</p>
+          <p className="text-3xl font-bold text-clay-primary">
+            {loading || error ? '—' : admissions.length}
+          </p>
           <p className="text-sm text-clay-text-muted">Active Admissions</p>
         </ClayCard>
         <ClayCard className="text-center">
           <p className="text-3xl font-bold text-clay-warning">
-            {loading
+            {loading || error
               ? '—'
               : admissions.filter((a: { bed?: { label: string } }) => !a.bed?.label).length}
           </p>
@@ -52,6 +55,11 @@ export default function NurseDashboardPage() {
           <h2 className="mb-4 text-lg font-semibold text-clay-text">Active Admissions</h2>
           {loading ? (
             <p className="text-sm text-clay-text-muted">Loading...</p>
+          ) : error ? (
+            <QueryError
+              message="We could not load admissions. Please try again."
+              onRetry={() => void refetch()}
+            />
           ) : admissions.length === 0 ? (
             <p className="text-sm text-clay-text-muted">No active admissions.</p>
           ) : (

--- a/apps/web/src/app/(dashboard)/patients/[id]/discharge/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/discharge/page.tsx
@@ -15,6 +15,7 @@ import {
   ME_QUERY,
   PATIENT_QUERY,
 } from '@/lib/graphql/queries';
+import { canDischargePatients } from '@/lib/clinical-access';
 
 export default function PatientDischargePage() {
   const { id } = useParams<{ id: string }>();
@@ -27,7 +28,9 @@ export default function PatientDischargePage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const roles: string[] = meData?.me?.roles ?? [];
   const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
+  const canDischarge = canWritePatients && canDischargePatients(roles);
 
   const { data: patientData, loading: patientLoading } = useQuery(PATIENT_QUERY, {
     variables: { id, hospitalId },
@@ -79,7 +82,7 @@ export default function PatientDischargePage() {
     return null;
   }
 
-  if (!canWritePatients) {
+  if (!canDischarge) {
     return (
       <ForbiddenAccess message="You do not have permission to discharge patients." />
     );

--- a/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
@@ -9,7 +9,14 @@ import { ClayBadge, ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { ADD_PATIENT_DOCUMENT_MUTATION, DELETE_PATIENT_DOCUMENT, DELETE_PATIENT_MUTATION, DISCHARGES_QUERY, LINK_PATIENT_ACCOUNT, ME_QUERY, PATIENT_DIAGNOSES_QUERY, PATIENT_NOTES_QUERY, PATIENT_PRESCRIPTIONS_QUERY, PATIENT_QUERY, PATIENT_VITALS_QUERY, UPDATE_PATIENT_STATUS } from '@/lib/graphql/queries';
 import { PatientClinicalActions } from '@/components/clinical/patient-clinical-actions';
+import {
+  canAdminPatients,
+  canDischargePatients,
+} from '@/lib/clinical-access';
 import { useAuth } from '@clerk/nextjs';
+
+/** Free-form status values — admission/discharge flows own admitted/discharged. */
+const EDITABLE_PATIENT_STATUSES = ['registered', 'checked_in', 'inactive'] as const;
 
 const DOCUMENT_TYPES = [
   { value: 'identification', label: 'Identification' },
@@ -121,7 +128,10 @@ export default function PatientDetailPage() {
   });
 
   const patient = data?.patient;
+  const roles: string[] = meData?.me?.roles ?? [];
   const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
+  const canDischarge = canWritePatients && canDischargePatients(roles);
+  const canLinkPortal = canWritePatients && canAdminPatients(roles);
 
   const apiBase = (
     process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql'
@@ -221,7 +231,7 @@ export default function PatientDetailPage() {
             Full History
           </ClayButton>
         </Link>
-        {patient.status === 'admitted' && canWritePatients ? (
+        {patient.status === 'admitted' && canDischarge ? (
           <Link href={`/patients/${id}/discharge`}>
             <ClayButton size="sm">Discharge</ClayButton>
           </Link>
@@ -230,17 +240,27 @@ export default function PatientDetailPage() {
           <select
             aria-label="Update patient status"
             className="rounded-2xl border border-white/60 bg-clay-surface px-3 py-2 text-sm shadow-clay-inset"
-            value={patient.status}
+            value={
+              (EDITABLE_PATIENT_STATUSES as readonly string[]).includes(patient.status)
+                ? patient.status
+                : 'registered'
+            }
             onChange={(e) => handleStatusChange(e.target.value)}
           >
-            {['registered', 'checked_in', 'admitted', 'discharged', 'inactive'].map((s) => (
+            {/* Show current admission/discharge status as read-only context when applicable */}
+            {!(EDITABLE_PATIENT_STATUSES as readonly string[]).includes(patient.status) ? (
+              <option value={patient.status} disabled>
+                {patient.status.replace(/_/g, ' ')} (via admission/discharge)
+              </option>
+            ) : null}
+            {EDITABLE_PATIENT_STATUSES.map((s) => (
               <option key={s} value={s}>
                 {s.replace(/_/g, ' ')}
               </option>
             ))}
           </select>
         ) : null}
-        {canWritePatients ? (
+        {canLinkPortal ? (
           <ClayButton
             size="sm"
             variant="ghost"
@@ -249,7 +269,7 @@ export default function PatientDetailPage() {
             Link portal account
           </ClayButton>
         ) : null}
-        {canWritePatients ? (
+        {canLinkPortal ? (
           <ClayButton
             size="sm"
             variant="ghost"

--- a/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
@@ -240,12 +240,14 @@ export default function PatientDetailPage() {
           <select
             aria-label="Update patient status"
             className="rounded-2xl border border-white/60 bg-clay-surface px-3 py-2 text-sm shadow-clay-inset"
-            value={
-              (EDITABLE_PATIENT_STATUSES as readonly string[]).includes(patient.status)
-                ? patient.status
-                : 'registered'
-            }
-            onChange={(e) => handleStatusChange(e.target.value)}
+            value={patient.status}
+            onChange={(e) => {
+              const next = e.target.value;
+              if (!(EDITABLE_PATIENT_STATUSES as readonly string[]).includes(next)) {
+                return;
+              }
+              handleStatusChange(next);
+            }}
           >
             {/* Show current admission/discharge status as read-only context when applicable */}
             {!(EDITABLE_PATIENT_STATUSES as readonly string[]).includes(patient.status) ? (

--- a/apps/web/src/app/(dashboard)/patients/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/page.tsx
@@ -6,13 +6,14 @@ import { Plus, Upload, Search } from 'lucide-react';
 import { useState } from 'react';
 import { ClayBadge, ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { QueryError } from '@/components/query-error';
 import { ME_QUERY, PATIENTS_QUERY } from '@/lib/graphql/queries';
 
 export default function PatientsPage() {
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const { data: meData } = useQuery(ME_QUERY);
-  const { data, loading } = useQuery(PATIENTS_QUERY, {
+  const { data, loading, error, refetch } = useQuery(PATIENTS_QUERY, {
     variables: {
       page,
       limit: 20,
@@ -23,12 +24,15 @@ export default function PatientsPage() {
   });
 
   const patients = data?.patients?.items ?? [];
-  const total = data?.patients?.total ?? 0;
+  const total = error ? 0 : (data?.patients?.total ?? 0);
   const canWritePatients = (meData?.me?.permissions ?? []).includes('patients:write');
 
   return (
     <div>
-      <DashboardHeader title="Patients" subtitle={`${total} patients registered`} />
+      <DashboardHeader
+        title="Patients"
+        subtitle={error ? 'Unable to load patients' : `${total} patients registered`}
+      />
 
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div className="relative flex-1 max-w-md">
@@ -74,6 +78,15 @@ export default function PatientsPage() {
             {loading ? (
               <tr>
                 <td colSpan={5} className="px-6 py-8 text-center text-clay-text-muted">Loading patients...</td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-8">
+                  <QueryError
+                    message="We could not load patients. Please try again."
+                    onRetry={() => void refetch()}
+                  />
+                </td>
               </tr>
             ) : patients.length === 0 ? (
               <tr>

--- a/apps/web/src/app/(dashboard)/pharmacy/page.tsx
+++ b/apps/web/src/app/(dashboard)/pharmacy/page.tsx
@@ -12,6 +12,7 @@ import {
   PHARMACY_STOCK_QUERY,
   UPSERT_PHARMACY_STOCK_MUTATION,
 } from '@/lib/graphql/queries';
+import { QueryError } from '@/components/query-error';
 
 export default function PharmacyPage() {
   const [drugName, setDrugName] = useState('');
@@ -23,12 +24,12 @@ export default function PharmacyPage() {
   const hospitalId = meData?.me?.hospitalId;
   const canWrite = (meData?.me?.permissions ?? []).includes('patients:write');
 
-  const { data: rxData, loading: rxLoading, refetch: refetchRx } = useQuery(
+  const { data: rxData, loading: rxLoading, error: rxError, refetch: refetchRx } = useQuery(
     PENDING_PRESCRIPTIONS_QUERY,
     { variables: { hospitalId }, skip: !hospitalId },
   );
 
-  const { data: stockData, loading: stockLoading, refetch: refetchStock } = useQuery(
+  const { data: stockData, loading: stockLoading, error: stockError, refetch: refetchStock } = useQuery(
     PHARMACY_STOCK_QUERY,
     { variables: { hospitalId }, skip: !hospitalId },
   );
@@ -99,6 +100,13 @@ export default function PharmacyPage() {
           </div>
           {rxLoading ? (
             <p className="px-6 py-8 text-center text-clay-text-muted">Loading...</p>
+          ) : rxError ? (
+            <div className="px-6 py-8">
+              <QueryError
+                message="We could not load pending prescriptions. Please try again."
+                onRetry={() => void refetchRx()}
+              />
+            </div>
           ) : prescriptions.length === 0 ? (
             <div className="px-6 py-12 text-center">
               <Pill className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />
@@ -186,6 +194,13 @@ export default function PharmacyPage() {
             </div>
             {stockLoading ? (
               <p className="px-6 py-8 text-center text-clay-text-muted">Loading...</p>
+            ) : stockError ? (
+              <div className="px-6 py-8">
+                <QueryError
+                  message="We could not load pharmacy stock. Please try again."
+                  onRetry={() => void refetchStock()}
+                />
+              </div>
             ) : stock.length === 0 ? (
               <p className="px-6 py-8 text-center text-clay-text-muted">No stock entries yet.</p>
             ) : (

--- a/apps/web/src/app/(dashboard)/reports/page.tsx
+++ b/apps/web/src/app/(dashboard)/reports/page.tsx
@@ -13,6 +13,7 @@ import {
 import { ClayButton, ClayCard, ClayStatCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { BED_OCCUPANCY_QUERY, HOSPITAL_REPORTS_QUERY, ME_QUERY } from '@/lib/graphql/queries';
+import { canAccessRoute } from '@/lib/route-access';
 
 export default function ReportsPage() {
   const { data: meData } = useQuery(ME_QUERY);
@@ -132,12 +133,35 @@ export default function ReportsPage() {
             <h2 className="mb-4 text-lg font-semibold text-clay-text">Beds by ward</h2>
             {occupancyQuery.loading ? (
               <p className="text-sm text-clay-text-muted">Loading occupancy...</p>
+            ) : occupancyQuery.error ? (
+              <div className="space-y-3">
+                <p className="text-sm text-clay-error">
+                  We could not load bed occupancy. Please try again.
+                </p>
+                <ClayButton
+                  type="button"
+                  size="sm"
+                  onClick={() => void occupancyQuery.refetch()}
+                >
+                  Try again
+                </ClayButton>
+              </div>
             ) : wards.length === 0 ? (
               <p className="text-sm text-clay-text-muted">
-                No wards configured yet.{' '}
-                <Link href="/settings/facility" className="text-clay-primary hover:underline">
-                  Set up facility
-                </Link>
+                No wards configured yet.
+                {canAccessRoute('/settings', {
+                  roles: meData?.me?.roles ?? [],
+                  permissions: meData?.me?.permissions ?? [],
+                }) ? (
+                  <>
+                    {' '}
+                    <Link href="/settings/facility" className="text-clay-primary hover:underline">
+                      Set up facility
+                    </Link>
+                  </>
+                ) : (
+                  ' Ask an administrator to configure wards and beds.'
+                )}
               </p>
             ) : (
               <div className="overflow-x-auto">

--- a/apps/web/src/app/(dashboard)/staff/[id]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/staff/[id]/edit/page.tsx
@@ -30,7 +30,7 @@ export default function EditStaffPage() {
   const [error, setError] = useState('');
 
   const { data: meData } = useQuery(ME_QUERY);
-  const { data, loading: fetching } = useQuery(STAFF_MEMBER_QUERY, {
+  const { data, loading: fetching, error: fetchError } = useQuery(STAFF_MEMBER_QUERY, {
     variables: { id },
   });
 
@@ -73,11 +73,22 @@ export default function EditStaffPage() {
     return <p className="text-clay-text-muted">Loading...</p>;
   }
 
+  if (fetchError) {
+    return (
+      <p className="text-sm text-clay-error">
+        We could not load this staff member. Please try again.
+      </p>
+    );
+  }
+
   const member = data?.staffMember;
+  if (!member) {
+    return <p className="text-clay-error">Staff member not found</p>;
+  }
 
   return (
     <div>
-      <DashboardHeader title="Edit Staff Member" subtitle={member?.fullName} />
+      <DashboardHeader title="Edit Staff Member" subtitle={member.fullName} />
       {error ? <p className="mb-4 text-sm text-clay-error">{error}</p> : null}
       <StaffForm
         defaultValues={member}

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -12,7 +12,7 @@ export default function AuthCallbackPage() {
     <div className="flex min-h-screen items-center justify-center bg-clay-bg px-6">
       <p className="text-clay-text-muted">Finishing sign in…</p>
       <AuthenticateWithRedirectCallback
-        signInFallbackRedirectUrl="/dashboard"
+        signInFallbackRedirectUrl="/onboarding"
         signUpFallbackRedirectUrl="/onboarding"
       />
     </div>

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -19,7 +19,7 @@ export function LoginForm() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  const redirectTo = safeInternalPath(searchParams.get('redirect'), '/dashboard');
+  const redirectTo = safeInternalPath(searchParams.get('redirect'), '/onboarding');
 
   const {
     register,

--- a/apps/web/src/components/clinical/patient-clinical-actions.tsx
+++ b/apps/web/src/components/clinical/patient-clinical-actions.tsx
@@ -29,6 +29,13 @@ import {
   STAFF_MEMBERS_QUERY,
   WARDS_QUERY,
 } from '@/lib/graphql/queries';
+import {
+  canAccessRoute,
+} from '@/lib/route-access';
+import {
+  canActAsClinician,
+  canAuthorClinical,
+} from '@/lib/clinical-access';
 
 interface PatientClinicalActionsProps {
   patientId: string;
@@ -63,19 +70,21 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
 
   const { data: meData } = useQuery(ME_QUERY);
   const permissions = meData?.me?.permissions ?? [];
+  const roles: string[] = meData?.me?.roles ?? [];
   const canWritePatients = permissions.includes('patients:write');
   const canWriteAppointments = permissions.includes('appointments:write');
-  const canWriteLabs =
-    permissions.includes('lab:write') || permissions.includes('patients:write');
+  const canAuthor = canAuthorClinical(roles);
+  const canClinician = canActAsClinician(roles);
+  const canManageFacility = canAccessRoute('/settings', { roles, permissions });
 
   const actionPermissions: Record<ActionKey, boolean> = {
     appointment: canWriteAppointments,
     admit: canWritePatients,
-    vitals: canWritePatients,
-    soap: canWritePatients,
-    diagnosis: canWritePatients,
-    prescription: canWritePatients,
-    lab: canWriteLabs,
+    vitals: canWritePatients && canAuthor,
+    soap: canWritePatients && canAuthor,
+    diagnosis: canWritePatients && canClinician,
+    prescription: canWritePatients && canClinician,
+    lab: canWritePatients && canAuthor,
   };
 
   const visibleActions = actions.filter(({ key }) => actionPermissions[key]);
@@ -379,12 +388,18 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
                         ))}
                       </select>
                       {wards.length === 0 && !wardsQuery.loading ? (
-                        <Link
-                          href="/settings/facility"
-                          className="text-xs text-clay-primary hover:underline"
-                        >
-                          No wards yet — set them up →
-                        </Link>
+                        canManageFacility ? (
+                          <Link
+                            href="/settings/facility"
+                            className="text-xs text-clay-primary hover:underline"
+                          >
+                            No wards yet — set them up →
+                          </Link>
+                        ) : (
+                          <p className="text-xs text-clay-text-muted">
+                            No wards yet — ask an administrator to set them up.
+                          </p>
+                        )
                       ) : null}
                     </div>
                     <div className="flex flex-col gap-2">

--- a/apps/web/src/components/query-error.tsx
+++ b/apps/web/src/components/query-error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { ClayButton } from '@careconnect/ui';
+
+export function QueryError({
+  message = 'We could not load this data. Please try again.',
+  onRetry,
+  className = '',
+}: {
+  message?: string;
+  onRetry?: () => void;
+  className?: string;
+}) {
+  return (
+    <div className={`space-y-3 text-center ${className}`.trim()}>
+      <p className="text-sm text-clay-error">{message}</p>
+      {onRetry ? (
+        <ClayButton type="button" size="sm" onClick={onRetry}>
+          Try again
+        </ClayButton>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/clinical-access.ts
+++ b/apps/web/src/lib/clinical-access.ts
@@ -1,0 +1,56 @@
+/** Roles that may discharge / transfer-out (matches API @Roles). */
+export const DISCHARGE_ROLES = [
+  'doctor',
+  'nurse',
+  'hospital_admin',
+  'hospital_manager',
+  'super_admin',
+] as const;
+
+/** Doctor + nurse + admins — notes, vitals, lab orders. */
+export const CLINICAL_AUTHOR_ROLES = [
+  'doctor',
+  'nurse',
+  'hospital_admin',
+  'hospital_manager',
+  'super_admin',
+] as const;
+
+/** Doctor + admins — diagnosis, prescriptions. */
+export const CLINICIAN_ROLES = [
+  'doctor',
+  'hospital_admin',
+  'hospital_manager',
+  'super_admin',
+] as const;
+
+/** Admin roles for destructive / portal-link patient actions. */
+export const PATIENT_ADMIN_ROLES = [
+  'hospital_admin',
+  'hospital_manager',
+  'super_admin',
+] as const;
+
+export function hasAnyRole(
+  roles: string[] | undefined,
+  allowed: readonly string[],
+): boolean {
+  if (!roles?.length) return false;
+  return allowed.some((role) => roles.includes(role));
+}
+
+export function canDischargePatients(roles: string[] | undefined): boolean {
+  return hasAnyRole(roles, DISCHARGE_ROLES);
+}
+
+export function canAuthorClinical(roles: string[] | undefined): boolean {
+  return hasAnyRole(roles, CLINICAL_AUTHOR_ROLES);
+}
+
+export function canActAsClinician(roles: string[] | undefined): boolean {
+  return hasAnyRole(roles, CLINICIAN_ROLES);
+}
+
+export function canAdminPatients(roles: string[] | undefined): boolean {
+  return hasAnyRole(roles, PATIENT_ADMIN_ROLES);
+}

--- a/apps/web/src/lib/route-access.ts
+++ b/apps/web/src/lib/route-access.ts
@@ -24,9 +24,20 @@ const WRITE_ROUTE_RULES: RouteRule[] = [
   { prefix: '/staff/new', anyPermissions: ['staff:write'] },
 ];
 
-const WRITE_ROUTE_PATTERNS: { pattern: RegExp; anyPermissions: string[] }[] = [
+const WRITE_ROUTE_PATTERNS: {
+  pattern: RegExp;
+  anyPermissions?: string[];
+  anyRoles?: string[];
+  /** When both are set, require permission AND role (e.g. discharge). */
+  requireAll?: boolean;
+}[] = [
   { pattern: /^\/patients\/[^/]+\/edit$/, anyPermissions: ['patients:write'] },
-  { pattern: /^\/patients\/[^/]+\/discharge$/, anyPermissions: ['patients:write'] },
+  {
+    pattern: /^\/patients\/[^/]+\/discharge$/,
+    anyPermissions: ['patients:write'],
+    anyRoles: ['doctor', 'nurse', 'hospital_admin', 'hospital_manager'],
+    requireAll: true,
+  },
   { pattern: /^\/staff\/[^/]+\/edit$/, anyPermissions: ['staff:write'] },
 ];
 
@@ -77,15 +88,31 @@ const SORTED_WRITE_RULES = [...WRITE_ROUTE_RULES].sort(
   (a, b) => b.prefix.length - a.prefix.length,
 );
 
-function hasWriteAccess(anyPermissions: string[], ctx: AccessContext): boolean {
+function hasWriteAccess(
+  rule: {
+    anyPermissions?: string[];
+    anyRoles?: string[];
+    requireAll?: boolean;
+  },
+  ctx: AccessContext,
+): boolean {
   if (ctx.roles.includes('super_admin')) return true;
-  return anyPermissions.some((perm) => ctx.permissions.includes(perm));
+  const hasPerm = rule.anyPermissions
+    ? rule.anyPermissions.some((perm) => ctx.permissions.includes(perm))
+    : false;
+  const hasRole = rule.anyRoles
+    ? rule.anyRoles.some((role) => ctx.roles.includes(role))
+    : false;
+  if (rule.requireAll && rule.anyPermissions && rule.anyRoles) {
+    return hasPerm && hasRole;
+  }
+  return hasPerm || hasRole;
 }
 
 function matchesWriteRoute(pathname: string, ctx: AccessContext): boolean | null {
-  for (const { pattern, anyPermissions } of WRITE_ROUTE_PATTERNS) {
-    if (pattern.test(pathname)) {
-      return hasWriteAccess(anyPermissions, ctx);
+  for (const rule of WRITE_ROUTE_PATTERNS) {
+    if (rule.pattern.test(pathname)) {
+      return hasWriteAccess(rule, ctx);
     }
   }
 
@@ -93,7 +120,7 @@ function matchesWriteRoute(pathname: string, ctx: AccessContext): boolean | null
     (r) => pathname === r.prefix || pathname.startsWith(`${r.prefix}/`),
   );
   if (!writeRule?.anyPermissions) return null;
-  return hasWriteAccess(writeRule.anyPermissions, ctx);
+  return hasWriteAccess(writeRule, ctx);
 }
 
 /** Routes any authenticated non-patient staff may open without a specific rule */


### PR DESCRIPTION
## Summary
- Closes all open rescan issues **#143–#162** (HIGH/MEDIUM/LOW) without breaking working clinical, pharmacy, or bootstrap flows
- **HIGH:** Staff invite rejects patient dual-role and preserves live Clerk `authId`; `createHospital` limited to bootstrap + `super_admin`
- **MEDIUM:** Clinical/pharmacy/patient role gates on API + matching UI CTAs; discharge doctor validation; auth redirects to `/onboarding`; GraphQL fail-closed on operational/finance/reports pages
- **LOW:** Facility links admin-only; Admit quick action write-gated; status select no free-form admitted/discharged; staff edit not-found

## Test plan
- [ ] Invite staff with a patient-portal email → clear rejection; invite non-patient hospital-less user with live `user_…` → authId preserved
- [ ] Bound hospital_admin cannot `createHospital`; bootstrap + super_admin still can
- [ ] Receptionist: no discharge/SOAP/vitals/Rx CTAs; pharmacist: no follow-up mutate / pharmacy queries blocked for lab tech
- [ ] Admin can delete/link patient; receptionist demographics create/update still works
- [ ] Login/OAuth without redirect lands on `/onboarding`
- [ ] Kill GraphQL briefly → pharmacy/patients/etc. show retry, not empty zeros; reports occupancy error ≠ “no wards”
- [ ] Staff edit unknown id → not found, not empty form


Made with [Cursor](https://cursor.com)