### PR TITLE
fix: addDocument unique file_url → ConflictException (#234)

### DIFF
--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException, ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { existsSync } from 'fs';
+import { QueryFailedError } from 'typeorm';
 import {
   Admission,
   Patient,
@@ -429,6 +430,30 @@ describe('PatientsService', () => {
           'user-1',
         ),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('maps unique file_url violation to ConflictException', async () => {
+      patientsRepo.findOne.mockResolvedValue({
+        id: 'patient-1',
+        hospitalId: 'hospital-1',
+      });
+      relatedRepo.create.mockImplementation((row: unknown) => row);
+      const uniqueError = new QueryFailedError('INSERT', [], new Error('dup'));
+      (uniqueError as QueryFailedError & { code?: string }).code = '23505';
+      relatedRepo.save.mockRejectedValue(uniqueError);
+      existsSyncMock.mockReturnValue(true);
+
+      await expect(
+        service.addDocument(
+          'patient-1',
+          'hospital-1',
+          {
+            name: 'scan.pdf',
+            fileUrl: '/uploads/a1b2c3d4-e5f6.pdf',
+          },
+          'user-1',
+        ),
+      ).rejects.toThrow(ConflictException);
     });
   });
 

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -9,7 +9,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { existsSync, unlinkSync } from 'fs';
 import { basename, join } from 'path';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, QueryFailedError, Repository } from 'typeorm';
 import {
   Patient,
   PatientAllergy,
@@ -1085,16 +1085,30 @@ export class PatientsService {
 
     const safeFileUrl = await this.assertOwnedUploadFileUrl(input.fileUrl);
 
-    return this.documentsRepo.save(
-      this.documentsRepo.create({
-        patientId,
-        name: input.name,
-        fileUrl: safeFileUrl,
-        fileType: input.fileType,
-        documentType: input.documentType,
-        uploadedById,
-      }),
-    );
+    try {
+      return await this.documentsRepo.save(
+        this.documentsRepo.create({
+          patientId,
+          name: input.name,
+          fileUrl: safeFileUrl,
+          fileType: input.fileType,
+          documentType: input.documentType,
+          uploadedById,
+        }),
+      );
+    } catch (error) {
+      // Concurrent binds of the same upload can race past assertOwnedUploadFileUrl
+      // and hit uq_patient_documents_file_url (#234).
+      if (
+        error instanceof QueryFailedError &&
+        (error as QueryFailedError & { code?: string }).code === '23505'
+      ) {
+        throw new ConflictException(
+          'Upload file is already linked to a patient document',
+        );
+      }
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Catch Postgres unique violations (`23505`) in `addDocument` and throw `ConflictException`
- Matches the existing `completeLabResult` pattern
- Adds a unit test for the race path
- Closes #234

## Test plan
- [ ] `pnpm --filter api test` — patients.service.spec `maps unique file_url violation`
- [ ] Parallel `addDocument` same `fileUrl` → one success, one 409


Made with [Cursor](https://cursor.com)