### PR TITLE
fix: serialize soft-delete with admit (#230)

### DIFF
--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -70,27 +70,39 @@ describe('AdmissionsService', () => {
   });
 
   describe('admitPatient concurrency guards', () => {
-    it('rejects when bed is already occupied after lock', async () => {
-      manager.findOne
-        .mockResolvedValueOnce({
-          id: 'patient-1',
-          hospitalId: 'hospital-a',
-          status: 'registered',
-        })
-        .mockResolvedValueOnce({ id: 'ward-1', hospitalId: 'hospital-a' });
+    const patientQb = (patient: Record<string, unknown> | null) => ({
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(patient),
+    });
 
-      const qb = {
-        setLock: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue({
-          id: 'bed-1',
-          status: 'occupied',
-          hospitalId: 'hospital-a',
-          wardId: 'ward-1',
-        }),
-      };
-      manager.createQueryBuilder.mockReturnValue(qb);
+    const bedQb = (bed: Record<string, unknown>) => ({
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(bed),
+    });
+
+    it('rejects when bed is already occupied after lock', async () => {
+      const lockedPatient = patientQb({
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+        status: 'registered',
+      });
+      const lockedBed = bedQb({
+        id: 'bed-1',
+        status: 'occupied',
+        hospitalId: 'hospital-a',
+        wardId: 'ward-1',
+      });
+      manager.createQueryBuilder
+        .mockReturnValueOnce(lockedPatient)
+        .mockReturnValueOnce(lockedBed);
+      manager.findOne.mockResolvedValueOnce({
+        id: 'ward-1',
+        hospitalId: 'hospital-a',
+      });
 
       await expect(
         service.admitPatient(
@@ -103,31 +115,28 @@ describe('AdmissionsService', () => {
           actor,
         ),
       ).rejects.toThrow(BadRequestException);
-      expect(qb.setLock).toHaveBeenCalledWith('pessimistic_write');
+      expect(lockedPatient.setLock).toHaveBeenCalledWith('pessimistic_write');
+      expect(lockedBed.setLock).toHaveBeenCalledWith('pessimistic_write');
     });
 
     it('rejects when patient already has an active admission', async () => {
+      const lockedPatient = patientQb({
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+        status: 'registered',
+      });
+      const lockedBed = bedQb({
+        id: 'bed-1',
+        status: 'available',
+        hospitalId: 'hospital-a',
+        wardId: 'ward-1',
+      });
+      manager.createQueryBuilder
+        .mockReturnValueOnce(lockedPatient)
+        .mockReturnValueOnce(lockedBed);
       manager.findOne
-        .mockResolvedValueOnce({
-          id: 'patient-1',
-          hospitalId: 'hospital-a',
-          status: 'registered',
-        })
         .mockResolvedValueOnce({ id: 'ward-1', hospitalId: 'hospital-a' })
         .mockResolvedValueOnce({ id: 'adm-existing', status: 'active' });
-
-      const qb = {
-        setLock: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue({
-          id: 'bed-1',
-          status: 'available',
-          hospitalId: 'hospital-a',
-          wardId: 'ward-1',
-        }),
-      };
-      manager.createQueryBuilder.mockReturnValue(qb);
 
       await expect(
         service.admitPatient(
@@ -140,10 +149,12 @@ describe('AdmissionsService', () => {
           actor,
         ),
       ).rejects.toThrow('Patient already has an active admission');
+      expect(lockedPatient.setLock).toHaveBeenCalledWith('pessimistic_write');
     });
 
-    it('throws NotFound when patient missing', async () => {
-      manager.findOne.mockResolvedValueOnce(null);
+    it('throws NotFound when patient missing or soft-deleted', async () => {
+      const lockedPatient = patientQb(null);
+      manager.createQueryBuilder.mockReturnValueOnce(lockedPatient);
       await expect(
         service.admitPatient(
           'hospital-a',
@@ -155,6 +166,7 @@ describe('AdmissionsService', () => {
           actor,
         ),
       ).rejects.toThrow(NotFoundException);
+      expect(lockedPatient.setLock).toHaveBeenCalledWith('pessimistic_write');
     });
   });
 

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -158,9 +158,14 @@ export class AdmissionsService {
     try {
       const savedId = await this.admissionsRepo.manager.transaction(
         async (manager) => {
-          const patient = await manager.findOne(Patient, {
-            where: { id: input.patientId, hospitalId },
-          });
+          // Lock patient before bed so admit serializes with soft-delete (#230).
+          // Soft-deleted patients are excluded by TypeORM DeleteDateColumn.
+          const patient = await manager
+            .createQueryBuilder(Patient, 'patient')
+            .setLock('pessimistic_write')
+            .where('patient.id = :id', { id: input.patientId })
+            .andWhere('patient.hospital_id = :hospitalId', { hospitalId })
+            .getOne();
           if (!patient) throw new NotFoundException('Patient not found');
 
           const ward = await manager.findOne(Ward, {

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -154,17 +154,58 @@ describe('PatientsService', () => {
         fullName: 'Jane Doe',
         userId: 'portal-1',
       };
-      patientsRepo.findOne.mockResolvedValue(patient);
-      admissionsRepo.findOne.mockResolvedValue(null);
+      const patientQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(patient),
+      };
       patientsRepo.manager.transaction.mockImplementation(
         (cb: (m: Record<string, unknown>) => unknown) => {
+          const repoByEntity = new Map<unknown, Record<string, unknown>>([
+            [
+              Patient,
+              {
+                save: jest.fn().mockResolvedValue(patient),
+                softRemove: jest.fn().mockResolvedValue(patient),
+              },
+            ],
+            [
+              Admission,
+              {
+                findOne: jest.fn().mockResolvedValue(null),
+              },
+            ],
+            [
+              PatientDocument,
+              {
+                find: jest.fn().mockResolvedValue([]),
+                remove: jest.fn(),
+              },
+            ],
+            [
+              // LabOrder / LabResult repos still used via getRepository
+              'LabOrder',
+              {
+                find: jest.fn().mockResolvedValue([]),
+              },
+            ],
+          ]);
           const manager = {
-            getRepository: () => ({
-              save: jest.fn().mockResolvedValue(patient),
-              find: jest.fn().mockResolvedValue([]),
-              remove: jest.fn(),
-              softRemove: jest.fn().mockResolvedValue(patient),
-            }),
+            createQueryBuilder: jest.fn().mockReturnValue(patientQb),
+            getRepository: (entity: unknown) => {
+              if (entity === Patient) return repoByEntity.get(Patient);
+              if (entity === Admission) return repoByEntity.get(Admission);
+              if (entity === PatientDocument)
+                return repoByEntity.get(PatientDocument);
+              return {
+                find: jest.fn().mockResolvedValue([]),
+                remove: jest.fn(),
+                save: jest.fn(),
+                softRemove: jest.fn(),
+                findOne: jest.fn().mockResolvedValue(null),
+              };
+            },
           };
           return Promise.resolve(cb(manager));
         },
@@ -178,6 +219,7 @@ describe('PatientsService', () => {
 
       expect(result).toBe(true);
       expect(patientsRepo.manager.transaction).toHaveBeenCalled();
+      expect(patientQb.setLock).toHaveBeenCalledWith('pessimistic_write');
       expect(audit.log).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'delete',
@@ -185,6 +227,49 @@ describe('PatientsService', () => {
           resourceId: 'patient-1',
         }),
       );
+    });
+
+    it('refuses delete when an active admission exists under the patient lock', async () => {
+      const patient = {
+        id: 'patient-1',
+        hospitalId: 'hospital-1',
+        fullName: 'Jane Doe',
+      };
+      const patientQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(patient),
+      };
+      patientsRepo.manager.transaction.mockImplementation(
+        (cb: (m: Record<string, unknown>) => unknown) => {
+          const manager = {
+            createQueryBuilder: jest.fn().mockReturnValue(patientQb),
+            getRepository: (entity: unknown) => {
+              if (entity === Admission) {
+                return {
+                  findOne: jest
+                    .fn()
+                    .mockResolvedValue({ id: 'adm-1', status: 'active' }),
+                };
+              }
+              return {
+                save: jest.fn(),
+                softRemove: jest.fn(),
+                find: jest.fn().mockResolvedValue([]),
+                remove: jest.fn(),
+              };
+            },
+          };
+          return Promise.resolve(cb(manager));
+        },
+      );
+
+      await expect(
+        service.deletePatient('patient-1', 'hospital-1', actor),
+      ).rejects.toThrow(BadRequestException);
+      expect(patientQb.setLock).toHaveBeenCalledWith('pessimistic_write');
+      expect(audit.log).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -415,28 +415,43 @@ export class PatientsService {
     hospitalId: string,
     actor: AuthenticatedUser,
   ): Promise<boolean> {
-    const patient = await this.findPatientOrThrow(id, hospitalId);
-
-    const activeAdmission = await this.admissionsRepo.findOne({
-      where: { patientId: id, hospitalId, status: 'active' },
-    });
-    if (activeAdmission) {
-      throw new BadRequestException(
-        'Cannot delete a patient with an active admission; discharge first',
-      );
-    }
-
     // Soft-delete policy: soft-remove the patient row; hard-remove linked
     // document metadata and unlink PHI files from disk. Other related rows
     // remain for audit but are unreachable via patient queries.
-    const previousUserId = patient.userId;
+    // Lock the patient row and re-check active admissions inside the txn so a
+    // concurrent admit cannot attach a live bed after the pre-check (#230).
+    let previousUserId: string | undefined;
+    let patientFullName = '';
     const fileUrlsToUnlink: string[] = [];
+    let patientId = id;
 
     await this.patientsRepo.manager.transaction(async (manager) => {
       const patientsRepo = manager.getRepository(Patient);
+      const admissionsRepo = manager.getRepository(Admission);
       const documentsRepo = manager.getRepository(PatientDocument);
       const labOrdersRepo = manager.getRepository(LabOrder);
       const labResultsRepo = manager.getRepository(LabResult);
+
+      const patient = await manager
+        .createQueryBuilder(Patient, 'patient')
+        .setLock('pessimistic_write')
+        .where('patient.id = :id', { id })
+        .andWhere('patient.hospital_id = :hospitalId', { hospitalId })
+        .getOne();
+      if (!patient) throw new NotFoundException('Patient not found');
+
+      const activeAdmission = await admissionsRepo.findOne({
+        where: { patientId: id, hospitalId, status: 'active' },
+      });
+      if (activeAdmission) {
+        throw new BadRequestException(
+          'Cannot delete a patient with an active admission; discharge first',
+        );
+      }
+
+      previousUserId = patient.userId;
+      patientFullName = patient.fullName;
+      patientId = patient.id;
 
       patient.userId = null as unknown as string | undefined;
       await patientsRepo.save(patient);
@@ -474,9 +489,9 @@ export class PatientsService {
       hospitalId,
       action: 'delete',
       resource: 'patient',
-      resourceId: patient.id,
+      resourceId: patientId,
       metadata: {
-        fullName: patient.fullName,
+        fullName: patientFullName,
         documentsRemoved: fileUrlsToUnlink.length,
         previousUserId,
       },


### PR DESCRIPTION
## Summary
- Fixes #230: soft-delete vs admit race that could leave an active admission on a deleted patient
- `deletePatient` locks the patient row and re-checks active admissions inside the transaction
- `admitPatient` locks the patient (pessimistic write) before the bed so the two paths serialize

## Test plan
- [x] `pnpm --filter api test -- patients.service.spec.ts admissions.service.spec.ts`
- [ ] CI lint-and-build green


Made with [Cursor](https://cursor.com)