### PR TITLE
Set up Cloud Agent dev environment (local Postgres) + fix API boot blockers

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,21 @@
+{
+  "name": "CareConnect",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "api",
+      "command": "pnpm --filter api dev",
+      "description": "NestJS GraphQL API — http://localhost:4000/graphql"
+    },
+    {
+      "name": "web",
+      "command": "pnpm --filter web dev",
+      "description": "Next.js web app — http://localhost:3000"
+    }
+  ],
+  "ports": [
+    { "name": "web", "port": 3000 },
+    { "name": "api", "port": 4000 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Idempotent dependency setup for CareConnect. Runs after checkout (and at
+# environment-build time). Must terminate and be safe to re-run.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+corepack enable >/dev/null 2>&1 || true
+
+# Install workspace deps exactly as CI does (blocked build scripts are fine).
+pnpm install --frozen-lockfile
+
+# Shared types must be built before the API/web compile against them.
+pnpm --filter @careconnect/types build
+
+echo "install.sh: dependencies ready"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
-# Idempotent dependency setup for CareConnect. Runs after checkout (and at
-# environment-build time). Must terminate and be safe to re-run.
+# Idempotent setup for CareConnect. Runs after checkout (and at environment-build
+# time). Must terminate and be safe to re-run.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+
+# System dependency: local PostgreSQL server (dev DB, replaces Neon). Idempotent.
+if ! command -v pg_ctlcluster >/dev/null 2>&1; then
+  echo "install.sh: installing PostgreSQL..."
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql postgresql-contrib
+else
+  echo "install.sh: PostgreSQL already installed"
+fi
 
 corepack enable >/dev/null 2>&1 || true
 

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Per-boot startup for CareConnect: bring up the local Postgres dev database,
+# apply migrations once, and write the app env files. Tolerates restarts and
+# returns (the dev servers themselves run as `terminals`).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PG_VER=16
+DB_NAME=careconnect
+DB_USER=careconnect
+DB_PASS=careconnect
+
+# --- 1. Start the local PostgreSQL cluster (idempotent) ------------------------
+sudo pg_ctlcluster "$PG_VER" main start 2>/dev/null || true
+for _ in $(seq 1 30); do
+  sudo -u postgres pg_isready -q && break
+  sleep 1
+done
+
+# --- 2. Ensure role + database exist ------------------------------------------
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASS}';"
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE DATABASE ${DB_NAME} OWNER ${DB_USER};"
+
+# --- 3. Apply SQL migrations once (gated on the first table) -------------------
+export PGPASSWORD="${DB_PASS}"
+applied="$(psql -h 127.0.0.1 -U "${DB_USER}" -d "${DB_NAME}" -tAc "SELECT to_regclass('public.hospitals')" 2>/dev/null || true)"
+if [ -z "${applied}" ] || [ "${applied}" = "" ]; then
+  echo "start.sh: applying database migrations..."
+  for f in supabase/migrations/*.sql; do
+    psql -h 127.0.0.1 -U "${DB_USER}" -d "${DB_NAME}" -v ON_ERROR_STOP=1 -f "$f" >/dev/null
+  done
+else
+  echo "start.sh: migrations already applied, skipping"
+fi
+
+# --- 4. Write env files -------------------------------------------------------
+# Real Clerk credentials, when added as Cloud Agent Secrets, are picked up here
+# automatically; otherwise CI-style placeholders keep build/API/SSR working.
+CLERK_PK="${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-pk_test_Y2ktcGxhY2Vob2xkZXIuY2xlcmsuYWNjb3VudHMuZGV2JA}"
+CLERK_SK="${CLERK_SECRET_KEY:-sk_test_ci_placeholder_not_real}"
+CLERK_ISS="${CLERK_ISSUER:-https://example.clerk.accounts.dev}"
+
+cat > apps/api/.env <<EOF
+API_PORT=4000
+DATABASE_URL=postgresql://${DB_USER}:${DB_PASS}@127.0.0.1:5432/${DB_NAME}
+DATABASE_SSL=false
+CLERK_SECRET_KEY=${CLERK_SK}
+CLERK_ISSUER=${CLERK_ISS}
+CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+CORS_ORIGIN=http://localhost:3000
+NODE_ENV=development
+API_PUBLIC_URL=http://localhost:4000
+EOF
+
+cat > apps/web/.env.local <<EOF
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${CLERK_PK}
+CLERK_SECRET_KEY=${CLERK_SK}
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/register
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/onboarding
+NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/onboarding
+NEXT_PUBLIC_API_URL=http://localhost:4000/graphql
+EOF
+
+echo "start.sh: PostgreSQL ready and env files written"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -67,3 +67,14 @@ NEXT_PUBLIC_API_URL=http://localhost:4000/graphql
 EOF
 
 echo "start.sh: PostgreSQL ready and env files written"
+
+# --- 5. Run the dev servers (Turbo runs both api :4000 and web :3000) ---------
+# `start` stays attached running the dev servers; the platform runs it detached.
+# Skip if something is already bound to the dev ports (idempotent re-runs).
+if (exec 3<>/dev/tcp/127.0.0.1/3000) 2>/dev/null; then
+  exec 3>&- 3<&-
+  echo "start.sh: web already listening on :3000, not starting dev servers"
+else
+  echo "start.sh: starting dev servers (pnpm dev)"
+  exec pnpm dev
+fi

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,23 +1,34 @@
 #!/usr/bin/env bash
 # Per-boot startup for CareConnect: bring up the local Postgres dev database,
-# apply migrations once, and write the app env files. Tolerates restarts and
-# returns (the dev servers themselves run as `terminals`).
+# apply any pending migrations, and write the app env files. Tolerates restarts
+# and returns (the dev servers themselves run as `terminals`).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-PG_VER=16
 DB_NAME=careconnect
 DB_USER=careconnect
 DB_PASS=careconnect
 
 # --- 1. Start the local PostgreSQL cluster (idempotent) ------------------------
-sudo pg_ctlcluster "$PG_VER" main start 2>/dev/null || true
+# Detect the installed cluster rather than hardcoding a version: install.sh pulls
+# the distro-default `postgresql` metapackage, whose major version differs across
+# Ubuntu releases, so a fixed version would silently fail to start on some images.
+read -r PG_VER PG_CLUSTER < <(pg_lsclusters -h 2>/dev/null | awk 'NR==1 {print $1, $2}')
+PG_VER="${PG_VER:-16}"
+PG_CLUSTER="${PG_CLUSTER:-main}"
+
+sudo pg_ctlcluster "$PG_VER" "$PG_CLUSTER" start 2>/dev/null || true
+ready=""
 for _ in $(seq 1 30); do
-  sudo -u postgres pg_isready -q && break
+  if sudo -u postgres pg_isready -q; then ready=1; break; fi
   sleep 1
 done
+if [ -z "$ready" ]; then
+  echo "start.sh: PostgreSQL cluster ${PG_VER}/${PG_CLUSTER} failed to become ready" >&2
+  exit 1
+fi
 
 # --- 2. Ensure role + database exist ------------------------------------------
 sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'" | grep -q 1 \
@@ -25,17 +36,30 @@ sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'" |
 sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1 \
   || sudo -u postgres psql -c "CREATE DATABASE ${DB_NAME} OWNER ${DB_USER};"
 
-# --- 3. Apply SQL migrations once (gated on the first table) -------------------
+# --- 3. Apply SQL migrations (tracked per-file so partial failures re-run) -----
 export PGPASSWORD="${DB_PASS}"
-applied="$(psql -h 127.0.0.1 -U "${DB_USER}" -d "${DB_NAME}" -tAc "SELECT to_regclass('public.hospitals')" 2>/dev/null || true)"
-if [ -z "${applied}" ] || [ "${applied}" = "" ]; then
-  echo "start.sh: applying database migrations..."
-  for f in supabase/migrations/*.sql; do
-    psql -h 127.0.0.1 -U "${DB_USER}" -d "${DB_NAME}" -v ON_ERROR_STOP=1 -f "$f" >/dev/null
-  done
-else
-  echo "start.sh: migrations already applied, skipping"
-fi
+PSQL=(psql -h 127.0.0.1 -U "${DB_USER}" -d "${DB_NAME}" -v ON_ERROR_STOP=1 -tAX)
+
+# Ledger of applied files. Gating on a single table (e.g. public.hospitals) would
+# skip every remaining migration whenever an earlier file succeeded but a later
+# one failed, leaving the schema permanently out of sync with the repo.
+"${PSQL[@]}" -c "CREATE TABLE IF NOT EXISTS public._migrations (filename text PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now());" >/dev/null
+
+for f in supabase/migrations/*.sql; do
+  base="$(basename "$f")"
+  if [ "$("${PSQL[@]}" -c "SELECT 1 FROM public._migrations WHERE filename = '${base}'")" = "1" ]; then
+    continue
+  fi
+  echo "start.sh: applying migration ${base}..."
+  # File + its ledger row commit in one transaction (every migration is
+  # transaction-safe — no CONCURRENTLY/VACUUM), so any failure rolls the whole
+  # thing back and the file re-runs cleanly on the next boot.
+  "${PSQL[@]}" --single-transaction >/dev/null <<SQL
+\i ${f}
+INSERT INTO public._migrations (filename) VALUES ('${base}');
+SQL
+done
+echo "start.sh: migrations up to date"
 
 # --- 4. Write env files -------------------------------------------------------
 # Real Clerk credentials, when added as Cloud Agent Secrets, are picked up here

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -67,14 +67,4 @@ NEXT_PUBLIC_API_URL=http://localhost:4000/graphql
 EOF
 
 echo "start.sh: PostgreSQL ready and env files written"
-
-# --- 5. Run the dev servers (Turbo runs both api :4000 and web :3000) ---------
-# `start` stays attached running the dev servers; the platform runs it detached.
-# Skip if something is already bound to the dev ports (idempotent re-runs).
-if (exec 3<>/dev/tcp/127.0.0.1/3000) 2>/dev/null; then
-  exec 3>&- 3<&-
-  echo "start.sh: web already listening on :3000, not starting dev servers"
-else
-  echo "start.sh: starting dev servers (pnpm dev)"
-  exec pnpm dev
-fi
+# The API (:4000) and web (:3000) dev servers run as `terminals` (see environment.json).

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@apollo/server": "^5.5.1",
+    "@as-integrations/express5": "^1.1.2",
     "@careconnect/types": "workspace:*",
     "@clerk/backend": "^2.33.6",
     "@nestjs/apollo": "^13.4.2",

--- a/apps/api/src/clinical/clinical.types.ts
+++ b/apps/api/src/clinical/clinical.types.ts
@@ -178,6 +178,42 @@ export class PrescriptionType {
   updatedAt: Date;
 }
 
+// Declared before LabOrderType: `emitDecoratorMetadata` emits an eager
+// `design:type` reference to LabResultType for LabOrderType.result, so the
+// class must exist first to avoid a temporal-dead-zone ReferenceError at load.
+@ObjectType()
+export class LabResultType {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID)
+  labOrderId: string;
+
+  @Field(() => ID)
+  hospitalId: string;
+
+  @Field({ nullable: true })
+  resultValue?: string;
+
+  @Field({ nullable: true })
+  referenceRange?: string;
+
+  @Field({ nullable: true })
+  unit?: string;
+
+  @Field({ nullable: true })
+  resultFileUrl?: string;
+
+  @Field(() => ID, { nullable: true })
+  enteredById?: string;
+
+  @Field({ nullable: true })
+  completedAt?: Date;
+
+  @Field()
+  createdAt: Date;
+}
+
 @ObjectType()
 export class LabOrderType {
   @Field(() => ID)
@@ -218,39 +254,6 @@ export class LabOrderType {
 
   @Field(() => LabResultType, { nullable: true })
   result?: LabResultType;
-}
-
-@ObjectType()
-export class LabResultType {
-  @Field(() => ID)
-  id: string;
-
-  @Field(() => ID)
-  labOrderId: string;
-
-  @Field(() => ID)
-  hospitalId: string;
-
-  @Field({ nullable: true })
-  resultValue?: string;
-
-  @Field({ nullable: true })
-  referenceRange?: string;
-
-  @Field({ nullable: true })
-  unit?: string;
-
-  @Field({ nullable: true })
-  resultFileUrl?: string;
-
-  @Field(() => ID, { nullable: true })
-  enteredById?: string;
-
-  @Field({ nullable: true })
-  completedAt?: Date;
-
-  @Field()
-  createdAt: Date;
 }
 
 @InputType()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@apollo/server':
         specifier: ^5.5.1
         version: 5.5.1(graphql@16.14.1)
+      '@as-integrations/express5':
+        specifier: ^1.1.2
+        version: 1.1.2(@apollo/server@5.5.1(graphql@16.14.1))(express@5.2.1)
       '@careconnect/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -38,7 +41,7 @@ importers:
         version: 2.33.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@nestjs/apollo':
         specifier: ^13.4.2
-        version: 13.4.2(@apollo/server@5.5.1(graphql@16.14.1))(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(@nestjs/graphql@13.4.2(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.14.1)(reflect-metadata@0.2.2))(graphql@16.14.1)
+        version: 13.4.2(@apollo/server@5.5.1(graphql@16.14.1))(@as-integrations/express5@1.1.2(@apollo/server@5.5.1(graphql@16.14.1))(express@5.2.1))(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(@nestjs/graphql@13.4.2(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.14.1)(reflect-metadata@0.2.2))(graphql@16.14.1)
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -464,6 +467,13 @@ packages:
 
   '@apollographql/graphql-playground-html@1.6.29':
     resolution: {integrity: sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==}
+
+  '@as-integrations/express5@1.1.2':
+    resolution: {integrity: sha512-BxfwtcWNf2CELDkuPQxi5Zl3WqY/dQVJYafeCBOGoFQjv5M0fjhxmAFZ9vKx/5YKKNeok4UY6PkFbHzmQrdxIA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@apollo/server': ^4.0.0 || ^5.0.0
+      express: ^5.0.0
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -6162,6 +6172,11 @@ snapshots:
     dependencies:
       xss: 1.0.15
 
+  '@as-integrations/express5@1.1.2(@apollo/server@5.5.1(graphql@16.14.1))(express@5.2.1)':
+    dependencies:
+      '@apollo/server': 5.5.1(graphql@16.14.1)
+      express: 5.2.1
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -7110,7 +7125,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@nestjs/apollo@13.4.2(@apollo/server@5.5.1(graphql@16.14.1))(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(@nestjs/graphql@13.4.2(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.14.1)(reflect-metadata@0.2.2))(graphql@16.14.1)':
+  '@nestjs/apollo@13.4.2(@apollo/server@5.5.1(graphql@16.14.1))(@as-integrations/express5@1.1.2(@apollo/server@5.5.1(graphql@16.14.1))(express@5.2.1))(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(@nestjs/graphql@13.4.2(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.14.1)(reflect-metadata@0.2.2))(graphql@16.14.1)':
     dependencies:
       '@apollo/server': 5.5.1(graphql@16.14.1)
       '@apollo/server-plugin-landing-page-graphql-playground': 4.0.1(@apollo/server@5.5.1(graphql@16.14.1))
@@ -7121,6 +7136,8 @@ snapshots:
       iterall: 1.3.0
       lodash.omit: 4.18.0
       tslib: 2.8.1
+    optionalDependencies:
+      '@as-integrations/express5': 1.1.2(@apollo/server@5.5.1(graphql@16.14.1))(express@5.2.1)
 
   '@nestjs/cli@11.0.22(@swc/core@1.15.43)(@types/node@24.13.1)(esbuild@0.25.12)(prettier@3.8.3)':
     dependencies:
@@ -9096,7 +9113,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -9133,7 +9150,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9147,7 +9164,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a self-contained Cloud Agent development environment for CareConnect and fixes two pre-existing bugs that prevented the NestJS API from starting at all.

The environment is **repo-managed** via `.cursor/environment.json`: it uses the default base image plus a **local PostgreSQL** (in place of Neon) and **CI-style placeholder Clerk keys**, so `install`, `build`, `lint`, the API (with a real database), and the web app's server-side rendering all work with zero external services. Real Clerk credentials added as Cloud Agent **Secrets** are picked up automatically to unlock live browser auth.

## Changes

### API boot fixes (required to run the app at all)
- `apps/api/src/clinical/clinical.types.ts` — declare `LabResultType` before `LabOrderType`. `emitDecoratorMetadata` emits an eager `design:type` reference to `LabResultType` for `LabOrderType.result`, so with the old ordering the API crashed on startup with `ReferenceError: Cannot access 'LabResultType' before initialization` (reproduced in the compiled output too — not env-specific).
- `apps/api/package.json` / `pnpm-lock.yaml` — add `@as-integrations/express5`. `@nestjs/apollo` lists it only as an *optional* peer, so pnpm skips it, but NestJS 11 defaults to Express 5 and the Apollo driver needs this integration to mount `/graphql`. Without it the API booted then failed to serve GraphQL.

### Environment setup (`.cursor/`)
- `environment.json` — repo-managed config: `install`/`start` scripts, two `terminals` (`api` → `pnpm --filter api dev` on :4000, `web` → `pnpm --filter web dev` on :3000), and exposed ports 3000/4000.
- `install.sh` — install PostgreSQL if missing (idempotent), `pnpm install --frozen-lockfile`, build shared `@careconnect/types`.
- `start.sh` — start the local PostgreSQL cluster, create the `careconnect` role/db, apply `supabase/migrations/*.sql` once (gated), and write `apps/api/.env` + `apps/web/.env.local`. Prefers real Clerk values from env/Secrets, falling back to CI-style placeholders.

## Validation

**Local VM**
| Check | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` (twice) | Idempotent, passes |
| Build shared types / API / web | All pass |
| Lint web / API | Pass (web: 0 errors) |
| API unit tests | 15 suites, 112 tests pass |
| Migrations → Postgres | 27 files, 37 tables, 10 roles seeded |
| API + GraphQL | `/graphql` served; introspection returns 100 types incl. `LabOrderType`/`LabResultType`; live DB queries |
| Web dev server + SSR | All public pages 200 with correct headings |

**Fresh Cloud Agents** — verified from a clean default base that `install.sh` installs PostgreSQL, `start.sh` yields 37 tables / 10 roles, and the `terminals` bring up the API (100 types) and web (`/login` 200, `/docs` SSR) end-to-end.

## Notes
- **Activate:** merging this PR puts `.cursor/environment.json` on the default branch, so future Cloud Agents auto-run install/start/terminals.
- **Live Clerk auth** requires a real Clerk instance (the repo's documented prerequisite): `clerkMiddleware` runs a dev-instance handshake that placeholder keys can't satisfy, so a browser gets a Clerk `host_invalid` error even on public routes. Add `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, and `CLERK_ISSUER` as Cloud Agent Secrets and `start.sh` uses them automatically.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3570bfa0-c507-4ed8-94c0-be20e66f62b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3570bfa0-c507-4ed8-94c0-be20e66f62b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

