### PR TITLE
fix: exclude soft-deleted patients from aggregates and block delete with open invoices (#242, #244)

### DIFF
--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -211,4 +211,26 @@ describe('AppointmentsService status machine', () => {
       );
     });
   });
+
+  describe('countAppointmentsToday', () => {
+    it('joins patients and excludes soft-deleted rows', async () => {
+      const qb = {
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(3),
+      };
+      appointmentsRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const count = await service.countAppointmentsToday('hospital-a');
+
+      expect(count).toBe(3);
+      expect(qb.innerJoin).toHaveBeenCalledWith('a.patient', 'patient');
+      expect(qb.andWhere).toHaveBeenCalledWith('patient.deleted_at IS NULL');
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'a.status NOT IN (:...excluded)',
+        { excluded: ['cancelled'] },
+      );
+    });
+  });
 });

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -368,10 +368,12 @@ export class AppointmentsService {
 
     return this.appointmentsRepo
       .createQueryBuilder('a')
+      .innerJoin('a.patient', 'patient')
       .where('a.hospital_id = :hospitalId', { hospitalId })
       .andWhere('a.scheduled_at >= :start', { start: today })
       .andWhere('a.scheduled_at < :end', { end: tomorrow })
       .andWhere('a.status NOT IN (:...excluded)', { excluded: ['cancelled'] })
+      .andWhere('patient.deleted_at IS NULL')
       .getCount();
   }
 }

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -179,4 +179,24 @@ describe('BillingService', () => {
       ).rejects.toThrow('Admission does not belong to the given patient');
     });
   });
+
+  describe('sumRevenue', () => {
+    it('joins invoice and patient and excludes soft-deleted patients', async () => {
+      const qb = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({ total: '125.50' }),
+      };
+      paymentsRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const total = await service.sumRevenue('hospital-a');
+
+      expect(total).toBe(125.5);
+      expect(qb.innerJoin).toHaveBeenCalledWith('payment.invoice', 'invoice');
+      expect(qb.innerJoin).toHaveBeenCalledWith('invoice.patient', 'patient');
+      expect(qb.andWhere).toHaveBeenCalledWith('patient.deleted_at IS NULL');
+    });
+  });
 });

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -152,7 +152,6 @@ export class BillingService {
       throw new BadRequestException('Invoice must have at least one item');
     }
 
-    await this.assertPatient(hospitalId, input.patientId);
     await this.assertAdmission(hospitalId, input.patientId, input.admissionId);
 
     const status = input.status ?? 'draft';
