### PR TITLE
fix: terminalize open workflows on patient soft-delete (#235)

### DIFF
--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -97,9 +97,13 @@ describe('PatientsService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     relatedRepo.find.mockResolvedValue([]);
-    relatedRepo.createQueryBuilder.mockImplementation(() => mockUploadUrlQb([]));
+    relatedRepo.createQueryBuilder.mockImplementation(() =>
+      mockUploadUrlQb([]),
+    );
     relatedRepo.manager.getRepository.mockReturnValue(labResultsRepo);
-    labResultsRepo.createQueryBuilder.mockImplementation(() => mockUploadUrlQb([]));
+    labResultsRepo.createQueryBuilder.mockImplementation(() =>
+      mockUploadUrlQb([]),
+    );
     existsSyncMock.mockReturnValue(true);
 
     const module: TestingModule = await Test.createTestingModule({
@@ -363,11 +367,17 @@ describe('PatientsService', () => {
       );
       expect(audit.log).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({
+          action: 'delete',
+          resource: 'patient',
+          resourceId: 'patient-1',
+          metadata: {
+            fullName: 'Jane Doe',
+            documentsRemoved: 0,
+            previousUserId: undefined,
             cancelledPrescriptions: 1,
             cancelledLabOrders: 1,
             cancelledAppointments: 1,
-          }),
+          },
         }),
       );
     });

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -5,6 +5,8 @@ import { existsSync } from 'fs';
 import { QueryFailedError } from 'typeorm';
 import {
   Admission,
+  Appointment,
+  LabOrder,
   Patient,
   PatientAllergy,
   PatientConsent,
@@ -14,6 +16,7 @@ import {
   PatientInsurance,
   PatientMedicalHistory,
   PatientMedication,
+  Prescription,
   User,
 } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
@@ -271,6 +274,102 @@ describe('PatientsService', () => {
       ).rejects.toThrow(BadRequestException);
       expect(patientQb.setLock).toHaveBeenCalledWith('pessimistic_write');
       expect(audit.log).not.toHaveBeenCalled();
+    });
+
+    it('cancels open Rx, labs, and appointments before soft-delete', async () => {
+      const patient = {
+        id: 'patient-1',
+        hospitalId: 'hospital-1',
+        fullName: 'Jane Doe',
+        userId: undefined,
+      };
+      const patientQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(patient),
+      };
+      const pendingRx = { id: 'rx-1', status: 'pending' };
+      const openLab = { id: 'lab-1', status: 'ordered' };
+      const openAppt = { id: 'appt-1', status: 'scheduled', notes: undefined };
+      const rxSave = jest.fn().mockResolvedValue(pendingRx);
+      const labSave = jest.fn().mockResolvedValue(openLab);
+      const apptSave = jest.fn().mockResolvedValue(openAppt);
+      const labFind = jest
+        .fn()
+        .mockResolvedValueOnce([openLab])
+        .mockResolvedValueOnce([]);
+
+      patientsRepo.manager.transaction.mockImplementation(
+        (cb: (m: Record<string, unknown>) => unknown) => {
+          const manager = {
+            createQueryBuilder: jest.fn().mockReturnValue(patientQb),
+            getRepository: (entity: unknown) => {
+              if (entity === Patient) {
+                return {
+                  save: jest.fn().mockResolvedValue(patient),
+                  softRemove: jest.fn().mockResolvedValue(patient),
+                };
+              }
+              if (entity === Admission) {
+                return { findOne: jest.fn().mockResolvedValue(null) };
+              }
+              if (entity === PatientDocument) {
+                return {
+                  find: jest.fn().mockResolvedValue([]),
+                  remove: jest.fn(),
+                };
+              }
+              if (entity === Prescription) {
+                return {
+                  find: jest.fn().mockResolvedValue([pendingRx]),
+                  save: rxSave,
+                };
+              }
+              if (entity === Appointment) {
+                return {
+                  find: jest.fn().mockResolvedValue([openAppt]),
+                  save: apptSave,
+                };
+              }
+              if (entity === LabOrder) {
+                return { find: labFind, save: labSave };
+              }
+              return {
+                find: jest.fn().mockResolvedValue([]),
+                save: jest.fn(),
+                remove: jest.fn(),
+              };
+            },
+          };
+          return Promise.resolve(cb(manager));
+        },
+      );
+
+      await service.deletePatient('patient-1', 'hospital-1', actor);
+
+      expect(rxSave).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'rx-1', status: 'cancelled' }),
+      );
+      expect(labSave).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'lab-1', status: 'cancelled' }),
+      );
+      expect(apptSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'appt-1',
+          status: 'cancelled',
+          notes: 'Cancelled: patient soft-deleted',
+        }),
+      );
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            cancelledPrescriptions: 1,
+            cancelledLabOrders: 1,
+            cancelledAppointments: 1,
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -9,7 +9,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { existsSync, unlinkSync } from 'fs';
 import { basename, join } from 'path';
