### PR TITLE
fix: gate transfers on live patients (#231)

### DIFF
--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -229,9 +229,14 @@ describe('AdmissionsService', () => {
         getOne: jest.fn().mockResolvedValue({
           id: 'adm-1',
           status: 'discharged',
+          patientId: 'patient-1',
         }),
       };
       manager.createQueryBuilder.mockReturnValue(admissionQb);
+      manager.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+      });
 
       await expect(
         service.transferOutAdmission(
@@ -240,6 +245,88 @@ describe('AdmissionsService', () => {
           actor,
         ),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects transfer-out when patient is soft-deleted', async () => {
+      const admissionQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'adm-1',
+          hospitalId: 'hospital-a',
+          patientId: 'patient-1',
+          bedId: 'bed-1',
+          status: 'active',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(admissionQb);
+      manager.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.transferOutAdmission(
+          'hospital-a',
+          { admissionId: 'adm-1' },
+          actor,
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('transferAdmission soft-delete', () => {
+    it('rejects bed transfer when patient is soft-deleted', async () => {
+      const admissionQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'adm-1',
+          hospitalId: 'hospital-a',
+          patientId: 'patient-1',
+          bedId: 'bed-1',
+          status: 'active',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(admissionQb);
+      manager.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.transferAdmission(
+          'hospital-a',
+          {
+            admissionId: 'adm-1',
+            wardId: 'ward-2',
+            bedId: 'bed-2',
+          },
+          actor,
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('activeAdmissions', () => {
+    it('excludes soft-deleted patients via deleted_at filter', async () => {
+      const qb = {
+        innerJoinAndSelect: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      admissionsRepo.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await service.activeAdmissions('hospital-a');
+
+      expect(admissionsRepo.createQueryBuilder).toHaveBeenCalledWith(
+        'admission',
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'patient.deleted_at IS NULL',
+      );
     });
   });
 });

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -150,6 +150,24 @@ export class AdmissionsService {
     return admission;
   }
 
+  /** Live in-tenant patient only — soft-deleted charts are excluded by DeleteDateColumn. */
+  private async requireLivePatient(
+    manager: {
+      findOne: (
+        entity: typeof Patient,
+        options: { where: { id: string; hospitalId: string } },
+      ) => Promise<Patient | null>;
+    },
+    patientId: string,
+    hospitalId: string,
+  ): Promise<Patient> {
+    const patient = await manager.findOne(Patient, {
+      where: { id: patientId, hospitalId },
+    });
+    if (!patient) throw new NotFoundException('Patient not found');
+    return patient;
+  }
+
   async admitPatient(
     hospitalId: string,
     input: AdmitPatientInput,
@@ -251,12 +269,18 @@ export class AdmissionsService {
   }
 
   async activeAdmissions(hospitalId: string): Promise<AdmissionType[]> {
-    const admissions = await this.admissionsRepo.find({
-      where: { hospitalId, status: 'active' },
-      relations: ['patient', 'attendingDoctor', 'ward', 'bed'],
-      order: { admittedAt: 'DESC' },
-      take: 200,
-    });
+    const admissions = await this.admissionsRepo
+      .createQueryBuilder('admission')
+      .innerJoinAndSelect('admission.patient', 'patient')
+      .leftJoinAndSelect('admission.attendingDoctor', 'attendingDoctor')
+      .leftJoinAndSelect('admission.ward', 'ward')
+      .leftJoinAndSelect('admission.bed', 'bed')
+      .where('admission.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('admission.status = :status', { status: 'active' })
+      .andWhere('patient.deleted_at IS NULL')
+      .orderBy('admission.admitted_at', 'DESC')
+      .take(200)
+      .getMany();
     return admissions.map((a) => this.toAdmissionType(a));
   }
 
@@ -299,6 +323,12 @@ export class AdmissionsService {
             'Only active admissions can be transferred to another bed',
           );
         }
+
+        // Soft-deleted charts must not move beds (#231).
+        const patient = await manager.findOne(Patient, {
+          where: { id: admission.patientId, hospitalId },
+        });
+        if (!patient) throw new NotFoundException('Admission not found');
 
         const ward = await manager.findOne(Ward, {
           where: { id: input.wardId, hospitalId },
@@ -386,6 +416,12 @@ export class AdmissionsService {
 
       assertAdmissionTransition(admission.status, 'transferred');
 
+      // Soft-deleted charts must not transfer-out / free beds (#231).
+      const patient = await manager.findOne(Patient, {
+        where: { id: admission.patientId, hospitalId },
+      });
+      if (!patient) throw new NotFoundException('Admission not found');
+
       if (admission.bedId) {
         const bed = await manager
           .createQueryBuilder(Bed, 'bed')
@@ -408,13 +444,8 @@ export class AdmissionsService {
       }
       await manager.save(admission);
 
-      const patient = await manager.findOne(Patient, {
-        where: { id: admission.patientId, hospitalId },
-      });
-      if (patient) {
-        patient.status = 'discharged';
-        await manager.save(patient);
-      }
+      patient.status = 'discharged';
+      await manager.save(patient);
     });
 
     const admission = await this.findAdmissionOrThrow(

--- a/apps/api/src/admissions/admissions.service.ts
+++ b/apps/api/src/admissions/admissions.service.ts
@@ -325,10 +325,7 @@ export class AdmissionsService {
         }
 
         // Soft-deleted charts must not move beds (#231).
-        const patient = await manager.findOne(Patient, {
-          where: { id: admission.patientId, hospitalId },
-        });
-        if (!patient) throw new NotFoundException('Admission not found');
+        await this.requireLivePatient(manager, admission.patientId, hospitalId);
 
         const ward = await manager.findOne(Ward, {
           where: { id: input.wardId, hospitalId },
@@ -417,10 +414,11 @@ export class AdmissionsService {
       assertAdmissionTransition(admission.status, 'transferred');
 
       // Soft-deleted charts must not transfer-out / free beds (#231).
-      const patient = await manager.findOne(Patient, {
-        where: { id: admission.patientId, hospitalId },
-      });
-      if (!patient) throw new NotFoundException('Admission not found');
+      const patient = await this.requireLivePatient(
+        manager,
+        admission.patientId,
+        hospitalId,
+      );
 
       if (admission.bedId) {
         const bed = await manager


### PR DESCRIPTION
## Summary
- Fixes #231: transfer / transfer-out ignored soft-deleted patients; `activeAdmissions` listed them
- Transfer and transfer-out now 404 when the owning patient is soft-deleted (before any bed mutation)
- `activeAdmissions` joins patients and filters `deleted_at IS NULL`

## Test plan
- [x] `pnpm --filter api test -- admissions.service.spec.ts`
- [ ] CI lint-and-build green


Made with [Cursor](https://cursor.com)