### PR TITLE
feat: hospital-scoped audit log read API + Reports UI (#237)

### DIFF
--- a/apps/api/src/audit/audit.module.ts
+++ b/apps/api/src/audit/audit.module.ts
@@ -2,11 +2,12 @@ import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuditLog } from '../database/entities/audit-log.entity';
 import { AuditService } from './audit.service';
+import { AuditResolver } from './audit.resolver';
 
 @Global()
 @Module({
   imports: [TypeOrmModule.forFeature([AuditLog])],
-  providers: [AuditService],
+  providers: [AuditService, AuditResolver],
   exports: [AuditService],
 })
 export class AuditModule {}

--- a/apps/api/src/audit/audit.resolver.ts
+++ b/apps/api/src/audit/audit.resolver.ts
@@ -1,0 +1,36 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Int, Query, Resolver } from '@nestjs/graphql';
+import { PERMISSIONS, ROLES } from '@careconnect/types';
+import { GqlAuthGuard } from '../auth/gql-auth.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { Permissions } from '../rbac/permissions.decorator';
+import { Roles } from '../rbac/roles.decorator';
+import { RolesGuard } from '../rbac/roles.guard';
+import { AuditService } from './audit.service';
+import { AuditLogsPageType } from './audit.types';
+
+@Resolver()
+@UseGuards(GqlAuthGuard, RolesGuard)
+export class AuditResolver {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Query(() => AuditLogsPageType)
+  @Permissions(PERMISSIONS.REPORTS_READ)
+  @Roles(ROLES.HOSPITAL_ADMIN, ROLES.HOSPITAL_MANAGER, ROLES.SUPER_ADMIN)
+  async auditLogs(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+    @Args('resource', { nullable: true }) resource?: string,
+    @Args('limit', { type: () => Int, nullable: true }) limit?: number,
+  ): Promise<AuditLogsPageType> {
+    const resolvedHospitalId = this.auditService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.auditService.listHospitalLogs(resolvedHospitalId, {
+      resource,
+      limit,
+    });
+  }
+}

--- a/apps/api/src/audit/audit.service.spec.ts
+++ b/apps/api/src/audit/audit.service.spec.ts
@@ -1,0 +1,104 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuditLog } from '../database/entities/audit-log.entity';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditService } from './audit.service';
+
+describe('AuditService', () => {
+  let service: AuditService;
+
+  const auditRepo = {
+    save: jest.fn(),
+    create: jest.fn((row: unknown) => row),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const actor: AuthenticatedUser = {
+    id: 'user-1',
+    authId: 'auth-1',
+    email: 'admin@hospital.com',
+    fullName: 'Admin',
+    hospitalId: 'hospital-1',
+    roles: ['hospital_admin'],
+    permissions: ['reports:read'],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        { provide: getRepositoryToken(AuditLog), useValue: auditRepo },
+      ],
+    }).compile();
+    service = module.get(AuditService);
+  });
+
+  describe('resolveHospitalId', () => {
+    it('uses the caller hospital by default', () => {
+      expect(service.resolveHospitalId(actor)).toBe('hospital-1');
+    });
+
+    it('rejects cross-hospital access for non-super-admin', () => {
+      expect(() => service.resolveHospitalId(actor, 'hospital-other')).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('requires hospital context when none is available', () => {
+      expect(() =>
+        service.resolveHospitalId({
+          ...actor,
+          hospitalId: undefined,
+          roles: ['hospital_admin'],
+        }),
+      ).toThrow(NotFoundException);
+    });
+  });
+
+  describe('listHospitalLogs', () => {
+    it('returns projected rows without metadata', async () => {
+      const qb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([
+          [
+            {
+              id: 'log-1',
+              actorId: 'user-1',
+              actor: { email: 'admin@hospital.com', fullName: 'Admin' },
+              hospitalId: 'hospital-1',
+              action: 'delete',
+              resource: 'patient',
+              resourceId: 'patient-1',
+              metadata: { fullName: 'secret' },
+              createdAt: new Date('2026-01-01T00:00:00Z'),
+            },
+          ],
+          1,
+        ]),
+      };
+      auditRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const page = await service.listHospitalLogs('hospital-1', { limit: 25 });
+
+      expect(page.total).toBe(1);
+      expect(page.items[0]).toEqual(
+        expect.objectContaining({
+          id: 'log-1',
+          actorEmail: 'admin@hospital.com',
+          actorName: 'Admin',
+          action: 'delete',
+          resource: 'patient',
+        }),
+      );
+      expect(page.items[0]).not.toHaveProperty('metadata');
+      expect(qb.take).toHaveBeenCalledWith(25);
+    });
+  });
+});

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -1,7 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AuditLog } from '../database/entities/audit-log.entity';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { AuditLogType, AuditLogsPageType } from './audit.types';
 
 @Injectable()
 export class AuditService {
@@ -28,5 +34,64 @@ export class AuditService {
         metadata: params.metadata ?? {},
       }),
     );