-import { EntityManager, QueryFailedError, Repository } from 'typeorm';
+import { EntityManager, In, QueryFailedError, Repository } from 'typeorm';
 import {
   Patient,
   PatientAllergy,
@@ -21,8 +21,10 @@ import {
   PatientMedicalHistory,
   PatientMedication,
   Admission,
+  Appointment,
   LabOrder,
   LabResult,
+  Prescription,
   User,
 } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
@@ -416,14 +418,19 @@ export class PatientsService {
     actor: AuthenticatedUser,
   ): Promise<boolean> {
     // Soft-delete policy: soft-remove the patient row; hard-remove linked
-    // document metadata and unlink PHI files from disk. Other related rows
-    // remain for audit but are unreachable via patient queries.
+    // document metadata and unlink PHI files from disk. Open clinical
+    // workflows (pending Rx, open labs, scheduled/checked-in appointments)
+    // are cancelled in the same transaction so they cannot become invisible
+    // and uncancelable after lists hide soft-deleted patients (#235).
     // Lock the patient row and re-check active admissions inside the txn so a
     // concurrent admit cannot attach a live bed after the pre-check (#230).
     let previousUserId: string | undefined;
     let patientFullName = '';
     const fileUrlsToUnlink: string[] = [];
     let patientId = id;
+    let cancelledPrescriptions = 0;
+    let cancelledLabOrders = 0;
+    let cancelledAppointments = 0;
 
     await this.patientsRepo.manager.transaction(async (manager) => {
       const patientsRepo = manager.getRepository(Patient);
@@ -431,6 +438,8 @@ export class PatientsService {
       const documentsRepo = manager.getRepository(PatientDocument);
       const labOrdersRepo = manager.getRepository(LabOrder);
       const labResultsRepo = manager.getRepository(LabResult);
+      const prescriptionsRepo = manager.getRepository(Prescription);
+      const appointmentsRepo = manager.getRepository(Appointment);
 
       const patient = await manager
         .createQueryBuilder(Patient, 'patient')
@@ -452,6 +461,47 @@ export class PatientsService {
       previousUserId = patient.userId;
       patientFullName = patient.fullName;
       patientId = patient.id;
+
+      // Terminalize open workflows before soft-delete so staff are not left
+      // with invisible pending Rx / labs / appointments.
+      const pendingRx = await prescriptionsRepo.find({
+        where: { patientId: id, hospitalId, status: 'pending' },
+      });
+      for (const rx of pendingRx) {
+        rx.status = 'cancelled';
+        await prescriptionsRepo.save(rx);
+      }
+      cancelledPrescriptions = pendingRx.length;
+
+      const openLabs = await labOrdersRepo.find({
+        where: {
+          patientId: id,
+          hospitalId,
+          status: In(['ordered', 'collected', 'processing']),
+        },
+      });
+      for (const lab of openLabs) {
+        lab.status = 'cancelled';
+        await labOrdersRepo.save(lab);
+      }
+      cancelledLabOrders = openLabs.length;
+
+      const openAppointments = await appointmentsRepo.find({
+        where: {
+          patientId: id,
+          hospitalId,
+          status: In(['scheduled', 'checked_in']),
+        },
+      });
+      for (const appointment of openAppointments) {
+        appointment.status = 'cancelled';
+        const cancelNote = 'Cancelled: patient soft-deleted';
+        appointment.notes = appointment.notes
+          ? `${appointment.notes}\n${cancelNote}`
+          : cancelNote;
+        await appointmentsRepo.save(appointment);
+      }
+      cancelledAppointments = openAppointments.length;
 
       patient.userId = null as unknown as string | undefined;
       await patientsRepo.save(patient);
@@ -494,6 +544,9 @@ export class PatientsService {
         fullName: patientFullName,
         documentsRemoved: fileUrlsToUnlink.length,
         previousUserId,
+        cancelledPrescriptions,
+        cancelledLabOrders,
+        cancelledAppointments,
       },
     });
 


### PR DESCRIPTION
## Summary
- On soft-delete, cancel pending prescriptions, open lab orders (`ordered`/`collected`/`processing`), and scheduled/checked-in appointments inside the same transaction
- Audit metadata records how many of each were cancelled
- Prevents invisible, uncancelable open workflows after #224 list filters
- Closes #235

## Test plan
- [ ] Unit: `deletePatient` cancels open Rx/labs/appointments
- [ ] Soft-delete patient with pending Rx → Rx status `cancelled`
- [ ] Soft-delete with open lab → lab `cancelled`, leaves actionable queue
- [ ] Soft-delete with future appointment → appointment `cancelled`


Made with [Cursor](https://cursor.com)