@@ -168,6 +167,16 @@ export class BillingService {
 
     const invoiceId = await this.invoicesRepo.manager.transaction(
       async (manager) => {
+        // Lock the live patient row so a concurrent soft-delete's open-invoice
+        // check (#244) serializes against this insert (same pattern as admit).
+        const patient = await manager
+          .createQueryBuilder(Patient, 'patient')
+          .setLock('pessimistic_write')
+          .where('patient.id = :id', { id: input.patientId })
+          .andWhere('patient.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!patient) throw new NotFoundException('Patient not found');
+
         const invoice = await manager.save(
           manager.create(Invoice, {
             hospitalId,

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -398,10 +398,15 @@ export class BillingService {
   }
 
   async sumRevenue(hospitalId: string): Promise<number> {
+    // Exclude payments whose patient has been soft-deleted so dashboard/report
+    // revenue matches invoice lists that already hide those patients (#244).
     const result = await this.paymentsRepo
       .createQueryBuilder('payment')
+      .innerJoin('payment.invoice', 'invoice')
+      .innerJoin('invoice.patient', 'patient')
       .select('COALESCE(SUM(payment.amount), 0)', 'total')
       .where('payment.hospital_id = :hospitalId', { hospitalId })
+      .andWhere('patient.deleted_at IS NULL')
       .getRawOne<{ total: string }>();
 
     return this.toNumber(result?.total);

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -2,10 +2,11 @@ import { BadRequestException, ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { existsSync } from 'fs';
-import { QueryFailedError } from 'typeorm';
+import { In, QueryFailedError } from 'typeorm';
 import {
   Admission,
   Appointment,
+  Invoice,
   LabOrder,
   Patient,
   PatientAllergy,
@@ -280,6 +281,60 @@ describe('PatientsService', () => {
       expect(audit.log).not.toHaveBeenCalled();
     });
 
+    it('refuses delete when open invoices exist under the patient lock', async () => {
+      const patient = {
+        id: 'patient-1',
+        hospitalId: 'hospital-1',
+        fullName: 'Jane Doe',
+      };
+      const patientQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(patient),
+      };
+      const invoiceFindOne = jest.fn().mockResolvedValue({
+        id: 'inv-1',
+        status: 'issued',
+      });
+      patientsRepo.manager.transaction.mockImplementation(
+        (cb: (m: Record<string, unknown>) => unknown) => {
+          const manager = {
+            createQueryBuilder: jest.fn().mockReturnValue(patientQb),
+            getRepository: (entity: unknown) => {
+              if (entity === Admission) {
+                return { findOne: jest.fn().mockResolvedValue(null) };
+              }
+              if (entity === Invoice) {
+                return { findOne: invoiceFindOne };
+              }
+              return {
+                save: jest.fn(),
+                softRemove: jest.fn(),
+                find: jest.fn().mockResolvedValue([]),
+                findOne: jest.fn().mockResolvedValue(null),
+                remove: jest.fn(),
+              };
+            },
+          };
+          return Promise.resolve(cb(manager));
+        },
+      );
+
+      await expect(
+        service.deletePatient('patient-1', 'hospital-1', actor),
+      ).rejects.toThrow(BadRequestException);
+      expect(invoiceFindOne).toHaveBeenCalledWith({
+        where: {
+          patientId: 'patient-1',
+          hospitalId: 'hospital-1',
+          status: In(['draft', 'issued']),
+        },
+      });
+      expect(patientQb.setLock).toHaveBeenCalledWith('pessimistic_write');
+      expect(audit.log).not.toHaveBeenCalled();
+    });
+
     it('cancels open Rx, labs, and appointments before soft-delete', async () => {
       const patient = {
         id: 'patient-1',
@@ -339,8 +394,12 @@ describe('PatientsService', () => {
               if (entity === LabOrder) {
                 return { find: labFind, save: labSave };
               }
+              if (entity === Invoice) {
+                return { findOne: jest.fn().mockResolvedValue(null) };
+              }
               return {
                 find: jest.fn().mockResolvedValue([]),
+                findOne: jest.fn().mockResolvedValue(null),
                 save: jest.fn(),
                 remove: jest.fn(),
               };

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -22,6 +22,7 @@ import {
   PatientMedication,
   Admission,
   Appointment,
+  Invoice,
   LabOrder,
   LabResult,
   Prescription,
@@ -422,6 +423,8 @@ export class PatientsService {
     // workflows (pending Rx, open labs, scheduled/checked-in appointments)
     // are cancelled in the same transaction so they cannot become invisible
     // and uncancelable after lists hide soft-deleted patients (#235).
+    // Open invoices (draft/issued) block delete so receivables are not stuck
+    // behind a 404 on pay/void (#244). Paid/void invoices are left as-is.
     // Lock the patient row and re-check active admissions inside the txn so a
     // concurrent admit cannot attach a live bed after the pre-check (#230).
     let previousUserId: string | undefined;
@@ -455,6 +458,20 @@ export class PatientsService {
       if (activeAdmission) {
         throw new BadRequestException(
           'Cannot delete a patient with an active admission; discharge first',
+        );
+      }
+
+      const invoicesRepo = manager.getRepository(Invoice);
+      const openInvoice = await invoicesRepo.findOne({
+        where: {
+          patientId: id,
+          hospitalId,
+          status: In(['draft', 'issued']),
+        },
+      });
+      if (openInvoice) {
+        throw new BadRequestException(
+          'Cannot delete a patient with open invoices; void or collect payment first',
         );
       }
 


### PR DESCRIPTION
## Summary
- **#242:** `countAppointmentsToday` now inner-joins patients and filters `patient.deleted_at IS NULL`, matching appointment list semantics (cancelled still excluded).
- **#244:** `sumRevenue` joins invoice → patient and omits payments for soft-deleted patients so revenue matches invoice lists.
- **#244 finance closeout:** `deletePatient` refuses soft-delete when draft/issued invoices exist (`BadRequestException`), same pattern as active admissions (#235). Paid/void invoices are left as-is; staff must void or collect first.

## Test plan
- [ ] Soft-delete a patient with a today appointment → dashboard/report today-count drops; appointment list already hid them
- [ ] Soft-delete a patient with only paid invoices → succeeds; `sumRevenue` no longer includes their payments
- [ ] Attempt soft-delete with a draft or issued invoice → `Cannot delete a patient with open invoices; void or collect payment first`
- [ ] After voiding/paying the open invoice, soft-delete succeeds
- [ ] Unit tests: `appointments.service.spec`, `billing.service.spec`, `patients.service.spec`

Closes #242
Closes #244

Made with [Cursor](https://cursor.com)