+  }
+
+  assertHospitalAccess(user: AuthenticatedUser, hospitalId: string) {
+    if (user.roles.includes('super_admin')) return;
+    if (!user.hospitalId || user.hospitalId !== hospitalId) {
+      throw new ForbiddenException('Access denied for this hospital');
+    }
+  }
+
+  resolveHospitalId(user: AuthenticatedUser, hospitalId?: string): string {
+    if (user.roles.includes('super_admin') && hospitalId) return hospitalId;
+    const id = hospitalId ?? user.hospitalId;
+    if (!id) throw new NotFoundException('Hospital context required');
+    this.assertHospitalAccess(user, id);
+    return id;
+  }
+
+  /**
+   * Hospital-scoped audit feed for compliance review (#237).
+   * Metadata is intentionally omitted from the GraphQL projection — it can
+   * contain PHI (e.g. patient names on delete).
+   */
+  async listHospitalLogs(
+    hospitalId: string,
+    opts: { resource?: string; limit?: number } = {},
+  ): Promise<AuditLogsPageType> {
+    const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+
+    const qb = this.auditRepo
+      .createQueryBuilder('log')
+      .leftJoinAndSelect('log.actor', 'actor')
+      .where('log.hospital_id = :hospitalId', { hospitalId })
+      .orderBy('log.created_at', 'DESC')
+      .take(limit);
+
+    if (opts.resource) {
+      qb.andWhere('log.resource = :resource', { resource: opts.resource });
+    }
+
+    const [rows, total] = await qb.getManyAndCount();
+
+    return {
+      total,
+      items: rows.map((row) => this.toAuditLogType(row)),
+    };
+  }
+
+  private toAuditLogType(row: AuditLog): AuditLogType {
+    return {
+      id: row.id,
+      actorId: row.actorId,
+      actorEmail: row.actor?.email,
+      actorName: row.actor?.fullName,
+      hospitalId: row.hospitalId,
+      action: row.action,
+      resource: row.resource,
+      resourceId: row.resourceId,
+      createdAt: row.createdAt,
+    };
   }
 }

--- a/apps/api/src/audit/audit.types.ts
+++ b/apps/api/src/audit/audit.types.ts
@@ -1,0 +1,40 @@
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class AuditLogType {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID, { nullable: true })
+  actorId?: string;
+
+  @Field({ nullable: true })
+  actorEmail?: string;
+
+  @Field({ nullable: true })
+  actorName?: string;
+
+  @Field(() => ID, { nullable: true })
+  hospitalId?: string;
+
+  @Field()
+  action: string;
+
+  @Field()
+  resource: string;
+
+  @Field(() => ID, { nullable: true })
+  resourceId?: string;
+
+  @Field()
+  createdAt: Date;
+}
+
+@ObjectType()
+export class AuditLogsPageType {
+  @Field(() => [AuditLogType])
+  items: AuditLogType[];
+
+  @Field(() => Int)
+  total: number;
+}

