### PR TITLE
fix: resolve security and flow issues #210–#228

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,9 +76,18 @@ Dependency scanning:
 snyk test --all-projects
 ```
 
-Snyk Code (SAST / OWASP-oriented code analysis) must be enabled for the Snyk organization
-before `snyk code test` works. If you see `SNYK-CODE-0005`, an org admin should enable
-**Snyk Code** in the Snyk UI (Settings → Snyk Code), then re-run:
+### Enabling Snyk Code (SAST)
+
+Snyk Code cannot be turned on from application code or CI alone. For org
+**`kkshettigar24`**, an organization admin must enable it in the Snyk UI:
+
+1. Sign in at [https://app.snyk.io](https://app.snyk.io) as an org admin for `kkshettigar24`.
+2. Open **Settings → Snyk Code** (or Organization settings → Snyk Code).
+3. Enable **Snyk Code** / code analysis for the organization.
+4. Confirm billing/plan allows Snyk Code if prompted.
+
+Until that is done, `snyk code test` returns **SNYK-CODE-0005** / 403 and OWASP/AI
+code analysis stays unavailable. After an admin enables it, re-run:
 
 ```bash
 snyk code test --all-projects

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -14,11 +14,12 @@ CLERK_SECRET_KEY=REPLACE_WITH_YOUR_CLERK_SECRET_KEY
 # Example: https://your-app.clerk.accounts.dev
 CLERK_ISSUER=https://REPLACE_WITH_YOUR_CLERK_FRONTEND_API
 
-# Optional — comma-separated authorized parties (azp) allowed in Clerk JWTs
+# REQUIRED outside development/test — comma-separated authorized parties (azp) for Clerk JWTs.
 # Example: http://localhost:3000,https://your-app.example.com
