### PR TITLE
fix: require hospital context and REST RolesGuard for uploads (#239, #240)

### DIFF
--- a/apps/api/src/rbac/permissions-any.decorator.ts
+++ b/apps/api/src/rbac/permissions-any.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+/** Require ANY of the listed permissions (OR). Distinct from @Permissions AND. */
+export const PERMISSIONS_ANY_KEY = 'permissionsAny';
+export const PermissionsAny = (...permissions: string[]) =>
+  SetMetadata(PERMISSIONS_ANY_KEY, permissions);

--- a/apps/api/src/rbac/roles.guard.spec.ts
+++ b/apps/api/src/rbac/roles.guard.spec.ts
@@ -3,6 +3,7 @@ import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { ROLES_KEY } from './roles.decorator';
 import { PERMISSIONS_KEY } from './permissions.decorator';
+import { PERMISSIONS_ANY_KEY } from './permissions-any.decorator';
 import { RolesGuard } from './roles.guard';
 import type { AuthenticatedUser } from '../auth/auth.types';
 
@@ -10,15 +11,32 @@ describe('RolesGuard', () => {
   let guard: RolesGuard;
   let reflector: Reflector;
 
-  const createContext = (user?: AuthenticatedUser): ExecutionContext => {
+  const createGqlContext = (user?: AuthenticatedUser): ExecutionContext => {
     const gqlCtx = {
       getContext: () => ({ req: { user } }),
     };
     jest.spyOn(GqlExecutionContext, 'create').mockReturnValue(gqlCtx as never);
 
     return {
+      getType: () => 'graphql',
       getHandler: () => jest.fn(),
       getClass: () => jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => {
+          throw new Error('HTTP request should not be used for GraphQL');
+        },
+      }),
+    } as unknown as ExecutionContext;
+  };
+
+  const createHttpContext = (user?: AuthenticatedUser): ExecutionContext => {
+    return {
+      getType: () => 'http',
+      getHandler: () => jest.fn(),
+      getClass: () => jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
     } as unknown as ExecutionContext;
   };
 
@@ -35,7 +53,7 @@ describe('RolesGuard', () => {
   it('denies access when no roles or permissions are required', () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
 
-    expect(guard.canActivate(createContext())).toBe(false);
+    expect(guard.canActivate(createGqlContext())).toBe(false);
   });
 
   it('requires an authenticated user when AllowAuthenticated is set', () => {
@@ -44,10 +62,10 @@ describe('RolesGuard', () => {
       return undefined;
     });
 
-    expect(guard.canActivate(createContext())).toBe(false);
+    expect(guard.canActivate(createGqlContext())).toBe(false);
     expect(
       guard.canActivate(
-        createContext({
+        createGqlContext({
           id: 'u1',
           authId: 'a1',
           email: 'a@b.c',
@@ -68,7 +86,7 @@ describe('RolesGuard', () => {
         return undefined;
       });
 
-    expect(guard.canActivate(createContext())).toBe(false);
+    expect(guard.canActivate(createGqlContext())).toBe(false);
   });
 
   it('allows super_admin regardless of required roles', () => {
@@ -89,7 +107,7 @@ describe('RolesGuard', () => {
       onboardingCompleted: true,
     };
 
-    expect(guard.canActivate(createContext(user))).toBe(true);
+    expect(guard.canActivate(createGqlContext(user))).toBe(true);
   });
 
   it('checks required roles', () => {
@@ -113,8 +131,8 @@ describe('RolesGuard', () => {
 
     const nurse: AuthenticatedUser = { ...doctor, roles: ['nurse'] };
 
-    expect(guard.canActivate(createContext(doctor))).toBe(true);
-    expect(guard.canActivate(createContext(nurse))).toBe(false);
+    expect(guard.canActivate(createGqlContext(doctor))).toBe(true);
+    expect(guard.canActivate(createGqlContext(nurse))).toBe(false);
   });
 
   it('checks required permissions', () => {
@@ -136,10 +154,78 @@ describe('RolesGuard', () => {
       onboardingCompleted: true,
     };
 
-    expect(guard.canActivate(createContext(user))).toBe(false);
+    expect(guard.canActivate(createGqlContext(user))).toBe(false);
 
     user.permissions.push('patients:write');
-    expect(guard.canActivate(createContext(user))).toBe(true);
+    expect(guard.canActivate(createGqlContext(user))).toBe(true);
+  });
+
+  it('checks required any-permissions with OR semantics', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockImplementation((key: string) => {
+        if (key === PERMISSIONS_ANY_KEY) {
+          return ['patients:write', 'lab:write'];
+        }
+        return undefined;
+      });
+
+    const doctor: AuthenticatedUser = {
+      id: '5',
+      authId: 'auth-5',
+      email: 'doc@hospital.com',
+      fullName: 'Doctor',
+      hospitalId: 'h-1',
+      roles: ['doctor'],
+      permissions: ['patients:write'],
+      onboardingCompleted: true,
+    };
+
+    const labTech: AuthenticatedUser = {
+      ...doctor,
+      id: '6',
+      roles: ['lab_technician'],
+      permissions: ['lab:write'],
+    };
+
+    const receptionist: AuthenticatedUser = {
+      ...doctor,
+      id: '7',
+      roles: ['receptionist'],
+      permissions: ['appointments:write'],
+    };
+
+    expect(guard.canActivate(createGqlContext(doctor))).toBe(true);
+    expect(guard.canActivate(createGqlContext(labTech))).toBe(true);
+    expect(guard.canActivate(createGqlContext(receptionist))).toBe(false);
+  });
+
+  it('reads the user from HTTP request context for REST', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockImplementation((key: string) => {
+        if (key === PERMISSIONS_ANY_KEY) {
+          return ['patients:write', 'lab:write'];
+        }
+        return undefined;
+      });
+
+    const createSpy = jest.spyOn(GqlExecutionContext, 'create');
+
+    const allowed: AuthenticatedUser = {
+      id: '8',
+      authId: 'auth-8',
+      email: 'lab@hospital.com',
+      fullName: 'Lab',
+      hospitalId: 'h-1',
+      roles: ['lab_technician'],
+      permissions: ['lab:write'],
+      onboardingCompleted: true,
+    };
+
+    expect(guard.canActivate(createHttpContext(allowed))).toBe(true);
+    expect(guard.canActivate(createHttpContext())).toBe(false);
+    expect(createSpy).not.toHaveBeenCalled();
   });
 
   it('denies patient role on staff-only hospital list endpoints', () => {
@@ -173,6 +259,6 @@ describe('RolesGuard', () => {
       onboardingCompleted: true,
     };
 
-    expect(guard.canActivate(createContext(patient))).toBe(false);
+    expect(guard.canActivate(createGqlContext(patient))).toBe(false);
   });
 });

--- a/apps/api/src/rbac/roles.guard.ts
+++ b/apps/api/src/rbac/roles.guard.ts
@@ -3,6 +3,7 @@ import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { ROLES_KEY } from './roles.decorator';
 import { PERMISSIONS_KEY } from './permissions.decorator';
+import { PERMISSIONS_ANY_KEY } from './permissions-any.decorator';
 import { ALLOW_AUTHENTICATED_KEY } from './allow-authenticated.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import type { RoleSlug } from '@careconnect/types';
@@ -22,22 +23,30 @@ export class RolesGuard implements CanActivate {
       [context.getHandler(), context.getClass()],
     );
 
+    const requiredAnyPermissions = this.reflector.getAllAndOverride<string[]>(
+      PERMISSIONS_ANY_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
     const allowAuthenticated = this.reflector.getAllAndOverride<boolean>(
       ALLOW_AUTHENTICATED_KEY,
       [context.getHandler(), context.getClass()],
     );
 
-    const ctx = GqlExecutionContext.create(context);
-    const gqlContext = ctx.getContext<{ req: { user?: AuthenticatedUser } }>();
-    const user = gqlContext.req?.user;
+    const user = this.getUser(context);
 
     // Explicit bootstrap / invite paths: any authenticated JWT, service enforces.
     if (allowAuthenticated) {
       return !!user;
     }
 
-    // Fail closed: handlers must declare @Roles, @Permissions, or @AllowAuthenticated.
-    if (!requiredRoles?.length && !requiredPermissions?.length) {
+    // Fail closed: handlers must declare @Roles, @Permissions, @PermissionsAny,
+    // or @AllowAuthenticated.
+    if (
+      !requiredRoles?.length &&
+      !requiredPermissions?.length &&
+      !requiredAnyPermissions?.length
+    ) {
       return false;
     }
 
@@ -57,6 +66,27 @@ export class RolesGuard implements CanActivate {
       if (!hasPermission) return false;
     }
 
+    if (requiredAnyPermissions?.length) {
+      const hasAny = requiredAnyPermissions.some((perm) =>
+        user.permissions.includes(perm),
+      );
+      if (!hasAny) return false;
+    }
+
     return true;
+  }
+
+  /** Resolve the authenticated user from HTTP or GraphQL context (#240). */
+  private getUser(context: ExecutionContext): AuthenticatedUser | undefined {
+    if (context.getType<string>() === 'http') {
+      const req = context
+        .switchToHttp()
+        .getRequest<{ user?: AuthenticatedUser }>();
+      return req?.user;
+    }
+
+    const ctx = GqlExecutionContext.create(context);
+    const gqlContext = ctx.getContext<{ req: { user?: AuthenticatedUser } }>();
+    return gqlContext.req?.user;
   }
 }

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -3,6 +3,7 @@ import {
   Post,
   Get,
   Param,
+  Query,
   UploadedFile,
   UseGuards,
   UseInterceptors,
@@ -14,12 +15,16 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { AuthGuard } from '@nestjs/passport';
+import { PERMISSIONS } from '@careconnect/types';
 import { diskStorage } from 'multer';
 import { createReadStream, existsSync, mkdirSync } from 'fs';
 import { extname, join, basename } from 'path';
 import { randomUUID } from 'crypto';
 import type { Request, Response } from 'express';
 import type { AuthenticatedUser } from '../auth/auth.types';
+import { AllowAuthenticated } from '../rbac/allow-authenticated.decorator';
+import { PermissionsAny } from '../rbac/permissions-any.decorator';
+import { RolesGuard } from '../rbac/roles.guard';
 import { UploadsService } from './uploads.service';
 
 const UPLOAD_DIR = join(process.cwd(), 'uploads');
@@ -54,11 +59,12 @@ const INLINE_MIME = new Set([
 type AuthedRequest = Request & { user?: AuthenticatedUser };
 
 @Controller('uploads')
-@UseGuards(AuthGuard('clerk-jwt'))
+@UseGuards(AuthGuard('clerk-jwt'), RolesGuard)
 export class UploadsController {
   constructor(private readonly uploadsService: UploadsService) {}
 
   @Post('patient-documents')
+  @PermissionsAny(PERMISSIONS.PATIENTS_WRITE, PERMISSIONS.LAB_WRITE)
   @UseInterceptors(
     FileInterceptor('file', {
       storage: diskStorage({
@@ -70,7 +76,12 @@ export class UploadsController {
         filename: (_req, file, cb) => {
           const ext = MIME_TO_EXT[file.mimetype];
           if (!ext) {
-            cb(new BadRequestException(`Unsupported file type: ${file.mimetype}`), '');
+            cb(
+              new BadRequestException(
+                `Unsupported file type: ${file.mimetype}`,
+              ),
+              '',
+            );
             return;
           }
           // Ignore client original extension — store only allowlisted ext (#206).
@@ -89,7 +100,11 @@ export class UploadsController {
         const clientExt = extname(file.originalname).toLowerCase();
         const expected = MIME_TO_EXT[file.mimetype];
         // Reject obvious MIME/extension mismatches (e.g. .html claimed as pdf).
-        if (clientExt && clientExt !== expected && !(file.mimetype === 'image/jpeg' && clientExt === '.jpeg')) {
+        if (
+          clientExt &&
+          clientExt !== expected &&
+          !(file.mimetype === 'image/jpeg' && clientExt === '.jpeg')
+        ) {
           cb(
             new BadRequestException(
               `File extension ${clientExt} does not match type ${file.mimetype}`,
@@ -105,9 +120,10 @@ export class UploadsController {
   async uploadPatientDocument(
     @UploadedFile() file: Express.Multer.File,
     @Req() req: AuthedRequest,
+    @Query('hospitalId') hospitalId?: string,
   ) {
     if (!req.user) throw new ForbiddenException('Authentication required');
-    await this.uploadsService.assertCanUpload(req.user);
+    await this.uploadsService.assertCanUpload(req.user, hospitalId);
 
     if (!file) throw new BadRequestException('file is required');
     // Prefer configured public base; otherwise return a stable relative path
@@ -129,6 +145,7 @@ export class UploadsController {
    * Replaces public static serving of PHI; requires a matching patient_documents row.
    */
   @Get(':filename')
+  @AllowAuthenticated()
   async download(
     @Param('filename') filename: string,
     @Req() req: AuthedRequest,

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -139,6 +139,15 @@ describe('UploadsService', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('denies staff without hospitalId', async () => {
+      await expect(
+        service.assertCanUpload({
+          ...staffUser,
+          hospitalId: undefined,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
     it('denies patient role', async () => {
       await expect(service.assertCanUpload(patientUser)).rejects.toThrow(
         ForbiddenException,
@@ -190,7 +199,7 @@ describe('UploadsService', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
-    it('allows super_admin without hospitalId when hospital check cannot apply', async () => {
+    it('denies super_admin without hospital context', async () => {
       await expect(
         service.assertCanUpload({
           ...staffUser,
@@ -198,8 +207,58 @@ describe('UploadsService', () => {
           roles: ['super_admin'],
           permissions: [],
         }),
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow(ForbiddenException);
       expect(hospitalsRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('allows unbound super_admin when explicit hospitalId is active', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-b',
+        isActive: true,
+      });
+
+      await expect(
+        service.assertCanUpload(
+          {
+            ...staffUser,
+            hospitalId: undefined,
+            roles: ['super_admin'],
+            permissions: [],
+          },
+          'hospital-b',
+        ),
+      ).resolves.toBeUndefined();
+      expect(hospitalsRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'hospital-b' },
+      });
+    });
+
+    it('denies unbound super_admin when explicit hospitalId is inactive', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-b',
+        isActive: false,
+      });
+
+      await expect(
+        service.assertCanUpload(
+          {
+            ...staffUser,
+            hospitalId: undefined,
+            roles: ['super_admin'],
+            permissions: [],
+          },
+          'hospital-b',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('ignores hospitalId override for non-super_admin staff', async () => {
+      await expect(
+        service.assertCanUpload(staffUser, 'hospital-b'),
+      ).resolves.toBeUndefined();
+      expect(hospitalsRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'hospital-a' },
+      });
     });
   });
 
@@ -349,7 +408,7 @@ describe('UploadsService', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('allows super_admin across hospitals', async () => {
+    it('allows super_admin across active hospitals', async () => {
       mockDocLookup(document);
       patientsRepo.findOne.mockResolvedValue(patient);
 
@@ -361,6 +420,24 @@ describe('UploadsService', () => {
           permissions: [],
         }),
       ).resolves.toBeUndefined();
+    });
+
+    it('denies super_admin download when patient hospital is inactive', async () => {
+      mockDocLookup(document);
+      patientsRepo.findOne.mockResolvedValue(patient);
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: false,
+      });
+
+      await expect(
+        service.assertCanDownload('abc.pdf', {
+          ...staffUser,
+          roles: ['super_admin'],
+          hospitalId: undefined,
+          permissions: [],
+        }),
+      ).rejects.toThrow(ForbiddenException);
     });
   });
 

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -194,8 +194,9 @@ export class UploadsService implements OnApplicationBootstrap {
       throw new NotFoundException('File not found');
     }
 
-    if (user.roles.includes('super_admin')) return;
-
+    // Inactive-tenant policy (#239): hospital-scoped PHI is unavailable when the
+    // tenant is inactive — including for super_admin. No silent break-glass;
+    // reactivation (or an audited platform path) is required first.
     const hospital = await this.hospitalsRepo.findOne({
       where: { id: patient.hospitalId },
     });
@@ -204,6 +205,8 @@ export class UploadsService implements OnApplicationBootstrap {
         'This hospital is currently inactive; file access is unavailable',
       );
     }
+
+    if (user.roles.includes('super_admin')) return;
 
     const isHospitalStaff =
       !!user.hospitalId &&
@@ -224,19 +227,35 @@ export class UploadsService implements OnApplicationBootstrap {
 
   /**
    * Staff with patients:write or lab:write may upload files.
-   * Refuse when the actor's hospital is inactive (fail-closed, incl. super_admin
-   * with a hospitalId scoped to an inactive tenant).
+   *
+   * Inactive-tenant / hospital-context policy (#239):
+   * - Every upload (including super_admin) requires an active hospital context.
+   * - Context is `user.hospitalId`, or for unbound super_admin an explicit
+   *   `hospitalId` override (query/body) that resolves to an active hospital.
+   * - Inactive tenants cannot stage PHI; there is no unaudited break-glass path.
    */
-  async assertCanUpload(user: AuthenticatedUser): Promise<void> {
-    if (user.hospitalId) {
-      const hospital = await this.hospitalsRepo.findOne({
-        where: { id: user.hospitalId },
-      });
-      if (!hospital || !hospital.isActive) {
-        throw new ForbiddenException(
-          'This hospital is currently inactive; uploads are unavailable',
-        );
-      }
+  async assertCanUpload(
+    user: AuthenticatedUser,
+    hospitalIdOverride?: string,
+  ): Promise<void> {
+    const hospitalId =
+      user.roles.includes('super_admin') && hospitalIdOverride
+        ? hospitalIdOverride
+        : user.hospitalId;
+
+    if (!hospitalId) {
+      throw new ForbiddenException(
+        'Active hospital context is required to upload documents',
+      );
+    }
+
+    const hospital = await this.hospitalsRepo.findOne({
+      where: { id: hospitalId },
+    });
+    if (!hospital || !hospital.isActive) {
+      throw new ForbiddenException(
+        'This hospital is currently inactive; uploads are unavailable',
+      );
     }
 
     if (user.roles.includes('super_admin')) return;


### PR DESCRIPTION
## Summary
- **#239:** Uploads now require an active hospital context for everyone, including `super_admin`. Unbound platform admins must pass `?hospitalId=` pointing at an active tenant; missing or inactive hospital context is `403`. Downloads no longer short-circuit `super_admin` before the inactive-tenant check — hospital-scoped PHI stays locked while a tenant is inactive (no unaudited break-glass).
- **#240:** `RolesGuard` reads the user from the HTTP request when `context.getType() === 'http'`, so REST can use the same fail-closed guard as GraphQL. `/uploads` now uses `@UseGuards(AuthGuard('clerk-jwt'), RolesGuard)` with `@PermissionsAny(patients:write, lab:write)` on upload (runs before multer) and `@AllowAuthenticated()` on download (patients still download their own files; `assertCanDownload` remains defense in depth).

Closes #239
Closes #240

## Test plan
- [ ] `pnpm --filter api exec jest -- src/rbac/roles.guard.spec.ts src/uploads/uploads.service.spec.ts`
- [ ] Upload as hospital staff with `patients:write` or `lab:write` against an active hospital succeeds
- [ ] Upload as patient / receptionist (no write perms) is refused at the guard, before multer
- [ ] Upload as unbound `super_admin` without `hospitalId` is `403`
- [ ] Upload as unbound `super_admin` with `?hospitalId=` of an active hospital succeeds; inactive hospital is `403`
- [ ] Download of a file from an inactive hospital is `403` even for `super_admin`
- [ ] Patient can still download their own document from an active hospital


Made with [Cursor](https://cursor.com)