### PR TITLE
fix: rescan issues #176–#184 (pharmacist PHI, admin hierarchy, hospital inactive)

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -110,6 +110,10 @@ describe('AuthService', () => {
           },
         ],
       });
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-1',
+        isActive: true,
+      });
 
       const result = await service.syncAndGetUser(
         'auth-1',
@@ -122,6 +126,7 @@ describe('AuthService', () => {
         email: 'active@hospital.com',
         fullName: 'Active User',
         hospitalId: 'hospital-1',
+        hospitalActive: true,
         roles: ['hospital_admin'],
         permissions: ['patients:read'],
         onboardingCompleted: true,

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -130,8 +130,12 @@ describe('AuthService', () => {
   });
 
   describe('toAuthenticatedUser', () => {
-    it('filters out roles from a different hospital', () => {
-      const result = service.toAuthenticatedUser({
+    it('filters out roles from a different hospital', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: true,
+      });
+      const result = await service.toAuthenticatedUser({
         id: 'user-1',
         authId: 'auth-1',
         email: 'doc@hospital.com',
@@ -162,10 +166,15 @@ describe('AuthService', () => {
 
       expect(result.roles).toEqual(['nurse']);
       expect(result.permissions).toEqual(['patients:read']);
+      expect(result.hospitalActive).toBe(true);
     });
 
-    it('keeps platform roles regardless of hospital scope', () => {
-      const result = service.toAuthenticatedUser({
+    it('keeps platform roles regardless of hospital scope', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: true,
+      });
+      const result = await service.toAuthenticatedUser({
         id: 'user-1',
         authId: 'auth-1',
         email: 'admin@careconnect.com',
@@ -193,6 +202,36 @@ describe('AuthService', () => {
 
       expect(result.roles).toEqual(['super_admin']);
       expect(result.permissions).toEqual(['hospitals:write']);
+    });
+
+    it('strips hospital staff roles when the hospital is deactivated', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: false,
+      });
+      const result = await service.toAuthenticatedUser({
+        id: 'user-1',
+        authId: 'auth-1',
+        email: 'nurse@hospital.com',
+        fullName: 'Nurse',
+        hospitalId: 'hospital-a',
+        isActive: true,
+        onboardingCompleted: true,
+        userRoles: [
+          {
+            hospitalId: 'hospital-a',
+            role: {
+              slug: 'nurse',
+              permissions: [{ slug: 'patients:read' }],
+            },
+          },
+        ],
+      } as User);
+
+      expect(result.roles).toEqual([]);
+      expect(result.permissions).toEqual([]);
+      expect(result.hospitalActive).toBe(false);
+      expect(result.hospitalId).toBe('hospital-a');
     });
   });
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -97,9 +97,17 @@ export class AuthService {
     return this.toAuthenticatedUser(user);
   }
 
-  toAuthenticatedUser(user: User): AuthenticatedUser {
+  async toAuthenticatedUser(user: User): Promise<AuthenticatedUser> {
     const activeHospitalId = user.hospitalId;
     const PLATFORM_ROLE_SLUGS = new Set(['super_admin', 'patient']);
+
+    let hospitalActive = true;
+    if (activeHospitalId) {
+      const hospital = await this.hospitalsRepo.findOne({
+        where: { id: activeHospitalId },
+      });
+      hospitalActive = !hospital || hospital.isActive;
+    }
 
     const scopedRoles =
       user.userRoles?.filter((ur) => {
@@ -111,8 +119,8 @@ export class AuthService {
         return !!activeHospitalId && ur.hospitalId === activeHospitalId;
       }) ?? [];
 
-    const roles = scopedRoles.map((ur) => ur.role.slug);
-    const permissions = [
+    let roles = scopedRoles.map((ur) => ur.role.slug);
+    let permissions = [
       ...new Set(
         scopedRoles.flatMap(
           (ur) => ur.role.permissions?.map((p) => p.slug) ?? [],
@@ -120,12 +128,20 @@ export class AuthService {
       ),
     ];
 
+    // Deactivated hospital: strip hospital-scoped staff roles/permissions so
+    // tenant APIs fail closed. Keep platform patient/super_admin identities.
+    if (!hospitalActive && !roles.includes('super_admin')) {
+      roles = roles.filter((slug) => PLATFORM_ROLE_SLUGS.has(slug));
+      permissions = [];
+    }
+
     return {
       id: user.id,
       authId: user.authId,
       email: user.email,
       fullName: user.fullName,
       hospitalId: user.hospitalId,
+      hospitalActive,
       roles: roles as AuthenticatedUser['roles'],
       permissions,
       onboardingCompleted: user.onboardingCompleted,

--- a/apps/api/src/auth/auth.types.ts
+++ b/apps/api/src/auth/auth.types.ts
@@ -16,6 +16,8 @@ export interface AuthenticatedUser {
   email: string;
   fullName: string;
   hospitalId?: string;
+  /** False when the user's bound hospital is deactivated. */
+  hospitalActive?: boolean;
   roles: RoleSlug[];
   permissions: string[];
   onboardingCompleted: boolean;

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -7,7 +7,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { existsSync } from 'fs';
 import { basename, join } from 'path';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
 import {
   Admission,
   ClinicalNote,
@@ -645,7 +645,29 @@ export class ClinicalService {
       order: { createdAt: 'DESC' },
       take: 200,
     });
-    return orders.map((o) => this.toLabOrderType(o));
+
+    const completedOrderIds = orders
+      .filter((o) => o.status === 'completed')
+      .map((o) => o.id);
+    const resultsByOrderId = new Map<string, LabResult>();
+    if (completedOrderIds.length > 0) {
+      const results = await this.labResultsRepo.find({
+        where: { hospitalId, labOrderId: In(completedOrderIds) },
+        order: { completedAt: 'DESC' },
+      });
+      for (const result of results) {
+        if (!resultsByOrderId.has(result.labOrderId)) {
+          resultsByOrderId.set(result.labOrderId, result);
+        }
+      }
+    }
+
+    return orders.map((o) => ({
+      ...this.toLabOrderType(o),
+      result: resultsByOrderId.has(o.id)
+        ? this.toLabResultType(resultsByOrderId.get(o.id)!)
+        : undefined,
+    }));
   }
 
   async listVitalSigns(

--- a/apps/api/src/clinical/clinical.types.ts
+++ b/apps/api/src/clinical/clinical.types.ts
@@ -215,6 +215,9 @@ export class LabOrderType {
 
   @Field()
   updatedAt: Date;
+
+  @Field(() => LabResultType, { nullable: true })
+  result?: LabResultType;
 }
 
 @ObjectType()

--- a/apps/api/src/patients/patients.module.ts
+++ b/apps/api/src/patients/patients.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import {
   Admission,
+  LabOrder,
+  LabResult,
   Patient,
   PatientAllergy,
   PatientConsent,

--- a/apps/api/src/patients/patients.module.ts
+++ b/apps/api/src/patients/patients.module.ts
@@ -30,6 +30,8 @@ import { PatientsService } from './patients.service';
       PatientImportJob,
       User,
       Admission,
+      LabOrder,
+      LabResult,
     ]),
   ],
   providers: [PatientsResolver, PatientsService],

--- a/apps/api/src/patients/patients.resolver.ts
+++ b/apps/api/src/patients/patients.resolver.ts
@@ -61,6 +61,14 @@ export class PatientsResolver {
   }
 
   @Mutation(() => PatientType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async createPatient(
     @CurrentUser() user: AuthenticatedUser,
@@ -75,6 +83,14 @@ export class PatientsResolver {
   }
 
   @Mutation(() => PatientType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async updatePatient(
     @CurrentUser() user: AuthenticatedUser,
@@ -110,6 +126,14 @@ export class PatientsResolver {
   }
 
   @Mutation(() => PatientType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async updatePatientStatus(
     @CurrentUser() user: AuthenticatedUser,
@@ -130,6 +154,14 @@ export class PatientsResolver {
   }
 
   @Mutation(() => BulkImportResultType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async importPatients(
     @CurrentUser() user: AuthenticatedUser,
@@ -151,6 +183,14 @@ export class PatientsResolver {
   }
 
   @Mutation(() => PatientDocumentType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async addPatientDocument(
     @CurrentUser() user: AuthenticatedUser,
@@ -179,6 +219,14 @@ export class PatientsResolver {
   }
 
   @Mutation(() => Boolean)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
   @Permissions(PERMISSIONS.PATIENTS_WRITE)
   async deletePatientDocument(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -21,6 +21,8 @@ import {
   PatientMedicalHistory,
   PatientMedication,
   Admission,
+  LabOrder,
+  LabResult,
   User,
 } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
@@ -432,6 +434,8 @@ export class PatientsService {
     await this.patientsRepo.manager.transaction(async (manager) => {
       const patientsRepo = manager.getRepository(Patient);
       const documentsRepo = manager.getRepository(PatientDocument);
+      const labOrdersRepo = manager.getRepository(LabOrder);
+      const labResultsRepo = manager.getRepository(LabResult);
 
       patient.userId = null as unknown as string | undefined;
       await patientsRepo.save(patient);
@@ -442,6 +446,19 @@ export class PatientsService {
       for (const document of documents) {
         if (document.fileUrl) fileUrlsToUnlink.push(document.fileUrl);
         await documentsRepo.remove(document);
+      }
+
+      const labOrders = await labOrdersRepo.find({
+        where: { patientId: id, hospitalId },
+        select: ['id'],
+      });
+      for (const order of labOrders) {
+        const results = await labResultsRepo.find({
+          where: { labOrderId: order.id, hospitalId },
+        });
+        for (const result of results) {
+          if (result.resultFileUrl) fileUrlsToUnlink.push(result.resultFileUrl);
+        }
       }
 
       await patientsRepo.softRemove(patient);

--- a/apps/api/src/portal/portal.module.ts
+++ b/apps/api/src/portal/portal.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import {
   Appointment,
+  Hospital,
   LabOrder,
   LabResult,
   Patient,
@@ -20,6 +21,7 @@ import { PortalService } from './portal.service';
       Prescription,
       LabOrder,
       LabResult,
+      Hospital,
     ]),
     AppointmentsModule,
     ClinicalModule,

--- a/apps/api/src/portal/portal.service.spec.ts
+++ b/apps/api/src/portal/portal.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
   Appointment,
+  Hospital,
   LabOrder,
   LabResult,
   Patient,
@@ -20,6 +21,7 @@ describe('PortalService', () => {
   const prescriptionsRepo = { find: jest.fn() };
   const labOrdersRepo = { find: jest.fn() };
   const labResultsRepo = { find: jest.fn() };
+  const hospitalsRepo = { findOne: jest.fn() };
   const appointmentsService = {
     toAppointmentType: jest.fn((a: unknown) => a),
   };
@@ -40,6 +42,10 @@ describe('PortalService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    hospitalsRepo.findOne.mockResolvedValue({
+      id: 'hospital-a',
+      isActive: true,
+    });
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PortalService,
@@ -54,6 +60,7 @@ describe('PortalService', () => {
         },
         { provide: getRepositoryToken(LabOrder), useValue: labOrdersRepo },
         { provide: getRepositoryToken(LabResult), useValue: labResultsRepo },
+        { provide: getRepositoryToken(Hospital), useValue: hospitalsRepo },
         { provide: AppointmentsService, useValue: appointmentsService },
         { provide: ClinicalService, useValue: clinicalService },
       ],

--- a/apps/api/src/portal/portal.service.ts
+++ b/apps/api/src/portal/portal.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import {
   Appointment,
+  Hospital,
   LabOrder,
   LabResult,
   Patient,
@@ -30,6 +31,8 @@ export class PortalService {
     private readonly labOrdersRepo: Repository<LabOrder>,
     @InjectRepository(LabResult)
     private readonly labResultsRepo: Repository<LabResult>,
+    @InjectRepository(Hospital)
+    private readonly hospitalsRepo: Repository<Hospital>,
     private readonly appointmentsService: AppointmentsService,
     private readonly clinicalService: ClinicalService,
   ) {}
@@ -79,6 +82,15 @@ export class PortalService {
         prescriptions: [],
         labResults: [],
       };
+    }
+
+    const hospital = await this.hospitalsRepo.findOne({
+      where: { id: patient.hospitalId },
+    });
+    if (!hospital || !hospital.isActive) {
+      throw new ForbiddenException(
+        'This hospital is currently inactive; portal records are unavailable',
+      );
     }
 
     const appointments = await this.appointmentsRepo.find({

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -272,6 +272,20 @@ export class StaffService {
     const staff = await this.findByIdForUser(id, actor);
     if (!staff) throw new NotFoundException('Staff member not found');
 
+    const targetIsHospitalAdmin = (staff.user?.userRoles ?? []).some(
+      (ur) => ur.role?.slug === 'hospital_admin',
+    );
+    const actorIsAdmin =
+      actor.roles.includes('hospital_admin') ||
+      actor.roles.includes('super_admin');
+    const touchingPrivileges =
+      input.roleSlug !== undefined || input.isActive !== undefined;
+    if (targetIsHospitalAdmin && touchingPrivileges && !actorIsAdmin) {
+      throw new ForbiddenException(
+        'Only a hospital admin can change or deactivate another hospital admin',
+      );
+    }
+
     if (input.fullName) {
       await this.usersRepo.update(staff.userId, { fullName: input.fullName });
     }

--- a/apps/web/src/app/(dashboard)/admissions/page.tsx
+++ b/apps/web/src/app/(dashboard)/admissions/page.tsx
@@ -16,7 +16,7 @@ import {
   PATIENTS_QUERY,
   WARDS_QUERY,
 } from '@/lib/graphql/queries';
-import { canDischargePatients } from '@/lib/clinical-access';
+import { canAdmitPatients, canDischargePatients } from '@/lib/clinical-access';
 import { canAccessRoute } from '@/lib/route-access';
 import { QueryError } from '@/components/query-error';
 
@@ -35,6 +35,7 @@ export default function AdmissionsPage() {
   const roles: string[] = meData?.me?.roles ?? [];
   const permissions: string[] = meData?.me?.permissions ?? [];
   const canWritePatients = permissions.includes('patients:write');
+  const canAdmit = canWritePatients && canAdmitPatients(roles);
   const canDischarge = canWritePatients && canDischargePatients(roles);
   const canManageFacility = canAccessRoute('/settings', { roles, permissions });
 
@@ -123,7 +124,7 @@ export default function AdmissionsPage() {
             Bed Occupancy
           </ClayButton>
         </Link>
-        {canWritePatients ? (
+        {canAdmit ? (
         <ClayButton onClick={() => setShowForm(!showForm)}>
           <Plus className="h-4 w-4" />
           {showForm ? 'Hide Form' : 'Admit Patient'}

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -20,7 +20,7 @@ const QUICK_ACTIONS = [
   { label: 'Bulk Import Patients', href: '/patients/import', anyPermissions: ['patients:write'] },
   { label: 'New Appointment', href: '/appointments/new', anyPermissions: ['appointments:write'] },
   { label: 'View Appointments', href: '/appointments' },
-  { label: 'Admit Patient', href: '/admissions', anyPermissions: ['patients:write'] },
+  { label: 'Admit Patient', href: '/admissions', anyPermissions: ['patients:write'], anyRoles: ['doctor', 'nurse', 'receptionist', 'hospital_admin', 'hospital_manager'] },
   { label: 'Add Staff Member', href: '/staff/new', anyPermissions: ['staff:write'] },
   { label: 'View Staff Directory', href: '/staff' },
   { label: 'Lab Queue', href: '/lab' },
@@ -31,6 +31,12 @@ function canSeeQuickAction(
   access: { roles: string[]; permissions: string[] },
 ): boolean {
   if (!canAccessRoute(action.href, access)) return false;
+  if ('anyRoles' in action && action.anyRoles) {
+    const hasRole =
+      access.roles.includes('super_admin') ||
+      action.anyRoles.some((role) => access.roles.includes(role));
+    if (!hasRole) return false;
+  }
   if ('anyPermissions' in action && action.anyPermissions) {
     return action.anyPermissions.some((perm) => access.permissions.includes(perm));
   }

--- a/apps/web/src/app/(dashboard)/finance/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/page.tsx
@@ -6,6 +6,7 @@ import { DollarSign, FileText, Plus } from 'lucide-react';
 import { ClayButton, ClayCard, ClayStatCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { HOSPITAL_REPORTS_QUERY, INVOICES_QUERY, ME_QUERY } from '@/lib/graphql/queries';
+import { canAccessRoute } from '@/lib/route-access';
 
 export default function FinancePage() {
   const { data: meData } = useQuery(ME_QUERY);
@@ -41,6 +42,19 @@ export default function FinancePage() {
   const invoiceCountDisplay = (value: number | null) =>
     value == null ? '—' : value;
   const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
+  const accessCtx = {
+    roles: meData?.me?.roles ?? [],
+    permissions: meData?.me?.permissions ?? [],
+  };
+  const canSeeReports = canAccessRoute('/reports', accessCtx);
+
+  const quickLinks = [
+    { label: 'View All Invoices', href: '/finance/invoices' },
+    ...(canWriteBilling
+      ? [{ label: 'Create Invoice', href: '/finance/invoices/new' }]
+      : []),
+    ...(canSeeReports ? [{ label: 'Reports Hub', href: '/reports' }] : []),
+  ];
 
   return (
     <div>
@@ -81,13 +95,7 @@ export default function FinancePage() {
       <ClayCard>
         <h2 className="mb-4 text-lg font-semibold text-clay-text">Quick Links</h2>
         <div className="grid gap-3 sm:grid-cols-2">
-          {[
-            { label: 'View All Invoices', href: '/finance/invoices' },
-            ...(canWriteBilling
-              ? [{ label: 'Create Invoice', href: '/finance/invoices/new' }]
-              : []),
-            { label: 'Reports Hub', href: '/reports' },
-          ].map((action) => (
+          {quickLinks.map((action) => (
             <Link
               key={action.label}
               href={action.href}

--- a/apps/web/src/app/(dashboard)/lab/page.tsx
+++ b/apps/web/src/app/(dashboard)/lab/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { useMutation, useQuery } from '@apollo/client';
-import { FlaskConical } from 'lucide-react';
+import { useAuth } from '@clerk/nextjs';
+import { FileText, FlaskConical, Upload } from 'lucide-react';
 import { ClayBadge, ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
 import { ClayTextarea } from '@/components/clinical/clay-textarea';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
@@ -29,22 +30,43 @@ const statusVariant = (status: string) => {
   }
 };
 
+type LabOrderRow = {
+  id: string;
+  testName: string;
+  status: string;
+  createdAt: string;
+  patient?: { fullName: string };
+  result?: {
+    resultValue?: string;
+    resultFileUrl?: string;
+  };
+};
+
 export default function LabPage() {
+  const { getToken } = useAuth();
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
   const [resultValue, setResultValue] = useState('');
   const [referenceRange, setReferenceRange] = useState('');
   const [unit, setUnit] = useState('');
+  const [resultFileUrl, setResultFileUrl] = useState<string | null>(null);
+  const [resultFileName, setResultFileName] = useState('');
+  const [uploading, setUploading] = useState(false);
   const [showNewOrder, setShowNewOrder] = useState(false);
   const [patientId, setPatientId] = useState('');
   const [patientSearch, setPatientSearch] = useState('');
   const [testName, setTestName] = useState('');
   const [orderNotes, setOrderNotes] = useState('');
   const [error, setError] = useState('');
+  const [fileError, setFileError] = useState('');
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
   const canCreateOrders = (meData?.me?.permissions ?? []).includes('patients:write');
   const canWriteLab = (meData?.me?.permissions ?? []).includes('lab:write');
+
+  const apiBase = (
+    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql'
+  ).replace(/\/graphql\/?$/, '');
 
   const { data, loading, error: listError, refetch } = useQuery(LAB_ORDERS_QUERY, {
     variables: { hospitalId, status: undefined },
@@ -56,13 +78,20 @@ export default function LabPage() {
     skip: !hospitalId || !canCreateOrders || patientSearch.length < 2,
   });
 
+  const resetCompleteForm = () => {
+    setSelectedOrderId(null);
+    setResultValue('');
+    setReferenceRange('');
+    setUnit('');
+    setResultFileUrl(null);
+    setResultFileName('');
+    setFileError('');
+  };
+
   const [completeResult, { loading: completing }] = useMutation(COMPLETE_LAB_RESULT_MUTATION, {
     onCompleted: () => {
       refetch();
-      setSelectedOrderId(null);
-      setResultValue('');
-      setReferenceRange('');
-      setUnit('');
+      resetCompleteForm();
     },
   });
 
@@ -76,8 +105,66 @@ export default function LabPage() {
     },
   });
 
-  const orders = data?.labOrders ?? [];
-  const pendingOrders = orders.filter((o: { status: string }) => o.status !== 'completed' && o.status !== 'cancelled');
+  const orders: LabOrderRow[] = data?.labOrders ?? [];
+  const pendingOrders = orders.filter(
+    (o) => o.status !== 'completed' && o.status !== 'cancelled',
+  );
+
+  const handleOpenResultFile = async (fileUrl: string) => {
+    setFileError('');
+    const token = await getToken();
+    let pathname: string;
+    try {
+      pathname = fileUrl.startsWith('/uploads/')
+        ? fileUrl.split('?')[0] ?? fileUrl
+        : new URL(fileUrl, apiBase).pathname;
+    } catch {
+      setFileError('Invalid document URL');
+      return;
+    }
+    if (!/^\/uploads\/[^/]+$/.test(pathname) || pathname.includes('..')) {
+      setFileError('Invalid document URL');
+      return;
+    }
+    const res = await fetch(`${apiBase}${pathname}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) {
+      setFileError('Unable to open result file');
+      return;
+    }
+    const blob = await res.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    window.open(objectUrl, '_blank', 'noopener,noreferrer');
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+  };
+
+  const handleFileUpload = async (file: File) => {
+    setUploading(true);
+    setFileError('');
+    try {
+      const token = await getToken();
+      const form = new FormData();
+      form.append('file', file);
+      const uploadRes = await fetch(`${apiBase}/uploads/patient-documents`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: form,
+      });
+      if (!uploadRes.ok) {
+        throw new Error('Upload failed');
+      }
+      const uploaded = (await uploadRes.json()) as { url: string };
+      setResultFileUrl(uploaded.url);
+      setResultFileName(file.name);
+    } catch (err) {
+      setFileError(err instanceof Error ? err.message : 'Upload failed');
+      setResultFileUrl(null);
+      setResultFileName('');
+    } finally {
+      setUploading(false);
+    }
+  };
 
   const handleComplete = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -95,6 +182,7 @@ export default function LabPage() {
             resultValue: resultValue.trim(),
             referenceRange: referenceRange || undefined,
             unit: unit || undefined,
+            resultFileUrl: resultFileUrl || undefined,
           },
         },
       });
@@ -126,12 +214,26 @@ export default function LabPage() {
     }
   };
 
+  const selectOrder = (orderId: string) => {
+    setSelectedOrderId(orderId);
+    setResultValue('');
+    setReferenceRange('');
+    setUnit('');
+    setResultFileUrl(null);
+    setResultFileName('');
+    setFileError('');
+  };
+
   return (
     <div>
       <DashboardHeader title="Lab Queue" subtitle="Manage lab orders and enter results" />
 
       {error ? (
         <p className="mb-4 rounded-2xl bg-red-50 px-4 py-2 text-sm text-clay-error">{error}</p>
+      ) : null}
+
+      {fileError ? (
+        <p className="mb-4 rounded-2xl bg-red-50 px-4 py-2 text-sm text-clay-error">{fileError}</p>
       ) : null}
 
       <div className="mb-6 flex justify-end">
@@ -220,76 +322,103 @@ export default function LabPage() {
             </div>
           ) : (
             <div className="divide-y divide-white/30">
-              {orders.map(
-                (order: {
-                  id: string;
-                  testName: string;
-                  status: string;
-                  createdAt: string;
-                  patient?: { fullName: string };
-                }) => (
+              {orders.map((order) => (
+                <div
+                  key={order.id}
+                  className={`flex w-full items-center gap-4 px-6 py-4 transition hover:bg-clay-primary-light/20 ${
+                    selectedOrderId === order.id ? 'bg-clay-primary-light/40' : ''
+                  }`}
+                >
                   <button
-                    key={order.id}
                     type="button"
-                    onClick={() => setSelectedOrderId(order.id)}
-                    className={`flex w-full items-center gap-4 px-6 py-4 text-left transition hover:bg-clay-primary-light/20 ${
-                      selectedOrderId === order.id ? 'bg-clay-primary-light/40' : ''
-                    }`}
+                    onClick={() => selectOrder(order.id)}
+                    className="min-w-0 flex-1 text-left"
                   >
-                    <div className="min-w-0 flex-1">
-                      <p className="font-medium text-clay-text">{order.testName}</p>
-                      <p className="text-sm text-clay-text-muted">
-                        {order.patient?.fullName ?? 'Unknown'} ·{' '}
-                        {new Date(order.createdAt).toLocaleString()}
-                      </p>
-                    </div>
+                    <p className="font-medium text-clay-text">{order.testName}</p>
+                    <p className="text-sm text-clay-text-muted">
+                      {order.patient?.fullName ?? 'Unknown'} ·{' '}
+                      {new Date(order.createdAt).toLocaleString()}
+                      {order.result?.resultValue ? ` · ${order.result.resultValue}` : ''}
+                    </p>
+                  </button>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {order.status === 'completed' && order.result?.resultFileUrl ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleOpenResultFile(order.result!.resultFileUrl!)}
+                        className="inline-flex items-center gap-1 rounded-xl bg-clay-primary-light/50 px-2 py-1 text-xs font-medium text-clay-primary hover:bg-clay-primary-light"
+                        title="Download result file"
+                      >
+                        <FileText className="h-3.5 w-3.5" />
+                        File
+                      </button>
+                    ) : null}
                     <ClayBadge variant={statusVariant(order.status)}>
                       {order.status}
                     </ClayBadge>
-                  </button>
-                ),
-              )}
+                  </div>
+                </div>
+              ))}
             </div>
           )}
         </ClayCard>
 
         {canWriteLab ? (
-        <ClayCard>
-          <h2 className="mb-4 text-lg font-semibold text-clay-text">Enter Result</h2>
-          {selectedOrderId ? (
-            <form onSubmit={handleComplete} className="space-y-4">
+          <ClayCard>
+            <h2 className="mb-4 text-lg font-semibold text-clay-text">Enter Result</h2>
+            {selectedOrderId ? (
+              <form onSubmit={handleComplete} className="space-y-4">
+                <p className="text-sm text-clay-text-muted">
+                  Order ID: <span className="font-mono text-clay-text">{selectedOrderId}</span>
+                </p>
+                <ClayInput
+                  label="Result Value *"
+                  placeholder="e.g. 12.5"
+                  value={resultValue}
+                  onChange={(e) => setResultValue(e.target.value)}
+                  required
+                />
+                <ClayInput
+                  label="Reference Range"
+                  placeholder="e.g. 10.0 - 15.0"
+                  value={referenceRange}
+                  onChange={(e) => setReferenceRange(e.target.value)}
+                />
+                <ClayInput
+                  label="Unit"
+                  placeholder="e.g. g/dL"
+                  value={unit}
+                  onChange={(e) => setUnit(e.target.value)}
+                />
+                <div>
+                  <p className="mb-2 text-sm font-medium text-clay-text">Result File (optional)</p>
+                  <label className="inline-flex cursor-pointer items-center gap-2 rounded-2xl bg-clay-surface px-4 py-2 text-sm font-medium text-clay-primary shadow-clay-sm hover:shadow-clay">
+                    <Upload className="h-4 w-4" />
+                    {uploading ? 'Uploading...' : resultFileName || 'Upload file'}
+                    <input
+                      type="file"
+                      className="hidden"
+                      disabled={uploading}
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) void handleFileUpload(file);
+                      }}
+                    />
+                  </label>
+                  {resultFileName ? (
+                    <p className="mt-2 text-xs text-clay-text-muted">{resultFileName} attached</p>
+                  ) : null}
+                </div>
+                <ClayButton type="submit" isLoading={completing || uploading}>
+                  Complete & Save Result
+                </ClayButton>
+              </form>
+            ) : (
               <p className="text-sm text-clay-text-muted">
-                Order ID: <span className="font-mono text-clay-text">{selectedOrderId}</span>
+                Select an order from the queue to enter results.
               </p>
-              <ClayInput
-                label="Result Value *"
-                placeholder="e.g. 12.5"
-                value={resultValue}
-                onChange={(e) => setResultValue(e.target.value)}
-                required
-              />
-              <ClayInput
-                label="Reference Range"
-                placeholder="e.g. 10.0 - 15.0"
-                value={referenceRange}
-                onChange={(e) => setReferenceRange(e.target.value)}
-              />
-              <ClayInput
-                label="Unit"
-                placeholder="e.g. g/dL"
-                value={unit}
-                onChange={(e) => setUnit(e.target.value)}
-              />
-              <ClayButton type="submit" isLoading={completing}>
-                Complete & Save Result
-              </ClayButton>
-            </form>
-          ) : (
-            <p className="text-sm text-clay-text-muted">
-              Select an order from the queue to enter results.
-            </p>
-          )}
-        </ClayCard>
+            )}
+          </ClayCard>
         ) : null}
       </div>
     </div>

--- a/apps/web/src/app/(dashboard)/patients/[id]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/edit/page.tsx
@@ -8,6 +8,7 @@ import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { PatientWizard } from '@/components/patients/patient-wizard';
 import { ME_QUERY, PATIENT_QUERY, UPDATE_PATIENT_MUTATION } from '@/lib/graphql/queries';
+import { QueryError } from '@/components/query-error';
 
 type PatientDetail = {
   fullName: string;
@@ -98,9 +99,9 @@ export default function EditPatientPage() {
   const [error, setError] = useState('');
 
   const { data: meData } = useQuery(ME_QUERY);
-  const { data, loading: fetching } = useQuery(PATIENT_QUERY, {
+  const { data, loading: fetching, error: fetchError, refetch } = useQuery(PATIENT_QUERY, {
     variables: { id, hospitalId: meData?.me?.hospitalId },
-    skip: !id,
+    skip: !id || !meData?.me?.hospitalId,
   });
 
   const [updatePatient, { loading }] = useMutation(UPDATE_PATIENT_MUTATION);
@@ -131,6 +132,17 @@ export default function EditPatientPage() {
 
   if (fetching) {
     return <p className="text-clay-text-muted">Loading patient...</p>;
+  }
+
+  if (fetchError) {
+    return (
+      <div className="py-8">
+        <QueryError
+          message="We could not load this patient. Please try again."
+          onRetry={() => void refetch()}
+        />
+      </div>
+    );
   }
 
   const patient = data?.patient;

--- a/apps/web/src/app/(dashboard)/reports/page.tsx
+++ b/apps/web/src/app/(dashboard)/reports/page.tsx
@@ -63,6 +63,17 @@ export default function ReportsPage() {
     timeStyle: 'short',
   });
 
+  const accessCtx = {
+    roles: meData?.me?.roles ?? [],
+    permissions: meData?.me?.permissions ?? [],
+  };
+
+  const secondaryLinks = [
+    { href: '/admissions/occupancy', label: 'Ward occupancy detail' },
+    { href: '/finance', label: 'Finance overview' },
+    { href: '/appointments', label: "Today's appointments" },
+  ].filter((link) => canAccessRoute(link.href, accessCtx));
+
   return (
     <div>
       <DashboardHeader
@@ -112,21 +123,13 @@ export default function ReportsPage() {
           </div>
 
           <div className="mb-6 flex flex-wrap gap-3">
-            <Link href="/admissions/occupancy">
-              <ClayButton variant="secondary" size="sm">
-                Ward occupancy detail
-              </ClayButton>
-            </Link>
-            <Link href="/finance">
-              <ClayButton variant="secondary" size="sm">
-                Finance overview
-              </ClayButton>
-            </Link>
-            <Link href="/appointments">
-              <ClayButton variant="secondary" size="sm">
-                Today&apos;s appointments
-              </ClayButton>
-            </Link>
+            {secondaryLinks.map((link) => (
+              <Link key={link.href} href={link.href}>
+                <ClayButton variant="secondary" size="sm">
+                  {link.label}
+                </ClayButton>
+              </Link>
+            ))}
           </div>
 
           <ClayCard>

--- a/apps/web/src/components/clinical/patient-clinical-actions.tsx
+++ b/apps/web/src/components/clinical/patient-clinical-actions.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/lib/route-access';
 import {
   canActAsClinician,
+  canAdmitPatients,
   canAuthorClinical,
 } from '@/lib/clinical-access';
 
@@ -75,11 +76,12 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
   const canWriteAppointments = permissions.includes('appointments:write');
   const canAuthor = canAuthorClinical(roles);
   const canClinician = canActAsClinician(roles);
+  const canAdmit = canWritePatients && canAdmitPatients(roles);
   const canManageFacility = canAccessRoute('/settings', { roles, permissions });
 
   const actionPermissions: Record<ActionKey, boolean> = {
     appointment: canWriteAppointments,
-    admit: canWritePatients,
+    admit: canAdmit,
     vitals: canWritePatients && canAuthor,
     soap: canWritePatients && canAuthor,
     diagnosis: canWritePatients && canClinician,

--- a/apps/web/src/lib/clinical-access.ts
+++ b/apps/web/src/lib/clinical-access.ts
@@ -1,3 +1,13 @@
+/** Roles that may admit patients / transfer beds (matches API @Roles). */
+export const ADMIT_ROLES = [
+  'doctor',
+  'nurse',
+  'receptionist',
+  'hospital_admin',
+  'hospital_manager',
+  'super_admin',
+] as const;
+
 /** Roles that may discharge / transfer-out (matches API @Roles). */
 export const DISCHARGE_ROLES = [
   'doctor',
@@ -37,6 +47,10 @@ export function hasAnyRole(
 ): boolean {
   if (!roles?.length) return false;
   return allowed.some((role) => roles.includes(role));
+}
+
+export function canAdmitPatients(roles: string[] | undefined): boolean {
+  return hasAnyRole(roles, ADMIT_ROLES);
 }
 
 export function canDischargePatients(roles: string[] | undefined): boolean {

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -657,6 +657,14 @@ export const LAB_ORDERS_QUERY = gql`
       status
       notes
       createdAt
+      result {
+        id
+        resultValue
+        referenceRange
+        unit
+        resultFileUrl
+        completedAt
+      }
     }
   }
 `;
@@ -678,6 +686,7 @@ export const COMPLETE_LAB_RESULT_MUTATION = gql`
       id
       labOrderId
       resultValue
+      resultFileUrl
       completedAt
     }
   }


### PR DESCRIPTION
## Summary
- Closes **#176–#184** from the post-#175 rescan
- **HIGH:** Pharmacist patient-write overreach gated; managers cannot demote/deactivate admins; Admit UI matches API roles
- **MEDIUM:** Deactivated hospital fail-closed for staff + portal; lab files purged on patient delete; lab queue upload/download; reports/finance link filtering; patient edit fail-closed
- **LOW:** `updatePatientStatus` included in patient write role gates (#184)

## Test plan
- [ ] Pharmacist: 403 on create/update/import/status/documents; dispense works; no Admit CTAs; follow-ups still read-only
- [ ] Receptionist: can create patients and admit; manager cannot demote hospital_admin
- [ ] Deactivate hospital → staff lose operational perms; portal linked patient gets 403 until reactivation
- [ ] Delete patient with lab attachment → file removed from uploads/
- [ ] Lab tech: upload on complete + download from queue
- [ ] Accountant: no appointments/occupancy links on reports; pharmacist: no Reports Hub without reports:read
- [ ] Patient edit GraphQL failure shows retry, not not-found


Made with [Cursor](https://cursor.com)