-# Required in production (JWT azp allowlist). Recommended in all environments.
-# CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+# Staging/production must set this; JWT azp checks are skipped when empty.
+# Local only: NODE_ENV=development|test skips the requirement, or set CARECONNECT_ALLOW_UNSET_AZP=true.
 CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+# CARECONNECT_ALLOW_UNSET_AZP=true
 
 CORS_ORIGIN=http://localhost:3000
 NODE_ENV=development

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -430,12 +430,16 @@ export class AdmissionsService {
   }
 
   async wardOccupancy(hospitalId: string): Promise<WardOccupancyType[]> {
-    const wards = await this.wardsRepo.find({ where: { hospitalId } });
+    const wards = await this.wardsRepo.find({
+      where: { hospitalId },
+      take: 200,
+    });
     const result: WardOccupancyType[] = [];
 
     for (const ward of wards) {
       const beds = await this.bedsRepo.find({
         where: { wardId: ward.id, hospitalId },
+        take: 200,
       });
       const occupiedBeds = beds.filter((b) => b.status === 'occupied').length;
       result.push({

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -80,6 +80,19 @@ describe('AppointmentsService status machine', () => {
       Object.assign(state, a);
       return Promise.resolve(state);
     });
+    apptManager.findOne.mockResolvedValue({
+      id: state.patientId ?? 'patient-1',
+      hospitalId: 'hospital-a',
+      status: 'registered',
+    });
+    const fetchQb = {
+      innerJoinAndSelect: jest.fn().mockReturnThis(),
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockImplementation(() => Promise.resolve({ ...state })),
+    };
+    appointmentsRepo.createQueryBuilder.mockReturnValue(fetchQb);
     appointmentsRepo.findOne.mockImplementation(() =>
       Promise.resolve({ ...state }),
     );
@@ -144,8 +157,22 @@ describe('AppointmentsService status machine', () => {
   });
 
   describe('doctor appointment scoping', () => {
+    const listQb = () => {
+      const qb = {
+        innerJoinAndSelect: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      appointmentsRepo.createQueryBuilder.mockReturnValue(qb);
+      return qb;
+    };
+
     it('forces doctorId for doctor-only actors', async () => {
-      appointmentsRepo.find.mockResolvedValue([]);
+      const qb = listQb();
       const doctor: AuthenticatedUser = {
         ...actor,
         id: 'doc-9',
@@ -161,15 +188,14 @@ describe('AppointmentsService status machine', () => {
         doctor,
       );
 
-      expect(appointmentsRepo.find).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { hospitalId: 'hospital-a', doctorId: 'doc-9' },
-        }),
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'appointment.doctor_id = :doctorId',
+        { doctorId: 'doc-9' },
       );
     });
 
     it('keeps hospital-wide list for receptionists', async () => {
-      appointmentsRepo.find.mockResolvedValue([]);
+      const qb = listQb();
 
       await service.findAll(
         'hospital-a',
@@ -179,10 +205,9 @@ describe('AppointmentsService status machine', () => {
         actor,
       );
 
-      expect(appointmentsRepo.find).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { hospitalId: 'hospital-a' },
-        }),
+      expect(qb.andWhere).not.toHaveBeenCalledWith(
+        'appointment.doctor_id = :doctorId',
+        expect.anything(),
       );
     });
   });

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Appointment, Department, Patient } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
@@ -113,10 +113,14 @@ export class AppointmentsService {
     id: string,
     hospitalId: string,
   ): Promise<Appointment> {
-    const appointment = await this.appointmentsRepo.findOne({
-      where: { id, hospitalId },
-      relations: ['patient', 'doctor'],
-    });
+    const appointment = await this.appointmentsRepo
+      .createQueryBuilder('appointment')
+      .innerJoinAndSelect('appointment.patient', 'patient')
+      .leftJoinAndSelect('appointment.doctor', 'doctor')
+      .where('appointment.id = :id', { id })
+      .andWhere('appointment.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('patient.deleted_at IS NULL')
+      .getOne();
     if (!appointment) throw new NotFoundException('Appointment not found');
     return appointment;
   }
@@ -179,12 +183,7 @@ export class AppointmentsService {
     status?: string,
     actor?: AuthenticatedUser,
   ): Promise<AppointmentType[]> {
-    const where: Record<string, unknown> = { hospitalId };
-
     const effectiveDoctorId = this.resolveDoctorScope(actor, doctorId);
-    if (effectiveDoctorId) {
-      where.doctorId = effectiveDoctorId;
-    }
 
     if (status) {
       if (
@@ -194,25 +193,40 @@ export class AppointmentsService {
       ) {
         throw new BadRequestException(`Invalid appointment status: ${status}`);
       }
-      where.status = status;
     }
 
+    const appointments = await this.appointmentsRepo
+      .createQueryBuilder('appointment')
+      .innerJoinAndSelect('appointment.patient', 'patient')
+      .leftJoinAndSelect('appointment.doctor', 'doctor')
+      .where('appointment.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('patient.deleted_at IS NULL');
+
+    if (effectiveDoctorId) {
+      appointments.andWhere('appointment.doctor_id = :doctorId', {
+        doctorId: effectiveDoctorId,
+      });
+    }
+    if (status) {
+      appointments.andWhere('appointment.status = :status', { status });
+    }
     if (date) {
       const start = new Date(date);
       start.setHours(0, 0, 0, 0);
       const end = new Date(date);
       end.setHours(23, 59, 59, 999);
-      where.scheduledAt = Between(start, end);
+      appointments.andWhere(
+        'appointment.scheduled_at BETWEEN :start AND :end',
+        { start, end },
+      );
     }
 
-    const appointments = await this.appointmentsRepo.find({
-      where,
-      relations: ['patient', 'doctor'],
-      order: { scheduledAt: 'ASC' },
-      take: 200,
-    });
+    const rows = await appointments
+      .orderBy('appointment.scheduled_at', 'ASC')
+      .take(200)
+      .getMany();
 
-    return appointments.map((a) => this.toAppointmentType(a));
+    return rows.map((a) => this.toAppointmentType(a));
   }
 
   /**
@@ -263,14 +277,17 @@ export class AppointmentsService {
           .getOne();
         if (!appointment) throw new NotFoundException('Appointment not found');
 
+        const patientAlive = await manager.findOne(Patient, {
+          where: { id: appointment.patientId, hospitalId },
+        });
+        if (!patientAlive) throw new NotFoundException('Appointment not found');
+
         assertTransition(appointment.status, status);
         appointment.status = status;
         await manager.save(appointment);
 
         if (status === 'checked_in') {
-          const patient = await manager.findOne(Patient, {
-            where: { id: appointment.patientId, hospitalId },
-          });
+          const patient = patientAlive;
           if (patient && patient.status === 'registered') {
             patient.status = 'checked_in';
             await manager.save(patient);
@@ -309,6 +326,11 @@ export class AppointmentsService {
           .andWhere('appointment.hospital_id = :hospitalId', { hospitalId })
           .getOne();
         if (!appointment) throw new NotFoundException('Appointment not found');
+
+        const patientAlive = await manager.findOne(Patient, {
+          where: { id: appointment.patientId, hospitalId },
+        });
+        if (!patientAlive) throw new NotFoundException('Appointment not found');
 
         assertTransition(appointment.status, 'cancelled');
 

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -195,7 +195,7 @@ export class AppointmentsService {
       }
     }
 
-    const appointments = await this.appointmentsRepo
+    const appointments = this.appointmentsRepo
       .createQueryBuilder('appointment')
       .innerJoinAndSelect('appointment.patient', 'patient')
       .leftJoinAndSelect('appointment.doctor', 'doctor')

--- a/apps/api/src/billing/billing.resolver.ts
+++ b/apps/api/src/billing/billing.resolver.ts
@@ -1,5 +1,5 @@
 import { UseGuards } from '@nestjs/common';
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Args, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { PERMISSIONS } from '@careconnect/types';
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -13,6 +13,7 @@ import {
   CreateInvoiceInput,
   InvoiceType,
   RecordPaymentInput,
+  BillingPatientLookupType,
 } from './billing.types';
 
 @Resolver()
@@ -32,6 +33,26 @@ export class BillingResolver {
       hospitalId,
     );
     return this.billingService.listInvoices(resolvedHospitalId);
+  }
+
+  @Query(() => [BillingPatientLookupType])
+  @Roles(...STAFF_ROLES)
+  @Permissions(PERMISSIONS.BILLING_READ)
+  async billingPatientSearch(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('search') search: string,
+    @Args('limit', { type: () => Int, nullable: true }) limit?: number,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+  ): Promise<BillingPatientLookupType[]> {
+    const resolvedHospitalId = this.billingService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.billingService.searchPatientsForBilling(
+      resolvedHospitalId,
+      search,
+      limit,
+    );
   }
 
   @Query(() => InvoiceType)

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -85,12 +85,17 @@ describe('BillingService', () => {
         getOne: jest.fn().mockResolvedValue({
           id: 'inv-1',
           hospitalId: 'hospital-a',
+          patientId: 'patient-1',
           status: 'issued',
           totalAmount: '100.00',
         }),
       };
       manager.createQueryBuilder.mockReturnValue(qb);
       manager.find.mockResolvedValue([{ amount: '100.00' }]);
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+      });
 
       await expect(
         service.recordPayment(
@@ -110,11 +115,16 @@ describe('BillingService', () => {
         getOne: jest.fn().mockResolvedValue({
           id: 'inv-1',
           hospitalId: 'hospital-a',
+          patientId: 'patient-1',
           status: 'paid',
           totalAmount: '100.00',
         }),
       };
       manager.createQueryBuilder.mockReturnValue(qb);
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+      });
 
       await expect(
         service.recordPayment(

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -214,12 +214,16 @@ export class BillingService {
   }
 
   async listInvoices(hospitalId: string): Promise<InvoiceType[]> {
-    const invoices = await this.invoicesRepo.find({
-      where: { hospitalId },
-      relations: ['items', 'payments', 'patient'],
-      take: 200,
-      order: { createdAt: 'DESC' },
-    });
+    const invoices = await this.invoicesRepo
+      .createQueryBuilder('invoice')
+      .innerJoinAndSelect('invoice.patient', 'patient')
+      .leftJoinAndSelect('invoice.items', 'items')
+      .leftJoinAndSelect('invoice.payments', 'payments')
+      .where('invoice.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('patient.deleted_at IS NULL')
+      .orderBy('invoice.created_at', 'DESC')
+      .take(200)
+      .getMany();
     return invoices.map((invoice) => this.toInvoiceType(invoice));
   }
 
@@ -260,10 +264,15 @@ export class BillingService {
   }
 
   async getInvoice(hospitalId: string, id: string): Promise<InvoiceType> {
-    const invoice = await this.invoicesRepo.findOne({
-      where: { id, hospitalId },
-      relations: ['items', 'payments', 'patient'],
-    });
+    const invoice = await this.invoicesRepo
+      .createQueryBuilder('invoice')
+      .innerJoinAndSelect('invoice.patient', 'patient')
+      .leftJoinAndSelect('invoice.items', 'items')
+      .leftJoinAndSelect('invoice.payments', 'payments')
+      .where('invoice.id = :id', { id })
+      .andWhere('invoice.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('patient.deleted_at IS NULL')
+      .getOne();
     if (!invoice) throw new NotFoundException('Invoice not found');
     return this.toInvoiceType(invoice);
   }
@@ -283,6 +292,7 @@ export class BillingService {
           .andWhere('invoice.hospital_id = :hospitalId', { hospitalId })
           .getOne();
         if (!invoice) throw new NotFoundException('Invoice not found');
+        await this.assertPatient(hospitalId, invoice.patientId);
         if (invoice.status === 'void') {
           throw new BadRequestException(
             'Cannot record payment on a void invoice',
@@ -356,6 +366,7 @@ export class BillingService {
         .andWhere('invoice.hospital_id = :hospitalId', { hospitalId })
         .getOne();
       if (!invoice) throw new NotFoundException('Invoice not found');
+      await this.assertPatient(hospitalId, invoice.patientId);
       if (invoice.status === 'void') {
         throw new BadRequestException('Invoice is already void');
       }

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -21,6 +21,7 @@ import {
   InvoiceType,
   PaymentType,
   RecordPaymentInput,
+  BillingPatientLookupType,
 } from './billing.types';
 
 @Injectable()
@@ -220,6 +221,42 @@ export class BillingService {
       order: { createdAt: 'DESC' },
     });
     return invoices.map((invoice) => this.toInvoiceType(invoice));
+  }
+
+  /**
+   * Constrained patient search for invoice creation. Returns id, MRN, and
+   * fullName only — gated on billing:read rather than patients:read.
+   */
+  async searchPatientsForBilling(
+    hospitalId: string,
+    search: string,
+    limit = 8,
+  ): Promise<BillingPatientLookupType[]> {
+    const trimmed = search?.trim() ?? '';
+    if (trimmed.length < 2) return [];
+
+    const safeLimit = Math.min(20, Math.max(1, Math.floor(limit) || 8));
+    const literal = trimmed.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+    const pattern = `%${literal}%`;
+
+    const patients = await this.patientsRepo
+      .createQueryBuilder('patient')
+      .select(['patient.id', 'patient.fullName', 'patient.identificationNumber'])
+      .where('patient.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('patient.deleted_at IS NULL')
+      .andWhere(
+        `(patient.full_name ILIKE :pattern ESCAPE '\\' OR patient.identification_number ILIKE :pattern ESCAPE '\\')`,
+        { pattern },
+      )
+      .orderBy('patient.full_name', 'ASC')
+      .take(safeLimit)
+      .getMany();
+
+    return patients.map((p) => ({
+      id: p.id,
+      mrn: p.identificationNumber,
+      fullName: p.fullName,
+    }));
   }
 
   async getInvoice(hospitalId: string, id: string): Promise<InvoiceType> {

--- a/apps/api/src/billing/billing.types.ts
+++ b/apps/api/src/billing/billing.types.ts
@@ -154,3 +154,16 @@ export class RecordPaymentInput {
   @MinLength(1)
   method: string;
 }
+
+/** Billing-safe patient picker — id, MRN (identification number), and name only. */
+@ObjectType()
+export class BillingPatientLookupType {
+  @Field(() => ID)
+  id: string;
+
+  @Field({ nullable: true })
+  mrn?: string;
+
+  @Field()
+  fullName: string;
+}

--- a/apps/api/src/clinical/clinical.service.spec.ts
+++ b/apps/api/src/clinical/clinical.service.spec.ts
@@ -1,6 +1,7 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { QueryFailedError } from 'typeorm';
 import {
   Admission,
   ClinicalNote,
@@ -165,6 +166,24 @@ describe('ClinicalService', () => {
         ),
       ).rejects.toThrow(BadRequestException);
       expect(labManager.save).not.toHaveBeenCalled();
+    });
+
+    it('maps unique result_file_url violation to ConflictException', async () => {
+      const uniqueError = new QueryFailedError('INSERT', [], new Error('dup'));
+      (uniqueError as QueryFailedError & { code?: string }).code = '23505';
+      labOrdersRepo.manager.transaction.mockRejectedValue(uniqueError);
+
+      await expect(
+        service.completeLabResult(
+          'hospital-a',
+          {
+            labOrderId: 'lab-1',
+            resultValue: '5.0',
+            resultFileUrl: '/uploads/abc.pdf',
+          },
+          actor,
+        ),
+      ).rejects.toThrow(ConflictException);
     });
 
     it('advances ordered → collected', async () => {

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -494,6 +494,8 @@ export class ClinicalService {
             .getOne();
           if (!order) throw new NotFoundException('Lab order not found');
 
+          await this.assertPatient(hospitalId, order.patientId);
+
           if (order.status === 'completed' || order.status === 'cancelled') {
             throw new BadRequestException(
               `Cannot complete lab order with status "${order.status}"`,
@@ -575,6 +577,8 @@ export class ClinicalService {
           .getOne();
         if (!order) throw new NotFoundException('Lab order not found');
 
+        await this.assertPatient(hospitalId, order.patientId);
+
         assertLabTransition(order.status, input.status);
         order.status = input.status;
         await manager.save(order);
@@ -617,6 +621,8 @@ export class ClinicalService {
         if (!prescription)
           throw new NotFoundException('Prescription not found');
 
+        await this.assertPatient(hospitalId, prescription.patientId);
+
         assertPrescriptionTransition(prescription.status, 'cancelled');
         prescription.status = 'cancelled';
         await manager.save(prescription);
@@ -646,19 +652,23 @@ export class ClinicalService {
     hospitalId: string,
     status?: string,
   ): Promise<LabOrderType[]> {
-    const where: { hospitalId: string; status?: string } = { hospitalId };
-    if (status) {
-      if (!(status in LAB_ALLOWED_TRANSITIONS)) {
-        throw new BadRequestException(`Invalid lab order status "${status}"`);
-      }
-      where.status = status;
+    if (status && !(status in LAB_ALLOWED_TRANSITIONS)) {
+      throw new BadRequestException(`Invalid lab order status "${status}"`);
     }
-    const orders = await this.labOrdersRepo.find({
-      where,
-      relations: ['patient', 'orderedBy'],
-      order: { createdAt: 'DESC' },
-      take: 200,
-    });
+
+    const qb = this.labOrdersRepo
+      .createQueryBuilder('order')
+      .innerJoinAndSelect('order.patient', 'patient')
+      .leftJoinAndSelect('order.orderedBy', 'orderedBy')
+      .where('order.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('patient.deleted_at IS NULL');
+    if (status) {
+      qb.andWhere('order.status = :status', { status });
+    }
+    const orders = await qb
+      .orderBy('order.created_at', 'DESC')
+      .take(200)
+      .getMany();
 
     const completedOrderIds = orders
       .filter((o) => o.status === 'completed')

--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -7,7 +8,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { existsSync } from 'fs';
 import { basename, join } from 'path';
-import { EntityManager, In, Repository } from 'typeorm';
+import { EntityManager, In, QueryFailedError, Repository } from 'typeorm';
 import {
   Admission,
   ClinicalNote,
@@ -481,46 +482,59 @@ export class ClinicalService {
     input: CompleteLabResultInput,
     actor: AuthenticatedUser,
   ): Promise<LabResultType> {
-    const resultId = await this.labOrdersRepo.manager.transaction(
-      async (manager) => {
-        const order = await manager
-          .createQueryBuilder(LabOrder, 'order')
-          .setLock('pessimistic_write')
-          .where('order.id = :id', { id: input.labOrderId })
-          .andWhere('order.hospital_id = :hospitalId', { hospitalId })
-          .getOne();
-        if (!order) throw new NotFoundException('Lab order not found');
+    let resultId: string;
+    try {
+      resultId = await this.labOrdersRepo.manager.transaction(
+        async (manager) => {
+          const order = await manager
+            .createQueryBuilder(LabOrder, 'order')
+            .setLock('pessimistic_write')
+            .where('order.id = :id', { id: input.labOrderId })
+            .andWhere('order.hospital_id = :hospitalId', { hospitalId })
+            .getOne();
+          if (!order) throw new NotFoundException('Lab order not found');
 
-        if (order.status === 'completed' || order.status === 'cancelled') {
-          throw new BadRequestException(
-            `Cannot complete lab order with status "${order.status}"`,
+          if (order.status === 'completed' || order.status === 'cancelled') {
+            throw new BadRequestException(
+              `Cannot complete lab order with status "${order.status}"`,
+            );
+          }
+          assertLabTransition(order.status, 'completed');
+
+          const safeResultFileUrl = await this.assertExclusiveLabUploadUrl(
+            manager,
+            input.resultFileUrl,
           );
-        }
-        assertLabTransition(order.status, 'completed');
 
-        const safeResultFileUrl = await this.assertExclusiveLabUploadUrl(
-          manager,
-          input.resultFileUrl,
+          const result = await manager.save(
+            manager.create(LabResult, {
+              labOrderId: order.id,
+              hospitalId,
+              resultValue: input.resultValue,
+              referenceRange: input.referenceRange,
+              unit: input.unit,
+              resultFileUrl: safeResultFileUrl,
+              enteredById: actor.id,
+              completedAt: new Date(),
+            }),
+          );
+
+          order.status = 'completed';
+          await manager.save(order);
+          return result.id;
+        },
+      );
+    } catch (error) {
+      if (
+        error instanceof QueryFailedError &&
+        (error as QueryFailedError & { code?: string }).code === '23505'
+      ) {
+        throw new ConflictException(
+          'Upload file is already linked to a lab result',
         );
-
-        const result = await manager.save(
-          manager.create(LabResult, {
-            labOrderId: order.id,
-            hospitalId,
-            resultValue: input.resultValue,
-            referenceRange: input.referenceRange,
-            unit: input.unit,
-            resultFileUrl: safeResultFileUrl,
-            enteredById: actor.id,
-            completedAt: new Date(),
-          }),
-        );
-
-        order.status = 'completed';
-        await manager.save(order);
-        return result.id;
-      },
-    );
+      }
+      throw error;
+    }
 
     const result = await this.labResultsRepo.findOne({
       where: { id: resultId, hospitalId },

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -115,14 +115,24 @@ export function validateEnv(config: Record<string, unknown>) {
     }
   }
 
-  if (config.NODE_ENV === 'production') {
+  const nodeEnv =
+    typeof config.NODE_ENV === 'string' ? config.NODE_ENV.trim() : '';
+  const isLocalDevOrTest =
+    nodeEnv === 'development' || nodeEnv === 'test' || nodeEnv === '';
+  const allowUnsetAzp =
+    typeof config.CARECONNECT_ALLOW_UNSET_AZP === 'string' &&
+    ['1', 'true', 'yes'].includes(
+      config.CARECONNECT_ALLOW_UNSET_AZP.trim().toLowerCase(),
+    );
+
+  if (!isLocalDevOrTest && !allowUnsetAzp) {
     if (
       !config.CLERK_AUTHORIZED_PARTIES ||
       typeof config.CLERK_AUTHORIZED_PARTIES !== 'string' ||
       !config.CLERK_AUTHORIZED_PARTIES.trim()
     ) {
       throw new Error(
-        'CLERK_AUTHORIZED_PARTIES is required in production (comma-separated authorized party URLs for JWT azp checks).',
+        'CLERK_AUTHORIZED_PARTIES is required outside development/test (comma-separated authorized party URLs for JWT azp checks). For local overrides only, set CARECONNECT_ALLOW_UNSET_AZP=true.',
       );
     }
   }

--- a/apps/api/src/discharge/discharge.service.spec.ts
+++ b/apps/api/src/discharge/discharge.service.spec.ts
@@ -33,6 +33,10 @@ describe('DischargeService', () => {
   const followManager = {
     createQueryBuilder: jest.fn(),
     save: jest.fn(),
+    findOne: jest.fn().mockResolvedValue({
+      id: 'patient-1',
+      hospitalId: 'hospital-a',
+    }),
   };
   const followUpsRepo = {
     save: jest.fn(),
@@ -114,6 +118,7 @@ describe('DischargeService', () => {
       const row = {
         id: 'fu-1',
         hospitalId: 'hospital-a',
+        patientId: 'patient-1',
         status: 'scheduled',
       };
       const qb = {
@@ -148,6 +153,7 @@ describe('DischargeService', () => {
         getOne: jest.fn().mockResolvedValue({
           id: 'fu-1',
           hospitalId: 'hospital-a',
+          patientId: 'patient-1',
           status: 'completed',
         }),
       };

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -359,7 +359,7 @@ export class DischargeService {
       throw new BadRequestException(`Invalid follow-up status "${status}"`);
     }
 
-    const items = await this.followUpsRepo
+    const items = this.followUpsRepo
       .createQueryBuilder('followUp')
       .innerJoinAndSelect('followUp.patient', 'patient')
       .leftJoinAndSelect('followUp.doctor', 'doctor')

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -318,6 +318,11 @@ export class DischargeService {
           .getOne();
         if (!followUp) throw new NotFoundException('Follow-up not found');
 
+        const patient = await manager.findOne(Patient, {
+          where: { id: followUp.patientId, hospitalId },
+        });
+        if (!patient) throw new NotFoundException('Follow-up not found');
+
         assertFollowUpTransition(followUp.status, input.status);
         followUp.status = input.status;
         if (input.notes !== undefined) {
@@ -350,22 +355,25 @@ export class DischargeService {
     hospitalId: string,
     status?: string,
   ): Promise<FollowUpType[]> {
-    const where: { hospitalId: string; status?: string } = { hospitalId };
-    if (status) {
-      if (!(status in FOLLOW_UP_TRANSITIONS)) {
-        throw new BadRequestException(`Invalid follow-up status "${status}"`);
-      }
-      where.status = status;
+    if (status && !(status in FOLLOW_UP_TRANSITIONS)) {
+      throw new BadRequestException(`Invalid follow-up status "${status}"`);
     }
 
-    const items = await this.followUpsRepo.find({
-      where,
-      relations: ['patient', 'doctor'],
-      order: { scheduledAt: 'ASC' },
-      take: 200,
-    });
+    const items = await this.followUpsRepo
+      .createQueryBuilder('followUp')
+      .innerJoinAndSelect('followUp.patient', 'patient')
+      .leftJoinAndSelect('followUp.doctor', 'doctor')
+      .where('followUp.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('patient.deleted_at IS NULL');
+    if (status) {
+      items.andWhere('followUp.status = :status', { status });
+    }
+    const rows = await items
+      .orderBy('followUp.scheduled_at', 'ASC')
+      .take(200)
+      .getMany();
 
-    return items.map((item) => this.toFollowUpType(item));
+    return rows.map((item) => this.toFollowUpType(item));
   }
 
   async dischargesForPatient(

--- a/apps/api/src/facility/facility.service.ts
+++ b/apps/api/src/facility/facility.service.ts
@@ -218,6 +218,7 @@ export class FacilityService {
     const departments = await this.departmentsRepo.find({
       where: { hospitalId },
       order: { name: 'ASC' },
+      take: 200,
     });
     return departments.map((d) => this.toDepartmentType(d));
   }
@@ -229,6 +230,7 @@ export class FacilityService {
     const wards = await this.wardsRepo.find({
       where: departmentId ? { hospitalId, departmentId } : { hospitalId },
       order: { name: 'ASC' },
+      take: 200,
     });
     return wards.map((w) => this.toWardType(w));
   }
@@ -237,6 +239,7 @@ export class FacilityService {
     const beds = await this.bedsRepo.find({
       where: wardId ? { hospitalId, wardId } : { hospitalId },
       order: { label: 'ASC' },
+      take: 200,
     });
     return beds.map((b) => this.toBedType(b));
   }

--- a/apps/api/src/inventory/inventory.service.spec.ts
+++ b/apps/api/src/inventory/inventory.service.spec.ts
@@ -1,0 +1,143 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { InventoryItem } from '../database/entities';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from '../audit/audit.service';
+import { InventoryService } from './inventory.service';
+
+describe('InventoryService', () => {
+  let service: InventoryService;
+
+  const manager = {
+    createQueryBuilder: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const inventoryRepo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+    manager: {
+      transaction: jest.fn((cb: (m: typeof manager) => unknown) =>
+        Promise.resolve(cb(manager)),
+      ),
+    },
+  };
+  const audit = { log: jest.fn() };
+
+  const actor: AuthenticatedUser = {
+    id: 'pharm-1',
+    authId: 'auth-1',
+    email: 'pharm@h.com',
+    fullName: 'Pharmacist',
+    hospitalId: 'hospital-a',
+    roles: ['pharmacist'],
+    permissions: ['patients:write'],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InventoryService,
+        { provide: getRepositoryToken(InventoryItem), useValue: inventoryRepo },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = module.get(InventoryService);
+  });
+
+  describe('updateInventoryQuantity delta', () => {
+    it('applies concurrent +1/+1 from the same base to yield +2', async () => {
+      let quantity = 10;
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockImplementation(() =>
+          Promise.resolve({
+            id: 'item-1',
+            hospitalId: 'hospital-a',
+            quantity: quantity.toFixed(2),
+          }),
+        ),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+      manager.save.mockImplementation((item: { quantity: string }) => {
+        quantity = Number(item.quantity);
+        return Promise.resolve({ ...item, id: 'item-1' });
+      });
+
+      await service.updateInventoryQuantity(
+        'hospital-a',
+        { id: 'item-1', delta: 1 },
+        actor,
+      );
+      await service.updateInventoryQuantity(
+        'hospital-a',
+        { id: 'item-1', delta: 1 },
+        actor,
+      );
+
+      expect(quantity).toBe(12);
+      expect(qb.setLock).toHaveBeenCalledWith('pessimistic_write');
+    });
+
+    it('clamps quantity at zero when delta would go negative', async () => {
+      const item = {
+        id: 'item-1',
+        hospitalId: 'hospital-a',
+        quantity: '1.00',
+      };
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(item),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+      manager.save.mockImplementation((row: typeof item) =>
+        Promise.resolve(row),
+      );
+
+      const result = await service.updateInventoryQuantity(
+        'hospital-a',
+        { id: 'item-1', delta: -5 },
+        actor,
+      );
+
+      expect(result.quantity).toBe(0);
+    });
+
+    it('rejects non-finite delta', async () => {
+      await expect(
+        service.updateInventoryQuantity(
+          'hospital-a',
+          { id: 'item-1', delta: Number.NaN },
+          actor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFound when item missing', async () => {
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.updateInventoryQuantity(
+          'hospital-a',
+          { id: 'missing', delta: 1 },
+          actor,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/inventory/inventory.service.ts
+++ b/apps/api/src/inventory/inventory.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   Injectable,
@@ -116,6 +117,10 @@ export class InventoryService {
     input: UpdateInventoryQuantityInput,
     actor: AuthenticatedUser,
   ): Promise<InventoryItemType> {
+    if (!Number.isFinite(input.delta)) {
+      throw new BadRequestException('delta must be a finite number');
+    }
+
     const saved = await this.inventoryRepo.manager.transaction(
       async (manager) => {
         const item = await manager
@@ -126,7 +131,8 @@ export class InventoryService {
           .getOne();
         if (!item) throw new NotFoundException('Inventory item not found');
 
-        item.quantity = input.quantity.toFixed(2);
+        const next = Math.max(0, Number(item.quantity) + input.delta);
+        item.quantity = next.toFixed(2);
         return manager.save(item);
       },
     );
@@ -137,7 +143,7 @@ export class InventoryService {
       action: 'update',
       resource: 'inventory_item',
       resourceId: saved.id,
-      metadata: { quantity: input.quantity },
+      metadata: { delta: input.delta, quantity: Number(saved.quantity) },
     });
 
     return this.toInventoryItemType(saved);

--- a/apps/api/src/inventory/inventory.types.ts
+++ b/apps/api/src/inventory/inventory.types.ts
@@ -74,8 +74,8 @@ export class UpdateInventoryQuantityInput {
   @IsUUID()
   id: string;
 
+  /** Signed adjustment applied under row lock (e.g. +1 / -1). */
   @Field(() => Float)
   @IsNumber()
-  @Min(0)
-  quantity: number;
+  delta: number;
 }

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -50,6 +50,23 @@ describe('PatientsService', () => {
     remove: jest.fn(),
     find: jest.fn(),
     findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+    manager: {
+      getRepository: jest.fn(),
+    },
+  };
+
+  const labResultsRepo = {
+    createQueryBuilder: jest.fn(),
+  };
+
+  const mockUploadUrlQb = (rows: unknown[] = []) => {
+    const qb = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(rows),
+    };
+    return qb;
   };
 
   const usersRepo = {
@@ -76,6 +93,9 @@ describe('PatientsService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     relatedRepo.find.mockResolvedValue([]);
+    relatedRepo.createQueryBuilder.mockImplementation(() => mockUploadUrlQb([]));
+    relatedRepo.manager.getRepository.mockReturnValue(labResultsRepo);
+    labResultsRepo.createQueryBuilder.mockImplementation(() => mockUploadUrlQb([]));
     existsSyncMock.mockReturnValue(true);
 
     const module: TestingModule = await Test.createTestingModule({
@@ -284,7 +304,6 @@ describe('PatientsService', () => {
         id: 'patient-1',
         hospitalId: 'hospital-1',
       });
-      relatedRepo.find.mockResolvedValue([]);
       relatedRepo.create.mockImplementation((row: unknown) => row);
       relatedRepo.save.mockImplementation((row: unknown) =>
         Promise.resolve(row),
@@ -302,6 +321,29 @@ describe('PatientsService', () => {
       );
 
       expect(result.fileUrl).toBe('/uploads/a1b2c3d4-e5f6.pdf');
+    });
+
+    it('rejects when the upload is already linked to a lab result', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-1',
+      });
+      labResultsRepo.createQueryBuilder.mockImplementation(() =>
+        mockUploadUrlQb([{ id: 'lab-result-1' }]),
+      );
+      existsSyncMock.mockReturnValue(true);
+
+      await expect(
+        service.addDocument(
+          'patient-1',
+          'hospital-1',
+          {
+            name: 'scan.pdf',
+            fileUrl: '/uploads/a1b2c3d4-e5f6.pdf',
+          },
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -346,4 +346,82 @@ describe('PatientsService', () => {
       ).rejects.toThrow(BadRequestException);
     });
   });
+
+  describe('linkPatientAccount', () => {
+    const patientBase = {
+      id: 'patient-1',
+      hospitalId: 'hospital-1',
+      fullName: 'Jane Doe',
+      email: 'jane@example.com',
+      userId: null as string | null,
+    };
+
+    const patientRoleUser = {
+      id: 'portal-1',
+      email: 'jane@example.com',
+      userRoles: [{ role: { slug: 'patient' } }],
+    };
+
+    it('links when chart email matches portal user email', async () => {
+      patientsRepo.findOne
+        .mockResolvedValueOnce({ ...patientBase })
+        .mockResolvedValueOnce(null);
+      usersRepo.findOne.mockResolvedValue(patientRoleUser);
+      patientsRepo.save.mockImplementation((row: unknown) =>
+        Promise.resolve(row),
+      );
+
+      const result = await service.linkPatientAccount(
+        'patient-1',
+        'hospital-1',
+        actor,
+        'portal-1',
+      );
+
+      expect(result.userId).toBe('portal-1');
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'link_account',
+          resource: 'patient',
+          resourceId: 'patient-1',
+        }),
+      );
+    });
+
+    it('rejects when portal email does not match chart email', async () => {
+      patientsRepo.findOne.mockResolvedValue({ ...patientBase });
+      usersRepo.findOne.mockResolvedValue({
+        ...patientRoleUser,
+        email: 'other@example.com',
+      });
+
+      await expect(
+        service.linkPatientAccount(
+          'patient-1',
+          'hospital-1',
+          actor,
+          'portal-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(patientsRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects when chart email is missing', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        ...patientBase,
+        email: null,
+      });
+      usersRepo.findOne.mockResolvedValue(patientRoleUser);
+
+      await expect(
+        service.linkPatientAccount(
+          'patient-1',
+          'hospital-1',
+          actor,
+          'portal-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(patientsRepo.save).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -686,6 +686,14 @@ export class PatientsService {
       );
     }
 
+    const chartEmail = patient.email?.trim().toLowerCase();
+    const portalEmail = targetUser.email?.trim().toLowerCase();
+    if (!chartEmail || !portalEmail || chartEmail !== portalEmail) {
+      throw new BadRequestException(
+        'Portal account email must match the patient chart email',
+      );
+    }
+
     const existingLink = await this.patientsRepo.findOne({
       where: { userId: targetUserId },
     });

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -9,7 +9,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { existsSync, unlinkSync } from 'fs';
 import { basename, join } from 'path';
-import { ILike, EntityManager, Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import {
   Patient,
   PatientAllergy,
@@ -466,7 +466,7 @@ export class PatientsService {
     });
 
     for (const fileUrl of fileUrlsToUnlink) {
-      this.unlinkStoredUpload(fileUrl);
+      await this.unlinkStoredUploadIfUnreferenced(fileUrl);
     }
 
     await this.audit.log({
@@ -556,8 +556,12 @@ export class PatientsService {
     if (!document) throw new NotFoundException('Patient document not found');
 
     const fileUrl = document.fileUrl;
+    // Unlink while this row still owns the unique file_url so a concurrent
+    // re-bind cannot claim the path and then have its disk file deleted (#222).
+    await this.unlinkStoredUploadIfUnreferenced(fileUrl, {
+      excludeDocumentId: document.id,
+    });
     await this.documentsRepo.remove(document);
-    this.unlinkStoredUpload(fileUrl);
 
     await this.audit.log({
       actorId: actor.id,
@@ -571,8 +575,15 @@ export class PatientsService {
     return true;
   }
 
-  /** Remove PHI file from local uploads/ when the document row is deleted. */
-  private unlinkStoredUpload(fileUrl: string | undefined) {
+  /**
+   * Remove PHI file from local uploads/ only when no document or lab result
+   * still references it. Pass excludeDocumentId while the row still exists
+   * so we can unlink-before-remove safely (#210 / #222).
+   */
+  private async unlinkStoredUploadIfUnreferenced(
+    fileUrl: string | undefined,
+    options?: { excludeDocumentId?: string },
+  ) {
     if (!fileUrl) return;
     try {
       const marker = '/uploads/';
@@ -581,6 +592,32 @@ export class PatientsService {
         idx >= 0 ? fileUrl.slice(idx + marker.length) : basename(fileUrl);
       const safe = basename(rawName.split('?')[0] ?? '');
       if (!safe || safe.includes('..')) return;
+
+      const suffix = `/uploads/${safe}`;
+      const docsQb = this.documentsRepo
+        .createQueryBuilder('doc')
+        .where(
+          '(doc.file_url = :relative OR doc.file_url = :filename OR RIGHT(doc.file_url, :len) = :suffix)',
+          { relative: suffix, filename: safe, len: suffix.length, suffix },
+        );
+      if (options?.excludeDocumentId) {
+        docsQb.andWhere('doc.id != :excludeId', {
+          excludeId: options.excludeDocumentId,
+        });
+      }
+      const otherDocs = await docsQb.getMany();
+      if (otherDocs.length > 0) return;
+
+      const labs = await this.documentsRepo.manager
+        .getRepository(LabResult)
+        .createQueryBuilder('result')
+        .where(
+          '(result.result_file_url = :relative OR result.result_file_url = :filename OR RIGHT(result.result_file_url, :len) = :suffix)',
+          { relative: suffix, filename: safe, len: suffix.length, suffix },
+        )
+        .getMany();
+      if (labs.length > 0) return;
+
       const path = join(process.cwd(), 'uploads', safe);
       if (existsSync(path)) {
         unlinkSync(path);
@@ -1083,14 +1120,34 @@ export class PatientsService {
       throw new BadRequestException('Upload file not found on server');
     }
 
-    const existingDocs = await this.documentsRepo.find({
-      where: { fileUrl: ILike(`%/uploads/${filename}`) },
-      take: 20,
-    });
+    const suffix = `/uploads/${filename}`;
+    const existingDocs = await this.documentsRepo
+      .createQueryBuilder('doc')
+      .where(
+        '(doc.file_url = :relative OR doc.file_url = :filename OR RIGHT(doc.file_url, :len) = :suffix)',
+        { relative: suffix, filename, len: suffix.length, suffix },
+      )
+      .getMany();
 
     if (existingDocs.length > 0) {
       throw new BadRequestException(
         'Upload file is already linked to a patient document',
+      );
+    }
+
+    // Mirror lab exclusivity: a lab-owned upload must not be re-bound as a
+    // document (cross-patient PHI / shared-disk unlink risk) (#210).
+    const existingLabs = await this.documentsRepo.manager
+      .getRepository(LabResult)
+      .createQueryBuilder('result')
+      .where(
+        '(result.result_file_url = :relative OR result.result_file_url = :filename OR RIGHT(result.result_file_url, :len) = :suffix)',
+        { relative: suffix, filename, len: suffix.length, suffix },
+      )
+      .getMany();
+    if (existingLabs.length > 0) {
+      throw new BadRequestException(
+        'Upload file is already linked to a lab result',
       );
     }
 

--- a/apps/api/src/pharmacy/pharmacy.service.spec.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.spec.ts
@@ -12,6 +12,10 @@ describe('PharmacyService', () => {
   const manager = {
     createQueryBuilder: jest.fn(),
     save: jest.fn(),
+    findOne: jest.fn().mockResolvedValue({
+      id: 'patient-1',
+      hospitalId: 'hospital-a',
+    }),
   };
 
   const pharmacyStockRepo = {
@@ -73,6 +77,7 @@ describe('PharmacyService', () => {
         getOne: jest.fn().mockResolvedValue({
           id: 'rx-1',
           hospitalId: 'hospital-a',
+          patientId: 'patient-1',
           status: 'pending',
           items: [{ drugName: 'Amoxicillin' }],
         }),
@@ -105,6 +110,7 @@ describe('PharmacyService', () => {
         getOne: jest.fn().mockResolvedValue({
           id: 'rx-1',
           hospitalId: 'hospital-a',
+          patientId: 'patient-1',
           status: 'pending',
           items: [{ drugName: 'Amoxicillin' }, { drugName: 'Amoxicillin' }],
         }),
@@ -146,6 +152,7 @@ describe('PharmacyService', () => {
         getOne: jest.fn().mockResolvedValue({
           id: 'rx-1',
           hospitalId: 'hospital-a',
+          patientId: 'patient-1',
           status: 'pending',
           items: [{ drugName: 'Amoxicillin' }],
           patient: null,

--- a/apps/api/src/pharmacy/pharmacy.service.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { PharmacyStock, Prescription } from '../database/entities';
+import { PharmacyStock, Prescription, Patient } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
 import {
@@ -180,12 +180,16 @@ export class PharmacyService {
   async listPendingPrescriptions(
     hospitalId: string,
   ): Promise<PendingPrescriptionType[]> {
-    const prescriptions = await this.prescriptionsRepo.find({
-      where: { hospitalId, status: 'pending' },
-      relations: ['items', 'patient'],
-      order: { createdAt: 'ASC' },
-      take: 200,
-    });
+    const prescriptions = await this.prescriptionsRepo
+      .createQueryBuilder('prescription')
+      .innerJoinAndSelect('prescription.patient', 'patient')
+      .leftJoinAndSelect('prescription.items', 'items')
+      .where('prescription.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('prescription.status = :status', { status: 'pending' })
+      .andWhere('patient.deleted_at IS NULL')
+      .orderBy('prescription.created_at', 'ASC')
+      .take(200)
+      .getMany();
     return prescriptions.map((prescription) =>
       this.toPendingPrescriptionType(prescription),
     );
@@ -208,6 +212,10 @@ export class PharmacyService {
           .getOne();
         if (!prescription)
           throw new NotFoundException('Prescription not found');
+        const patient = await manager.findOne(Patient, {
+          where: { id: prescription.patientId, hospitalId },
+        });
+        if (!patient) throw new NotFoundException('Prescription not found');
         if (prescription.status !== 'pending') {
           throw new BadRequestException(
             'Only pending prescriptions can be dispensed',

--- a/apps/api/src/rbac/roles.guard.spec.ts
+++ b/apps/api/src/rbac/roles.guard.spec.ts
@@ -32,10 +32,10 @@ describe('RolesGuard', () => {
     jest.restoreAllMocks();
   });
 
-  it('allows access when no roles or permissions are required', () => {
+  it('denies access when no roles or permissions are required', () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
 
-    expect(guard.canActivate(createContext())).toBe(true);
+    expect(guard.canActivate(createContext())).toBe(false);
   });
 
   it('requires an authenticated user when AllowAuthenticated is set', () => {

--- a/apps/api/src/rbac/roles.guard.ts
+++ b/apps/api/src/rbac/roles.guard.ts
@@ -36,8 +36,9 @@ export class RolesGuard implements CanActivate {
       return !!user;
     }
 
+    // Fail closed: handlers must declare @Roles, @Permissions, or @AllowAuthenticated.
     if (!requiredRoles?.length && !requiredPermissions?.length) {
-      return true;
+      return false;
     }
 
     if (!user) return false;

--- a/apps/api/src/staff/staff.resolver.ts
+++ b/apps/api/src/staff/staff.resolver.ts
@@ -75,6 +75,19 @@ export class StaffResolver {
     return this.staffService.toStaffType(full!);
   }
 
+  @Mutation(() => StaffType)
+  @Roles(ROLES.HOSPITAL_ADMIN, ROLES.HOSPITAL_MANAGER, ROLES.SUPER_ADMIN)
+  @Permissions(PERMISSIONS.STAFF_WRITE)
+  async resendStaffInvite(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('id') id: string,
+  ): Promise<StaffType> {
+    const member = await this.staffService.resendStaffInvite(id, user);
+    const inviteToken = member.inviteToken;
+    const full = await this.staffService.findById(member.id);
+    return this.staffService.toStaffType({ ...full!, inviteToken });
+  }
+
   @Mutation(() => Boolean)
   @Roles(ROLES.HOSPITAL_ADMIN, ROLES.SUPER_ADMIN)
   @Permissions(PERMISSIONS.STAFF_WRITE)

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -360,4 +360,71 @@ describe('StaffService', () => {
       });
     });
   });
+
+  describe('resendStaffInvite', () => {
+    const pendingStaff = {
+      id: 'staff-1',
+      userId: 'user-1',
+      hospitalId: 'hospital-a',
+      isActive: true,
+      user: {
+        email: 'doc@example.com',
+        fullName: 'Doc',
+        userRoles: [{ role: { slug: 'doctor' } }],
+      },
+    };
+
+    it('rotates token and resets expiry for pending invites', async () => {
+      staffRepo.findOne.mockResolvedValue({ ...pendingStaff });
+      const invite = {
+        id: 'invite-1',
+        staffProfileId: 'staff-1',
+        email: 'doc@example.com',
+        acceptedAt: null,
+        token: 'old-token',
+        expiresAt: new Date(Date.now() - 1000),
+      };
+      invitesRepo.findOne.mockResolvedValue(invite);
+      invitesRepo.save.mockImplementation((row: unknown) =>
+        Promise.resolve(row),
+      );
+
+      const result = await service.resendStaffInvite('staff-1', hospitalAdmin);
+
+      expect(result.inviteToken).toBeDefined();
+      expect(result.inviteToken).not.toBe('old-token');
+      expect(invite.token).toBe(result.inviteToken);
+      expect(invite.expiresAt.getTime()).toBeGreaterThan(Date.now());
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'resend_invite',
+          resource: 'staff',
+          resourceId: 'staff-1',
+        }),
+      );
+    });
+
+    it('rejects when invite was already accepted', async () => {
+      staffRepo.findOne.mockResolvedValue({ ...pendingStaff });
+      invitesRepo.findOne.mockResolvedValue({
+        id: 'invite-1',
+        staffProfileId: 'staff-1',
+        acceptedAt: new Date(),
+        token: 'old-token',
+      });
+
+      await expect(
+        service.resendStaffInvite('staff-1', hospitalAdmin),
+      ).rejects.toThrow(BadRequestException);
+      expect(invitesRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects when staff member is not found', async () => {
+      staffRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.resendStaffInvite('missing', hospitalAdmin),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
 });

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -368,6 +368,52 @@ export class StaffService {
     return true;
   }
 
+  /**
+   * Rotate token and reset expiry for a pending (unaccepted) staff invite.
+   * Managers can recover lost/expired invites without deleting the profile.
+   */
+  async resendStaffInvite(
+    staffId: string,
+    actor: AuthenticatedUser,
+  ): Promise<StaffProfile & { inviteToken: string }> {
+    const staff = await this.findByIdForUser(staffId, actor);
+    if (!staff) throw new NotFoundException('Staff member not found');
+    if (!staff.isActive) {
+      throw new BadRequestException(
+        'Cannot resend invite for a deactivated staff member',
+      );
+    }
+
+    const invite = await this.invitesRepo.findOne({
+      where: { staffProfileId: staff.id },
+      order: { createdAt: 'DESC' },
+    });
+    if (!invite) {
+      throw new NotFoundException('No invite found for this staff member');
+    }
+    if (invite.acceptedAt) {
+      throw new BadRequestException(
+        'Invite has already been accepted; cannot resend',
+      );
+    }
+
+    const token = randomBytes(32).toString('hex');
+    invite.token = token;
+    invite.expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    await this.invitesRepo.save(invite);
+
+    await this.audit.log({
+      actorId: actor.id,
+      hospitalId: staff.hospitalId,
+      action: 'resend_invite',
+      resource: 'staff',
+      resourceId: staff.id,
+      metadata: { email: invite.email },
+    });
+
+    return Object.assign(staff, { inviteToken: token });
+  }
+
   /** Expire unaccepted invites so deactivated staff cannot self-reactivate. */
   private async invalidateOutstandingInvites(staff: StaffProfile) {
     const now = new Date();

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -102,12 +102,12 @@ export class UploadsController {
       },
     }),
   )
-  uploadPatientDocument(
+  async uploadPatientDocument(
     @UploadedFile() file: Express.Multer.File,
     @Req() req: AuthedRequest,
   ) {
     if (!req.user) throw new ForbiddenException('Authentication required');
-    this.uploadsService.assertCanUpload(req.user);
+    await this.uploadsService.assertCanUpload(req.user);
 
     if (!file) throw new BadRequestException('file is required');
     // Prefer configured public base; otherwise return a stable relative path

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -125,43 +125,81 @@ describe('UploadsService', () => {
   };
 
   describe('assertCanUpload', () => {
-    it('allows staff with patients:write', () => {
-      expect(() => service.assertCanUpload(staffUser)).not.toThrow();
+    it('allows staff with patients:write', async () => {
+      await expect(service.assertCanUpload(staffUser)).resolves.toBeUndefined();
     });
 
-    it('allows super_admin', () => {
-      expect(() =>
+    it('allows super_admin', async () => {
+      await expect(
         service.assertCanUpload({
           ...staffUser,
           roles: ['super_admin'],
           permissions: [],
         }),
-      ).not.toThrow();
+      ).resolves.toBeUndefined();
     });
 
-    it('denies patient role', () => {
-      expect(() => service.assertCanUpload(patientUser)).toThrow(
+    it('denies patient role', async () => {
+      await expect(service.assertCanUpload(patientUser)).rejects.toThrow(
         ForbiddenException,
       );
     });
 
-    it('denies staff without patients:write', () => {
-      expect(() =>
+    it('denies staff without patients:write', async () => {
+      await expect(
         service.assertCanUpload({
           ...staffUser,
           permissions: ['patients:read'],
         }),
-      ).toThrow(ForbiddenException);
+      ).rejects.toThrow(ForbiddenException);
     });
 
-    it('allows lab technicians with lab:write', () => {
-      expect(() =>
+    it('allows lab technicians with lab:write', async () => {
+      await expect(
         service.assertCanUpload({
           ...staffUser,
           roles: ['lab_technician'],
           permissions: ['lab:write'],
         }),
-      ).not.toThrow();
+      ).resolves.toBeUndefined();
+    });
+
+    it('denies upload when actor hospital is inactive', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: false,
+      });
+
+      await expect(service.assertCanUpload(staffUser)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('denies super_admin upload when their hospitalId is inactive', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: false,
+      });
+
+      await expect(
+        service.assertCanUpload({
+          ...staffUser,
+          roles: ['super_admin'],
+          permissions: [],
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('allows super_admin without hospitalId when hospital check cannot apply', async () => {
+      await expect(
+        service.assertCanUpload({
+          ...staffUser,
+          hospitalId: undefined,
+          roles: ['super_admin'],
+          permissions: [],
+        }),
+      ).resolves.toBeUndefined();
+      expect(hospitalsRepo.findOne).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -222,8 +222,23 @@ export class UploadsService implements OnApplicationBootstrap {
     throw new ForbiddenException('Access denied');
   }
 
-  /** Staff with patients:write or lab:write may upload files. */
-  assertCanUpload(user: AuthenticatedUser): void {
+  /**
+   * Staff with patients:write or lab:write may upload files.
+   * Refuse when the actor's hospital is inactive (fail-closed, incl. super_admin
+   * with a hospitalId scoped to an inactive tenant).
+   */
+  async assertCanUpload(user: AuthenticatedUser): Promise<void> {
+    if (user.hospitalId) {
+      const hospital = await this.hospitalsRepo.findOne({
+        where: { id: user.hospitalId },
+      });
+      if (!hospital || !hospital.isActive) {
+        throw new ForbiddenException(
+          'This hospital is currently inactive; uploads are unavailable',
+        );
+      }
+    }
+
     if (user.roles.includes('super_admin')) return;
     if (user.permissions.includes(PERMISSIONS.PATIENTS_WRITE)) return;
     if (user.permissions.includes(PERMISSIONS.LAB_WRITE)) return;

--- a/apps/web/src/app/(dashboard)/admissions/page.tsx
+++ b/apps/web/src/app/(dashboard)/admissions/page.tsx
@@ -57,7 +57,11 @@ export default function AdmissionsPage() {
     skip: !hospitalId,
   });
 
-  const { data: patientsData } = useQuery(PATIENTS_QUERY, {
+  const {
+    data: patientsData,
+    error: patientsError,
+    refetch: refetchPatients,
+  } = useQuery(PATIENTS_QUERY, {
     variables: { search: patientSearch, limit: 8, hospitalId },
     skip: !hospitalId || patientSearch.length < 2,
   });
@@ -231,7 +235,13 @@ export default function AdmissionsPage() {
               value={patientSearch}
               onChange={(e) => setPatientSearch(e.target.value)}
             />
-            {patientsData?.patients?.items?.length ? (
+            {patientsError ? (
+              <QueryError
+                message="We could not search patients. Please try again."
+                onRetry={() => void refetchPatients()}
+                className="text-left"
+              />
+            ) : patientsData?.patients?.items?.length ? (
               <div className="rounded-2xl bg-clay-primary-light/30 p-2">
                 {patientsData.patients.items.map((p: { id: string; fullName: string }) => (
                   <button

--- a/apps/web/src/app/(dashboard)/finance/invoices/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/invoices/[id]/page.tsx
@@ -77,7 +77,10 @@ export default function InvoiceDetailPage() {
           <div className="flex items-center justify-between">
             <ClayBadge>{invoice.status}</ClayBadge>
             <div className="flex items-center gap-3">
-              {canWriteBilling && invoice.status !== 'void' && invoice.status !== 'paid' ? (
+              {canWriteBilling &&
+              invoice.status !== 'void' &&
+              invoice.status !== 'paid' &&
+              (invoice.payments ?? []).length === 0 ? (
                 <ClayButton
                   size="sm"
                   variant="ghost"

--- a/apps/web/src/app/(dashboard)/finance/invoices/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/invoices/new/page.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery } from '@apollo/client';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
 import { ForbiddenAccess } from '@/components/auth/forbidden-access';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
+import { QueryError } from '@/components/query-error';
 import {
   CREATE_INVOICE_MUTATION,
   ME_QUERY,
@@ -32,10 +33,13 @@ export default function NewInvoicePage() {
   const hospitalId = meData?.me?.hospitalId;
   const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
 
-  const { data: patientsData } = useQuery(PATIENTS_QUERY, {
-    variables: { search: patientSearch, limit: 8, hospitalId },
-    skip: !hospitalId || patientSearch.length < 2,
-  });
+  const { data: patientsData, error: patientsError, refetch: refetchPatients } = useQuery(
+    PATIENTS_QUERY,
+    {
+      variables: { search: patientSearch, limit: 8, hospitalId },
+      skip: !hospitalId || patientSearch.length < 2,
+    },
+  );
 
   const [createInvoice, { loading }] = useMutation(CREATE_INVOICE_MUTATION, {
     onCompleted: () => router.push('/finance/invoices'),
@@ -120,7 +124,13 @@ export default function NewInvoicePage() {
             value={patientSearch}
             onChange={(e) => setPatientSearch(e.target.value)}
           />
-          {patientsData?.patients?.items?.length ? (
+          {patientsError ? (
+            <QueryError
+              message="We could not search patients. Please try again."
+              onRetry={() => void refetchPatients()}
+              className="text-left"
+            />
+          ) : patientsData?.patients?.items?.length ? (
             <div className="rounded-2xl bg-clay-primary-light/30 p-2">
               {patientsData.patients.items.map((p: { id: string; fullName: string }) => (
                 <button

--- a/apps/web/src/app/(dashboard)/finance/invoices/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/finance/invoices/new/page.tsx
@@ -10,7 +10,7 @@ import { QueryError } from '@/components/query-error';
 import {
   CREATE_INVOICE_MUTATION,
   ME_QUERY,
-  PATIENTS_QUERY,
+  BILLING_PATIENT_SEARCH_QUERY,
 } from '@/lib/graphql/queries';
 
 type LineItem = {
@@ -34,7 +34,7 @@ export default function NewInvoicePage() {
   const canWriteBilling = (meData?.me?.permissions ?? []).includes('billing:write');
 
   const { data: patientsData, error: patientsError, refetch: refetchPatients } = useQuery(
-    PATIENTS_QUERY,
+    BILLING_PATIENT_SEARCH_QUERY,
     {
       variables: { search: patientSearch, limit: 8, hospitalId },
       skip: !hospitalId || patientSearch.length < 2,
@@ -130,21 +130,26 @@ export default function NewInvoicePage() {
               onRetry={() => void refetchPatients()}
               className="text-left"
             />
-          ) : patientsData?.patients?.items?.length ? (
+          ) : patientsData?.billingPatientSearch?.length ? (
             <div className="rounded-2xl bg-clay-primary-light/30 p-2">
-              {patientsData.patients.items.map((p: { id: string; fullName: string }) => (
-                <button
-                  key={p.id}
-                  type="button"
-                  onClick={() => {
-                    setPatientId(p.id);
-                    setPatientSearch(p.fullName);
-                  }}
-                  className="block w-full rounded-xl px-3 py-2 text-left text-sm text-clay-text hover:bg-clay-primary-light/50"
-                >
-                  {p.fullName}
-                </button>
-              ))}
+              {patientsData.billingPatientSearch.map(
+                (p: { id: string; fullName: string; mrn?: string }) => (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => {
+                      setPatientId(p.id);
+                      setPatientSearch(p.fullName);
+                    }}
+                    className="block w-full rounded-xl px-3 py-2 text-left text-sm text-clay-text hover:bg-clay-primary-light/50"
+                  >
+                    {p.fullName}
+                    {p.mrn ? (
+                      <span className="ml-2 text-clay-text-muted">({p.mrn})</span>
+                    ) : null}
+                  </button>
+                ),
+              )}
             </div>
           ) : null}
           <ClayInput

--- a/apps/web/src/app/(dashboard)/follow-ups/page.tsx
+++ b/apps/web/src/app/(dashboard)/follow-ups/page.tsx
@@ -10,6 +10,7 @@ import {
   FOLLOW_UPS_QUERY,
   ME_QUERY,
   PATIENTS_QUERY,
+  STAFF_MEMBERS_QUERY,
   UPDATE_FOLLOW_UP_STATUS_MUTATION,
 } from '@/lib/graphql/queries';
 import { QueryError } from '@/components/query-error';
@@ -47,6 +48,7 @@ export default function FollowUpsPage() {
   const [showForm, setShowForm] = useState(false);
   const [patientSearch, setPatientSearch] = useState('');
   const [patientId, setPatientId] = useState('');
+  const [doctorId, setDoctorId] = useState('');
   const [scheduledAt, setScheduledAt] = useState('');
   const [type, setType] = useState('outpatient');
   const [error, setError] = useState('');
@@ -64,6 +66,22 @@ export default function FollowUpsPage() {
     },
   );
 
+  const {
+    data: staffData,
+    error: staffError,
+    refetch: refetchStaff,
+  } = useQuery(STAFF_MEMBERS_QUERY, {
+    variables: { hospitalId },
+    skip: !hospitalId || !showForm,
+  });
+
+  const doctors = staffError
+    ? []
+    : (staffData?.staffMembers ?? []).filter(
+        (s: { roleSlug: string; isActive: boolean }) =>
+          s.isActive && (s.roleSlug === 'doctor' || s.roleSlug === 'hospital_admin'),
+      );
+
   const [updateStatus] = useMutation(UPDATE_FOLLOW_UP_STATUS_MUTATION, {
     onCompleted: () => refetch(),
   });
@@ -72,6 +90,7 @@ export default function FollowUpsPage() {
       refetch();
       setShowForm(false);
       setPatientId('');
+      setDoctorId('');
       setScheduledAt('');
       setPatientSearch('');
     },
@@ -92,8 +111,16 @@ export default function FollowUpsPage() {
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
+    if (staffError) {
+      setError('Could not load doctors. Please retry before scheduling.');
+      return;
+    }
     if (!patientId || !scheduledAt) {
       setError('Patient and schedule are required');
+      return;
+    }
+    if (!doctorId) {
+      setError('Doctor is required');
       return;
     }
     await createFollowUp({
@@ -101,6 +128,7 @@ export default function FollowUpsPage() {
         hospitalId,
         input: {
           patientId,
+          doctorId,
           scheduledAt: new Date(scheduledAt).toISOString(),
           type,
         },
@@ -172,6 +200,33 @@ export default function FollowUpsPage() {
               onChange={(e) => setScheduledAt(e.target.value)}
               required
             />
+            <div className="flex flex-col gap-2">
+              <label htmlFor="follow-up-doctor" className="text-sm font-medium text-clay-text">
+                Doctor *
+              </label>
+              {staffError ? (
+                <QueryError
+                  message="We could not load doctors. Please try again."
+                  onRetry={() => void refetchStaff()}
+                  className="text-left"
+                />
+              ) : (
+                <select
+                  id="follow-up-doctor"
+                  value={doctorId}
+                  onChange={(e) => setDoctorId(e.target.value)}
+                  required
+                  className="w-full rounded-2xl border border-white/60 bg-clay-surface px-4 py-3 text-sm text-clay-text shadow-clay-inset outline-none focus:ring-2 focus:ring-clay-primary/30"
+                >
+                  <option value="">Select doctor</option>
+                  {doctors.map((d: { userId: string; fullName: string }) => (
+                    <option key={d.userId} value={d.userId}>
+                      {d.fullName}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
             <label className="block text-sm font-medium text-clay-text">
               Type
               <select

--- a/apps/web/src/app/(dashboard)/follow-ups/page.tsx
+++ b/apps/web/src/app/(dashboard)/follow-ups/page.tsx
@@ -56,10 +56,13 @@ export default function FollowUpsPage() {
     skip: !hospitalId,
   });
 
-  const { data: patientsData } = useQuery(PATIENTS_QUERY, {
-    variables: { search: patientSearch, limit: 8, hospitalId },
-    skip: !hospitalId || patientSearch.length < 2,
-  });
+  const { data: patientsData, error: patientsError, refetch: refetchPatients } = useQuery(
+    PATIENTS_QUERY,
+    {
+      variables: { search: patientSearch, limit: 8, hospitalId },
+      skip: !hospitalId || patientSearch.length < 2,
+    },
+  );
 
   const [updateStatus] = useMutation(UPDATE_FOLLOW_UP_STATUS_MUTATION, {
     onCompleted: () => refetch(),
@@ -134,7 +137,13 @@ export default function FollowUpsPage() {
               onChange={(e) => setPatientSearch(e.target.value)}
               placeholder="Type at least 2 characters"
             />
-            {(patientsData?.patients?.items ?? []).length > 0 ? (
+            {patientsError ? (
+              <QueryError
+                message="We could not search patients. Please try again."
+                onRetry={() => void refetchPatients()}
+                className="text-left"
+              />
+            ) : (patientsData?.patients?.items ?? []).length > 0 ? (
               <ul className="max-h-40 overflow-auto rounded-2xl bg-clay-primary-light/20 text-sm">
                 {(patientsData?.patients?.items ?? []).map(
                   (p: { id: string; fullName: string }) => (

--- a/apps/web/src/app/(dashboard)/inventory/page.tsx
+++ b/apps/web/src/app/(dashboard)/inventory/page.tsx
@@ -74,11 +74,10 @@ export default function InventoryPage() {
     }
   };
 
-  const handleAdjust = async (id: string, currentQty: number, delta: number) => {
-    const newQty = Math.max(0, currentQty + delta);
+  const handleAdjust = async (id: string, delta: number) => {
     try {
       await updateQuantity({
-        variables: { hospitalId, input: { id, quantity: newQty } },
+        variables: { hospitalId, input: { id, delta } },
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update quantity');
@@ -197,7 +196,7 @@ export default function InventoryPage() {
                           size="sm"
                           variant="secondary"
                           disabled={updating}
-                          onClick={() => handleAdjust(item.id, item.quantity, -1)}
+                          onClick={() => handleAdjust(item.id, -1)}
                         >
                           −
                         </ClayButton>
@@ -205,7 +204,7 @@ export default function InventoryPage() {
                           size="sm"
                           variant="secondary"
                           disabled={updating}
-                          onClick={() => handleAdjust(item.id, item.quantity, 1)}
+                          onClick={() => handleAdjust(item.id, 1)}
                         >
                           +
                         </ClayButton>

--- a/apps/web/src/app/(dashboard)/lab/page.tsx
+++ b/apps/web/src/app/(dashboard)/lab/page.tsx
@@ -85,10 +85,13 @@ export default function LabPage() {
     skip: !hospitalId,
   });
 
-  const { data: patientsData } = useQuery(PATIENTS_QUERY, {
-    variables: { search: patientSearch, limit: 8, hospitalId },
-    skip: !hospitalId || !canCreateOrders || patientSearch.length < 2,
-  });
+  const { data: patientsData, error: patientsError, refetch: refetchPatients } = useQuery(
+    PATIENTS_QUERY,
+    {
+      variables: { search: patientSearch, limit: 8, hospitalId },
+      skip: !hospitalId || !canCreateOrders || patientSearch.length < 2,
+    },
+  );
 
   const resetCompleteForm = () => {
     setSelectedOrderId(null);
@@ -285,7 +288,13 @@ export default function LabPage() {
               value={patientSearch}
               onChange={(e) => setPatientSearch(e.target.value)}
             />
-            {patientsData?.patients?.items?.length ? (
+            {patientsError ? (
+              <QueryError
+                message="We could not search patients. Please try again."
+                onRetry={() => void refetchPatients()}
+                className="text-left"
+              />
+            ) : patientsData?.patients?.items?.length ? (
               <div className="rounded-2xl bg-clay-primary-light/30 p-2">
                 {patientsData.patients.items.map((p: { id: string; fullName: string }) => (
                   <button

--- a/apps/web/src/app/(dashboard)/patients/[id]/discharge/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/discharge/page.tsx
@@ -15,6 +15,7 @@ import {
   CREATE_DISCHARGE_MUTATION,
   ME_QUERY,
   PATIENT_QUERY,
+  STAFF_MEMBERS_QUERY,
 } from '@/lib/graphql/queries';
 import { canDischargePatients } from '@/lib/clinical-access';
 
@@ -25,6 +26,7 @@ export default function PatientDischargePage() {
   const [medications, setMedications] = useState('');
   const [instructions, setInstructions] = useState('');
   const [followUpDate, setFollowUpDate] = useState('');
+  const [followUpDoctorId, setFollowUpDoctorId] = useState('');
   const [error, setError] = useState('');
 
   const { data: meData } = useQuery(ME_QUERY);
@@ -48,6 +50,22 @@ export default function PatientDischargePage() {
     skip: !hospitalId,
   });
 
+  const {
+    data: staffData,
+    error: staffError,
+    refetch: refetchStaff,
+  } = useQuery(STAFF_MEMBERS_QUERY, {
+    variables: { hospitalId },
+    skip: !hospitalId || !canDischarge,
+  });
+
+  const doctors = staffError
+    ? []
+    : (staffData?.staffMembers ?? []).filter(
+        (s: { roleSlug: string; isActive: boolean }) =>
+          s.isActive && (s.roleSlug === 'doctor' || s.roleSlug === 'hospital_admin'),
+      );
+
   const admission = admissionsData?.activeAdmissions?.find(
     (item: { patientId: string }) => item.patientId === id,
   );
@@ -65,6 +83,17 @@ export default function PatientDischargePage() {
       return;
     }
 
+    if (followUpDate) {
+      if (staffError) {
+        setError('Could not load doctors. Please retry before scheduling a follow-up.');
+        return;
+      }
+      if (!followUpDoctorId) {
+        setError('Doctor is required when scheduling a follow-up.');
+        return;
+      }
+    }
+
     try {
       await createDischarge({
         variables: {
@@ -76,6 +105,7 @@ export default function PatientDischargePage() {
             instructions: instructions || undefined,
             followUpScheduledAt: followUpDate ? new Date(followUpDate).toISOString() : undefined,
             followUpType: followUpDate ? 'post_discharge' : undefined,
+            followUpDoctorId: followUpDate ? followUpDoctorId : undefined,
           },
         },
       });
@@ -193,10 +223,43 @@ export default function PatientDischargePage() {
                 id="follow-up-date"
                 type="datetime-local"
                 value={followUpDate}
-                onChange={(e) => setFollowUpDate(e.target.value)}
+                onChange={(e) => {
+                  setFollowUpDate(e.target.value);
+                  if (!e.target.value) setFollowUpDoctorId('');
+                }}
                 className="w-full rounded-2xl border border-white/60 bg-clay-surface px-4 py-3 text-clay-text shadow-clay-inset outline-none focus:ring-2 focus:ring-clay-primary/30"
               />
             </div>
+
+            {followUpDate ? (
+              <div className="flex w-full flex-col gap-2">
+                <label htmlFor="follow-up-doctor" className="text-sm font-medium text-clay-text">
+                  Follow-up Doctor *
+                </label>
+                {staffError ? (
+                  <QueryError
+                    message="We could not load doctors. Please try again."
+                    onRetry={() => void refetchStaff()}
+                    className="text-left"
+                  />
+                ) : (
+                  <select
+                    id="follow-up-doctor"
+                    value={followUpDoctorId}
+                    onChange={(e) => setFollowUpDoctorId(e.target.value)}
+                    required
+                    className="w-full rounded-2xl border border-white/60 bg-clay-surface px-4 py-3 text-clay-text shadow-clay-inset outline-none focus:ring-2 focus:ring-clay-primary/30"
+                  >
+                    <option value="">Select doctor</option>
+                    {doctors.map((d: { userId: string; fullName: string }) => (
+                      <option key={d.userId} value={d.userId}>
+                        {d.fullName}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            ) : null}
 
             {error ? <p className="text-sm text-clay-error">{error}</p> : null}
 

--- a/apps/web/src/app/(dashboard)/settings/facility/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/facility/page.tsx
@@ -17,6 +17,7 @@ import {
   DELETE_WARD_MUTATION,
   DEPARTMENTS_QUERY,
   ME_QUERY,
+  UPDATE_BED_STATUS_MUTATION,
   WARDS_QUERY,
 } from '@/lib/graphql/queries';
 
@@ -124,6 +125,17 @@ export default function FacilitySettingsPage() {
     },
     onError: (err) => setError(err.message),
   });
+
+  const [updateBedStatus, { loading: updatingBedStatus }] = useMutation(
+    UPDATE_BED_STATUS_MUTATION,
+    {
+      onCompleted: () => {
+        setMessage('Bed status updated');
+        bedsQuery.refetch();
+      },
+      onError: (err) => setError(err.message),
+    },
+  );
 
   const departments: Department[] = departmentsQuery.data?.departments ?? [];
   const wards: Ward[] = wardsQuery.data?.wards ?? [];
@@ -461,19 +473,45 @@ export default function FacilitySettingsPage() {
                       {b.status}
                     </ClayBadge>
                     {b.status !== 'occupied' && canWriteFacility ? (
-                      <ClayButton
-                        type="button"
-                        size="sm"
-                        variant="ghost"
-                        aria-label={`Delete ${b.label}`}
-                        onClick={() => {
-                          if (confirm(`Delete bed “${b.label}”?`)) {
-                            deleteBed({ variables: { id: b.id, hospitalId } });
+                      <>
+                        <ClayButton
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          isLoading={updatingBedStatus}
+                          aria-label={
+                            b.status === 'maintenance'
+                              ? `Mark ${b.label} available`
+                              : `Mark ${b.label} maintenance`
                           }
-                        }}
-                      >
-                        <Trash2 className="h-4 w-4 text-clay-error" />
-                      </ClayButton>
+                          onClick={() => {
+                            resetFlash();
+                            const nextStatus =
+                              b.status === 'maintenance' ? 'available' : 'maintenance';
+                            updateBedStatus({
+                              variables: {
+                                hospitalId,
+                                input: { bedId: b.id, status: nextStatus },
+                              },
+                            });
+                          }}
+                        >
+                          {b.status === 'maintenance' ? 'Set available' : 'Set maintenance'}
+                        </ClayButton>
+                        <ClayButton
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          aria-label={`Delete ${b.label}`}
+                          onClick={() => {
+                            if (confirm(`Delete bed “${b.label}”?`)) {
+                              deleteBed({ variables: { id: b.id, hospitalId } });
+                            }
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4 text-clay-error" />
+                        </ClayButton>
+                      </>
                     ) : null}
                   </div>
                 </div>

--- a/apps/web/src/app/(dashboard)/staff/page.tsx
+++ b/apps/web/src/app/(dashboard)/staff/page.tsx
@@ -3,13 +3,14 @@
 import Link from 'next/link';
 import { useState } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
-import { Plus, Pencil, Trash2, RotateCcw } from 'lucide-react';
+import { Mail, Plus, Pencil, Trash2, RotateCcw } from 'lucide-react';
 import { ClayBadge, ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { QueryError } from '@/components/query-error';
 import {
   DELETE_STAFF_MUTATION,
   ME_QUERY,
+  RESEND_STAFF_INVITE_MUTATION,
   STAFF_MEMBERS_QUERY,
   UPDATE_STAFF_MUTATION,
 } from '@/lib/graphql/queries';
@@ -29,18 +30,27 @@ export default function StaffPage() {
     onCompleted: () => refetch(),
   });
 
+  const [resendInvite] = useMutation(RESEND_STAFF_INVITE_MUTATION);
+
   const staff = data?.staffMembers ?? [];
   const permissions = meData?.me?.permissions ?? [];
   const roles = meData?.me?.roles ?? [];
   const canWriteStaff = permissions.includes('staff:write');
+  const canResendInvite =
+    canWriteStaff &&
+    (roles.includes('hospital_admin') ||
+      roles.includes('hospital_manager') ||
+      roles.includes('super_admin'));
   const canDeactivateStaff =
     canWriteStaff &&
     (roles.includes('hospital_admin') || roles.includes('super_admin'));
   const [actionError, setActionError] = useState('');
+  const [inviteNotice, setInviteNotice] = useState('');
 
   const handleDelete = async (id: string, name: string) => {
     if (!confirm(`Deactivate ${name}?`)) return;
     setActionError('');
+    setInviteNotice('');
     try {
       await deleteStaff({ variables: { id } });
     } catch (err) {
@@ -50,10 +60,34 @@ export default function StaffPage() {
 
   const handleReactivate = async (id: string) => {
     setActionError('');
+    setInviteNotice('');
     try {
       await updateStaff({ variables: { id, input: { isActive: true } } });
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Failed to reactivate staff member');
+    }
+  };
+
+  const handleResendInvite = async (id: string, name: string) => {
+    setActionError('');
+    setInviteNotice('');
+    try {
+      const result = await resendInvite({ variables: { id } });
+      const url = result.data?.resendStaffInvite?.inviteUrl as string | undefined;
+      if (url) {
+        try {
+          await navigator.clipboard.writeText(url);
+          setInviteNotice(`Invite resent for ${name}. Link copied to clipboard.`);
+        } catch {
+          setInviteNotice(`Invite resent for ${name}: ${url}`);
+        }
+      } else {
+        setInviteNotice(`Invite resent for ${name}.`);
+      }
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to resend staff invite',
+      );
     }
   };
 
@@ -74,6 +108,9 @@ export default function StaffPage() {
 
       {actionError ? (
         <p className="mb-4 text-sm text-clay-error">{actionError}</p>
+      ) : null}
+      {inviteNotice ? (
+        <p className="mb-4 text-sm text-clay-text">{inviteNotice}</p>
       ) : null}
 
       <ClayCard padding="none" className="overflow-hidden">
@@ -157,6 +194,17 @@ export default function StaffPage() {
                             <Pencil className="h-4 w-4" />
                           </button>
                         </Link>
+                        {member.isActive && canResendInvite ? (
+                          <button
+                            onClick={() =>
+                              void handleResendInvite(member.id, member.fullName)
+                            }
+                            title="Resend invite"
+                            className="flex h-8 w-8 items-center justify-center rounded-xl bg-clay-primary-light text-clay-primary hover:shadow-clay-sm"
+                          >
+                            <Mail className="h-4 w-4" />
+                          </button>
+                        ) : null}
                         {member.isActive ? (
                           canDeactivateStaff ? (
                             <button

--- a/apps/web/src/components/clinical/patient-clinical-actions.tsx
+++ b/apps/web/src/components/clinical/patient-clinical-actions.tsx
@@ -543,33 +543,43 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
 }
 
 function DoctorSelect({ hospitalId }: { hospitalId?: string }) {
-  const { data } = useQuery(STAFF_MEMBERS_QUERY, {
+  const { data, error, refetch } = useQuery(STAFF_MEMBERS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
-  const doctors = (data?.staffMembers ?? []).filter(
-    (s: { roleSlug: string; isActive: boolean }) =>
-      s.isActive && (s.roleSlug === 'doctor' || s.roleSlug === 'hospital_admin'),
-  );
+  const doctors = error
+    ? []
+    : (data?.staffMembers ?? []).filter(
+        (s: { roleSlug: string; isActive: boolean }) =>
+          s.isActive && (s.roleSlug === 'doctor' || s.roleSlug === 'hospital_admin'),
+      );
 
   return (
     <div className="flex flex-col gap-2">
       <label htmlFor="clinical-doctor" className="text-sm font-medium text-clay-text">
         Doctor (optional)
       </label>
-      <select
-        id="clinical-doctor"
-        name="doctorId"
-        className="rounded-2xl border border-white/60 bg-clay-surface px-4 py-3 text-sm shadow-clay-inset"
-        defaultValue=""
-      >
-        <option value="">Unassigned</option>
-        {doctors.map((d: { userId: string; fullName: string }) => (
-          <option key={d.userId} value={d.userId}>
-            {d.fullName}
-          </option>
-        ))}
-      </select>
+      {error ? (
+        <QueryError
+          message="We could not load doctors. Please try again."
+          onRetry={() => void refetch()}
+          className="text-left"
+        />
+      ) : (
+        <select
+          id="clinical-doctor"
+          name="doctorId"
+          className="rounded-2xl border border-white/60 bg-clay-surface px-4 py-3 text-sm shadow-clay-inset"
+          defaultValue=""
+        >
+          <option value="">Unassigned</option>
+          {doctors.map((d: { userId: string; fullName: string }) => (
+            <option key={d.userId} value={d.userId}>
+              {d.fullName}
+            </option>
+          ))}
+        </select>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/clinical/patient-clinical-actions.tsx
+++ b/apps/web/src/components/clinical/patient-clinical-actions.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { ClayButton, ClayCard, ClayInput } from '@careconnect/ui';
 import { ClayTextarea } from '@/components/clinical/clay-textarea';
+import { QueryError } from '@/components/query-error';
 import {
   ADMIT_PATIENT_MUTATION,
   BEDS_QUERY,
@@ -108,10 +109,14 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
     skip: !hospitalId || !admitWardId || expanded !== 'admit',
   });
 
-  const wards: Array<{ id: string; name: string; floor?: string }> =
-    wardsQuery.data?.wards ?? [];
-  const beds: Array<{ id: string; label: string; status: string }> = bedsQuery.data?.beds ?? [];
+  const wards: Array<{ id: string; name: string; floor?: string }> = wardsQuery.error
+    ? []
+    : (wardsQuery.data?.wards ?? []);
+  const beds: Array<{ id: string; label: string; status: string }> = bedsQuery.error
+    ? []
+    : (bedsQuery.data?.beds ?? []);
   const availableBeds = beds.filter((b) => b.status === 'available');
+  const facilityQueryError = wardsQuery.error || bedsQuery.error;
 
   const toggle = (key: ActionKey) => {
     setExpanded((prev) => (prev === key ? null : key));
@@ -389,7 +394,16 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
                           </option>
                         ))}
                       </select>
-                      {wards.length === 0 && !wardsQuery.loading ? (
+                      {facilityQueryError ? (
+                        <QueryError
+                          message="We could not load wards or beds. Please try again."
+                          onRetry={() => {
+                            void wardsQuery.refetch();
+                            if (admitWardId) void bedsQuery.refetch();
+                          }}
+                          className="text-left"
+                        />
+                      ) : wards.length === 0 && !wardsQuery.loading ? (
                         canManageFacility ? (
                           <Link
                             href="/settings/facility"
@@ -428,7 +442,10 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
                           </option>
                         ))}
                       </select>
-                      {admitWardId && availableBeds.length === 0 && !bedsQuery.loading ? (
+                      {admitWardId &&
+                      !bedsQuery.error &&
+                      availableBeds.length === 0 &&
+                      !bedsQuery.loading ? (
                         <p className="text-xs text-clay-text-muted">
                           No available beds in this ward.
                         </p>

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -47,6 +47,16 @@ export const CREATE_STAFF_MUTATION = gql`
   }
 `;
 
+export const RESEND_STAFF_INVITE_MUTATION = gql`
+  mutation ResendStaffInvite($id: String!) {
+    resendStaffInvite(id: $id) {
+      id
+      inviteToken
+      inviteUrl
+    }
+  }
+`;
+
 export const COMPLETE_PATIENT_ONBOARDING = gql`
   mutation CompletePatientOnboarding($fullName: String!) {
     completePatientOnboarding(fullName: $fullName) {

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -808,6 +808,7 @@ export const CREATE_FOLLOW_UP_MUTATION = gql`
     createFollowUp(input: $input, hospitalId: $hospitalId) {
       id
       patientId
+      doctorId
       scheduledAt
       type
       status
@@ -909,6 +910,16 @@ export const INVOICES_QUERY = gql`
         method
         paidAt
       }
+    }
+  }
+`;
+
+export const BILLING_PATIENT_SEARCH_QUERY = gql`
+  query BillingPatientSearch($search: String!, $limit: Int, $hospitalId: String) {
+    billingPatientSearch(search: $search, limit: $limit, hospitalId: $hospitalId) {
+      id
+      mrn
+      fullName
     }
   }
 `;

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -170,6 +170,17 @@ export const DELETE_BED_MUTATION = gql`
   }
 `;
 
+export const UPDATE_BED_STATUS_MUTATION = gql`
+  mutation UpdateBedStatus($input: UpdateBedStatusInput!, $hospitalId: String) {
+    updateBedStatus(input: $input, hospitalId: $hospitalId) {
+      id
+      label
+      status
+      wardId
+    }
+  }
+`;
+
 export const CANCEL_APPOINTMENT_MUTATION = gql`
   mutation CancelAppointment($input: CancelAppointmentInput!, $hospitalId: String) {
     cancelAppointment(input: $input, hospitalId: $hospitalId) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "overrides": {
       "multer": ">=2.2.0",
       "brace-expansion@^2": ">=2.1.4",
-      "brace-expansion": ">=5.0.9",
+      "brace-expansion@^5": ">=5.0.9",
       "ws": ">=8.21.0",
       "body-parser": ">=2.3.0",
       "postcss": ">=8.5.23",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "overrides": {
       "multer": ">=2.2.0",
       "brace-expansion@^2": ">=2.1.4",
+      "brace-expansion": ">=5.0.9",
       "ws": ">=8.21.0",
       "body-parser": ">=2.3.0",
       "postcss": ">=8.5.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   multer: '>=2.2.0'
   brace-expansion@^2: '>=2.1.4'
-  brace-expansion: '>=5.0.9'
+  brace-expansion@^5: '>=5.0.9'
   ws: '>=8.21.0'
   body-parser: '>=2.3.0'
   postcss: '>=8.5.23'
@@ -2886,6 +2886,9 @@ packages:
   backo2@1.0.2:
     resolution: {integrity: sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2908,6 +2911,9 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -3073,6 +3079,9 @@ packages:
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -8573,6 +8582,8 @@ snapshots:
 
   backo2@1.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -8602,6 +8613,11 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.9:
     dependencies:
@@ -8751,6 +8767,8 @@ snapshots:
       esprima: 4.0.1
 
   component-emitter@1.3.1: {}
+
+  concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -10538,7 +10556,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   multer: '>=2.2.0'
   brace-expansion@^2: '>=2.1.4'
+  brace-expansion: '>=5.0.9'
   ws: '>=8.21.0'
   body-parser: '>=2.3.0'
   postcss: '>=8.5.23'
@@ -2885,9 +2886,6 @@ packages:
   backo2@1.0.2:
     resolution: {integrity: sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2911,12 +2909,9 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3078,9 +3073,6 @@ packages:
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -8581,8 +8573,6 @@ snapshots:
 
   backo2@1.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -8613,12 +8603,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.15:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8766,8 +8751,6 @@ snapshots:
       esprima: 4.0.1
 
   component-emitter@1.3.1: {}
-
-  concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -9095,7 +9078,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -9132,7 +9115,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9146,7 +9129,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10551,15 +10534,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/supabase/migrations/20240609000027_lab_results_result_file_url_unique.sql
+++ b/supabase/migrations/20240609000027_lab_results_result_file_url_unique.sql
@@ -1,0 +1,5 @@
+-- Each stored upload may be linked to at most one lab result.
+-- Mirrors patient_documents.file_url uniqueness (20240609000024).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_lab_results_result_file_url
+  ON lab_results (result_file_url)
+  WHERE result_file_url IS NOT NULL AND result_file_url <> '';


### PR DESCRIPTION
## Summary
- Closes remaining open issues **#210–#228** (P1–P4) from the post-#209 rescan
- One commit per fix (plus UI follow-up for invite resend)
- Hardens upload/document exclusivity, soft-delete PHI reachability, RBAC fail-closed defaults, and incomplete staff/billing/facility/follow-up flows

### By severity
| Sev | Issues | Highlights |
|-----|--------|------------|
| **P1** | #210, #211 | Lab↔document upload exclusivity; brace-expansion ≥5.0.9 |
| **P2** | #212–#215, #222–#224 | Portal email match; fail-closed pickers; bed status UI; accountant billing search; TOCTOU unlink; lab file_url unique; soft-deleted PHI excluded |
| **P3** | #216–#220, #225–#228 | List caps; invite resend; RolesGuard fail-closed; inactive upload block; Void/payments UX; inventory deltas; follow-up doctors; azp outside prod |
| **P4** | #221 | Document how to enable Snyk Code (org admin still required) |

## Test plan
- [x] `pnpm --filter api test` (106 passed)
- [x] `pnpm --filter api build` + `pnpm --filter web build`
- [ ] Apply migration `20240609000027_lab_results_result_file_url_unique.sql` in deployed envs
- [ ] Smoke: accountant invoice create (patient search), staff resend invite, bed maintenance toggle, follow-up with doctor, inventory ±
- [ ] Smoke: add document with lab-owned URL → rejected; Void hidden when payments exist


Made with [Cursor](https://cursor.com)