### PR TITLE
fix: doctor pickers match API doctor-role validation (#233)

### DIFF
--- a/apps/web/src/app/(dashboard)/follow-ups/page.tsx
+++ b/apps/web/src/app/(dashboard)/follow-ups/page.tsx
@@ -79,7 +79,8 @@ export default function FollowUpsPage() {
     ? []
     : (staffData?.staffMembers ?? []).filter(
         (s: { roleSlug: string; isActive: boolean }) =>
-          s.isActive && (s.roleSlug === 'doctor' || s.roleSlug === 'hospital_admin'),
+          // Match HospitalDoctorValidator / appointments/new: doctor role only.
+          s.isActive && s.roleSlug === 'doctor',
       );
 
   const [updateStatus] = useMutation(UPDATE_FOLLOW_UP_STATUS_MUTATION, {

--- a/apps/web/src/app/(dashboard)/patients/[id]/discharge/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/discharge/page.tsx
@@ -63,7 +63,8 @@ export default function PatientDischargePage() {
     ? []
     : (staffData?.staffMembers ?? []).filter(
         (s: { roleSlug: string; isActive: boolean }) =>
-          s.isActive && (s.roleSlug === 'doctor' || s.roleSlug === 'hospital_admin'),
+          // Match HospitalDoctorValidator / appointments/new: doctor role only.
+          s.isActive && s.roleSlug === 'doctor',
       );
 
   const admission = admissionsData?.activeAdmissions?.find(

--- a/apps/web/src/components/clinical/patient-clinical-actions.tsx
+++ b/apps/web/src/components/clinical/patient-clinical-actions.tsx
@@ -551,7 +551,8 @@ function DoctorSelect({ hospitalId }: { hospitalId?: string }) {
     ? []
     : (data?.staffMembers ?? []).filter(
         (s: { roleSlug: string; isActive: boolean }) =>
-          s.isActive && (s.roleSlug === 'doctor' || s.roleSlug === 'hospital_admin'),
+          // Match HospitalDoctorValidator / appointments/new: doctor role only.
+          s.isActive && s.roleSlug === 'doctor',
       );
 
   return (


### PR DESCRIPTION
## Summary
- Filter chart / follow-up / discharge doctor pickers to active `doctor` staff only
- Matches `HospitalDoctorValidator` and the existing appointments/new picker
- Closes #233

## Test plan
- [ ] Open patient chart clinical actions doctor select — no hospital_admin options
- [ ] Follow-ups schedule form doctor select — doctor-only
- [ ] Discharge follow-up doctor select — doctor-only
- [ ] Selecting a listed doctor succeeds against the API


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated doctor selection for follow-ups and appointments to show only active staff with the doctor role.
  * Removed hospital administrators from selectable doctor lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->