### PR TITLE
fix: require follow-up doctor on API (#232)

### DIFF
--- a/apps/api/src/discharge/discharge.service.spec.ts
+++ b/apps/api/src/discharge/discharge.service.spec.ts
@@ -53,6 +53,7 @@ describe('DischargeService', () => {
   const audit = { log: jest.fn() };
   const doctorValidator = {
     assertHospitalDoctor: jest.fn().mockResolvedValue(undefined),
+    assertHospitalDoctorOrThrow: jest.fn().mockResolvedValue(undefined),
   };
 
   const actor: AuthenticatedUser = {
@@ -110,6 +111,64 @@ describe('DischargeService', () => {
       ).rejects.toThrow(
         'A discharge summary already exists for this admission',
       );
+    });
+
+    it('rejects scheduled follow-up when no doctor is provided or attending', async () => {
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'adm-1',
+          hospitalId: 'hospital-a',
+          patientId: 'patient-1',
+          status: 'active',
+          bedId: null,
+          attendingDoctorId: null,
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValue(qb);
+      manager.findOne
+        .mockResolvedValueOnce(null) // no existing discharge
+        .mockResolvedValueOnce({ id: 'patient-1', hospitalId: 'hospital-a' });
+      manager.save.mockImplementation((entity: Record<string, unknown>) =>
+        Promise.resolve({ id: 'discharge-1', ...entity }),
+      );
+
+      await expect(
+        service.createDischarge(
+          'hospital-a',
+          {
+            admissionId: 'adm-1',
+            summary: 'Recovered',
+            followUpScheduledAt: '2026-08-20T10:00:00.000Z',
+          },
+          actor,
+        ),
+      ).rejects.toThrow(
+        'Follow-up doctor is required when scheduling a follow-up',
+      );
+    });
+  });
+
+  describe('createFollowUp', () => {
+    it('rejects missing doctorId', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-a',
+      });
+
+      await expect(
+        service.createFollowUp(
+          'hospital-a',
+          {
+            patientId: 'patient-1',
+            doctorId: '',
+            scheduledAt: '2026-08-20T10:00:00.000Z',
+          },
+          actor,
+        ),
+      ).rejects.toThrow('Follow-up doctor is required');
     });
   });
 

--- a/apps/api/src/discharge/discharge.service.spec.ts
+++ b/apps/api/src/discharge/discharge.service.spec.ts
@@ -53,7 +53,6 @@ describe('DischargeService', () => {
   const audit = { log: jest.fn() };
   const doctorValidator = {
     assertHospitalDoctor: jest.fn().mockResolvedValue(undefined),
-    assertHospitalDoctorOrThrow: jest.fn().mockResolvedValue(undefined),
   };
 
   const actor: AuthenticatedUser = {

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -191,13 +191,16 @@ export class DischargeService {
           if (input.followUpScheduledAt) {
             const followUpDoctorId =
               input.followUpDoctorId ?? admission.attendingDoctorId;
-            if (followUpDoctorId) {
-              await this.doctorValidator.assertHospitalDoctor(
-                hospitalId,
-                followUpDoctorId,
-                'Follow-up doctor',
+            if (!followUpDoctorId) {
+              throw new BadRequestException(
+                'Follow-up doctor is required when scheduling a follow-up',
               );
             }
+            await this.doctorValidator.assertHospitalDoctor(
+              hospitalId,
+              followUpDoctorId,
+              'Follow-up doctor',
+            );
             await manager.save(
               manager.create(FollowUp, {
                 hospitalId,
@@ -265,13 +268,14 @@ export class DischargeService {
       }
     }
 
-    if (input.doctorId) {
-      await this.doctorValidator.assertHospitalDoctor(
-        hospitalId,
-        input.doctorId,
-        'Follow-up doctor',
-      );
+    if (!input.doctorId) {
+      throw new BadRequestException('Follow-up doctor is required');
     }
+    await this.doctorValidator.assertHospitalDoctor(
+      hospitalId,
+      input.doctorId,
+      'Follow-up doctor',
+    );
 
     const followUp = await this.followUpsRepo.save(
       this.followUpsRepo.create({

--- a/apps/api/src/discharge/discharge.types.ts
+++ b/apps/api/src/discharge/discharge.types.ts
@@ -135,10 +135,9 @@ export class CreateFollowUpInput {
   @IsUUID()
   dischargeId?: string;
 
-  @Field({ nullable: true })
-  @IsOptional()
+  @Field()
   @IsUUID()
-  doctorId?: string;
+  doctorId: string;
 
   @Field()
   @IsDateString()


### PR DESCRIPTION
## Summary
- Require `doctorId` on `CreateFollowUpInput` and reject empty values with 400
- When discharge schedules a follow-up, require `followUpDoctorId` or attending doctor (no null `doctor_id` rows)
- Add unit coverage for both rejection paths

Closes #232

## Test plan
- [x] `npx jest src/discharge/discharge.service.spec.ts`
- [ ] GraphQL `createFollowUp` without `doctorId` → validation/400
- [ ] Discharge with `followUpScheduledAt` and no doctor/attending → 400
- [ ] Existing UI follow-up / discharge flows still succeed when doctor is selected


Made with [Cursor](https://cursor.com)