--- a/apps/web/src/app/(dashboard)/reports/page.tsx
+++ b/apps/web/src/app/(dashboard)/reports/page.tsx
@@ -6,18 +6,35 @@ import {
   Activity,
   BedDouble,
   Calendar,
+  ClipboardList,
   DollarSign,
   UserCog,
   Users,
 } from 'lucide-react';
 import { ClayButton, ClayCard, ClayStatCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
-import { BED_OCCUPANCY_QUERY, HOSPITAL_REPORTS_QUERY, ME_QUERY } from '@/lib/graphql/queries';
+import {
+  AUDIT_LOGS_QUERY,
+  BED_OCCUPANCY_QUERY,
+  HOSPITAL_REPORTS_QUERY,
+  ME_QUERY,
+} from '@/lib/graphql/queries';
 import { canAccessRoute } from '@/lib/route-access';
+
+const AUDIT_VIEW_ROLES = new Set([
+  'hospital_admin',
+  'hospital_manager',
+  'super_admin',
+]);
 
 export default function ReportsPage() {
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
+  const roles: string[] = meData?.me?.roles ?? [];
+  const permissions: string[] = meData?.me?.permissions ?? [];
+  const canViewAudit =
+    permissions.includes('reports:read') &&
+    roles.some((r) => AUDIT_VIEW_ROLES.has(r));
 
   const { data, loading, error } = useQuery(HOSPITAL_REPORTS_QUERY, {
     variables: { hospitalId },
@@ -26,6 +43,10 @@ export default function ReportsPage() {
   const occupancyQuery = useQuery(BED_OCCUPANCY_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
+  });
+  const auditQuery = useQuery(AUDIT_LOGS_QUERY, {
+    variables: { hospitalId, limit: 25 },
+    skip: !hospitalId || !canViewAudit,
   });
 
   const reports = data?.hospitalReports;
@@ -203,6 +224,90 @@ export default function ReportsPage() {
               hospital database state.
             </p>
           </ClayCard>
+
+          {canViewAudit ? (
+            <ClayCard className="mt-6">
+              <div className="mb-4 flex items-center gap-2">
+                <ClipboardList className="h-5 w-5 text-clay-primary" />
+                <h2 className="text-lg font-semibold text-clay-text">
+                  Recent audit activity
+                </h2>
+              </div>
+              {auditQuery.loading ? (
+                <p className="text-sm text-clay-text-muted">Loading audit log...</p>
+              ) : auditQuery.error ? (
+                <div className="space-y-3">
+                  <p className="text-sm text-clay-error">
+                    We could not load audit events. Please try again.
+                  </p>
+                  <ClayButton
+                    type="button"
+                    size="sm"
+                    onClick={() => void auditQuery.refetch()}
+                  >
+                    Try again
+                  </ClayButton>
+                </div>
+              ) : (auditQuery.data?.auditLogs?.items ?? []).length === 0 ? (
+                <p className="text-sm text-clay-text-muted">
+                  No audit events recorded for this hospital yet.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[36rem] text-left text-sm">
+                    <thead>
+                      <tr className="border-b border-white/40 text-clay-text-muted">
+                        <th className="pb-2 font-medium">When</th>
+                        <th className="pb-2 font-medium">Actor</th>
+                        <th className="pb-2 font-medium">Action</th>
+                        <th className="pb-2 font-medium">Resource</th>
+                        <th className="pb-2 font-medium">Resource ID</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {(
+                        auditQuery.data?.auditLogs?.items as Array<{
+                          id: string;
+                          createdAt: string;
+                          actorName?: string;
+                          actorEmail?: string;
+                          action: string;
+                          resource: string;
+                          resourceId?: string;
+                        }>
+                      ).map((row) => (
+                        <tr
+                          key={row.id}
+                          className="border-b border-white/20 text-clay-text"
+                        >
+                          <td className="py-2 whitespace-nowrap">
+                            {new Date(row.createdAt).toLocaleString()}
+                          </td>
+                          <td className="py-2">
+                            {row.actorName || row.actorEmail || '—'}
+                          </td>
+                          <td className="py-2 font-medium">{row.action}</td>
+                          <td className="py-2">{row.resource}</td>
+                          <td className="py-2 font-mono text-xs">
+                            {row.resourceId ?? '—'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  <p className="mt-3 text-xs text-clay-text-muted">
+                    Showing{' '}
+                    {Math.min(
+                      auditQuery.data?.auditLogs?.items?.length ?? 0,
+                      25,
+                    )}{' '}
+                    of {auditQuery.data?.auditLogs?.total ?? 0} events
+                    (metadata omitted from this view).
+                  </p>
+                </div>
+              )}
+            </ClayCard>
+          ) : null}
         </>
       )}
     </div>

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -1094,3 +1094,21 @@ export const HOSPITAL_REPORTS_QUERY = gql`
     }
   }
 `;
+
+export const AUDIT_LOGS_QUERY = gql`
+  query AuditLogs($hospitalId: String, $resource: String, $limit: Int) {
+    auditLogs(hospitalId: $hospitalId, resource: $resource, limit: $limit) {
+      total
+      items {
+        id
+        actorId
+        actorEmail
+        actorName
+        action
+        resource
+        resourceId
+        createdAt
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- Add `auditLogs` GraphQL query (hospital-scoped, `reports:read` + admin/manager/super_admin roles)
- Omit `metadata` from the GraphQL type (can contain PHI)
- Show a Recent audit activity table on the Reports page for authorized roles
- Closes #237

## Test plan
- [ ] Unit: `audit.service.spec` resolveHospitalId + listHospitalLogs
- [ ] Hospital admin on `/reports` sees recent audit rows
- [ ] Non-admin clinician with reports:read still blocked by `@Roles`
- [ ] Cross-hospital hospitalId rejected for non-super_admin


Made with [Cursor](https://cursor.com)