### PR TITLE
fix: Lab Queue cancel control for open orders (#236)

### DIFF
--- a/apps/web/src/app/(dashboard)/lab/page.tsx
+++ b/apps/web/src/app/(dashboard)/lab/page.tsx
@@ -130,7 +130,10 @@ export default function LabPage() {
     (o) => o.status !== 'completed' && o.status !== 'cancelled',
   );
 
-  const handleAdvanceStatus = async (labOrderId: string, status: string) => {
+  const handleAdvanceStatus = async (
+    labOrderId: string,
+    status: string,
+  ): Promise<boolean> => {
     setError('');
     try {
       await updateLabStatus({
@@ -139,8 +142,10 @@ export default function LabPage() {
           input: { labOrderId, status },
         },
       });
+      return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update lab order status');
+      return false;
     }
   };
 
@@ -408,8 +413,8 @@ export default function LabPage() {
                             return;
                           }
                           void handleAdvanceStatus(order.id, 'cancelled').then(
-                            () => {
-                              if (selectedOrderId === order.id) {
+                            (ok) => {
+                              if (ok && selectedOrderId === order.id) {
                                 setSelectedOrderId(null);
                               }
                             },

--- a/apps/web/src/app/(dashboard)/lab/page.tsx
+++ b/apps/web/src/app/(dashboard)/lab/page.tsx
@@ -393,6 +393,32 @@ export default function LabPage() {
                         File
                       </button>
                     ) : null}
+                    {canWriteLab &&
+                    !['completed', 'cancelled'].includes(order.status) ? (
+                      <ClayButton
+                        size="sm"
+                        variant="danger"
+                        isLoading={updatingStatus}
+                        onClick={() => {
+                          if (
+                            !confirm(
+                              'Cancel this lab order? This cannot be undone from the queue.',
+                            )
+                          ) {
+                            return;
+                          }
+                          void handleAdvanceStatus(order.id, 'cancelled').then(
+                            () => {
+                              if (selectedOrderId === order.id) {
+                                setSelectedOrderId(null);
+                              }
+                            },
+                          );
+                        }}
+                      >
+                        Cancel
+                      </ClayButton>
+                    ) : null}
                     {canWriteLab && nextLabStatus(order.status) ? (
                       <ClayButton
                         size="sm"


### PR DESCRIPTION
## Summary
- Add a Cancel button on Lab Queue rows for open orders (`ordered` / `collected` / `processing`)
- Uses existing `updateLabOrderStatus` → `cancelled` (already allowed by the API)
- Confirm dialog; clears selection when the selected order is cancelled
- Closes #236

## Test plan
- [ ] Lab tech with `lab:write` sees Cancel on open orders
- [ ] Confirm → status becomes cancelled and order leaves pending queue
- [ ] Advance (collected/processing) still works alongside Cancel


Made with [Cursor](https://cursor.com)