### PR TITLE
fix: add GraphQL query complexity limit (#238)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
     "class-validator": "^0.15.1",
     "graphql": "^16.14.1",
     "graphql-depth-limit": "^1.1.0",
+    "graphql-query-complexity": "^2.0.0",
     "jsonwebtoken": "^9.0.3",
     "jwks-rsa": "^4.0.1",
     "multer": "^2.2.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import depthLimit from 'graphql-depth-limit';
 import { join } from 'path';
 import type { Request, Response } from 'express';
+import { graphqlQueryComplexityPlugin } from './common/graphql-query-complexity.plugin';
 import { validateEnv } from './config/env.validation';
 import { AuthModule } from './auth/auth.module';
 import { AppThrottlerGuard } from './common/app-throttler.guard';
@@ -158,7 +159,9 @@ import { UploadsModule } from './uploads/uploads.module';
           // Playground + introspection only outside production.
           playground: !isProduction,
           introspection: !isProduction,
+          // Depth 10 (#207). Max complexity 1000 via graphql-query-complexity (#238).
           validationRules: [depthLimit(10)],
+          plugins: [graphqlQueryComplexityPlugin],
           context: ({ req, res }: { req: Request; res: Response }) => ({
             req,
             res,

--- a/apps/api/src/common/graphql-query-complexity.plugin.spec.ts
+++ b/apps/api/src/common/graphql-query-complexity.plugin.spec.ts
@@ -1,8 +1,9 @@
-import { buildSchema, GraphQLError, parse } from 'graphql';
+import { buildSchema, getOperationAST, GraphQLError, parse } from 'graphql';
 import {
   assertQueryWithinComplexityLimit,
   computeQueryComplexity,
   isIntrospectionDocument,
+  isPureIntrospectionOperation,
   MAX_GRAPHQL_QUERY_COMPLEXITY,
 } from './graphql-query-complexity.plugin';
 
@@ -11,6 +12,15 @@ const schema = buildSchema(`
     hello: String
   }
 `);
+
+function requireOperation(source: string, operationName?: string) {
+  const document = parse(source);
+  const operation = getOperationAST(document, operationName);
+  if (!operation) {
+    throw new Error(`Expected operation ${operationName ?? '(anonymous)'}`);
+  }
+  return { document, operation };
+}
 
 describe('graphql query complexity', () => {
   it('counts each selected field toward the budget', () => {
@@ -48,10 +58,61 @@ describe('graphql query complexity', () => {
     ).not.toThrow();
   });
 
-  it('treats GraphQL introspection as exempt', () => {
+  it('treats GraphQL schema introspection as exempt', () => {
     expect(
       isIntrospectionDocument(parse('{ __schema { queryType { name } } }')),
     ).toBe(true);
+    expect(
+      isIntrospectionDocument(parse('{ __type(name: "Query") { name } }')),
+    ).toBe(true);
     expect(isIntrospectionDocument(parse('{ hello }'))).toBe(false);
+  });
+
+  it('does not treat __typename as schema introspection', () => {
+    expect(isIntrospectionDocument(parse('{ __typename }'))).toBe(false);
+    expect(isIntrospectionDocument(parse('{ __typename hello }'))).toBe(false);
+
+    const { document, operation } = requireOperation('{ __typename hello }');
+    expect(isPureIntrospectionOperation(document, operation)).toBe(false);
+  });
+
+  it('does not exempt mixed introspection and data selections', () => {
+    expect(
+      isIntrospectionDocument(
+        parse('{ __schema { queryType { name } } hello }'),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not exempt mixed documents that also contain data operations', () => {
+    const source = `
+      query Intro { __schema { queryType { name } } }
+      query Normal { hello }
+    `;
+    const document = parse(source);
+    expect(isIntrospectionDocument(document)).toBe(false);
+
+    const intro = requireOperation(source, 'Intro');
+    const normal = requireOperation(source, 'Normal');
+    expect(isPureIntrospectionOperation(intro.document, intro.operation)).toBe(
+      true,
+    );
+    expect(
+      isPureIntrospectionOperation(normal.document, normal.operation),
+    ).toBe(false);
+  });
+
+  it('treats fragment-only schema introspection as exempt', () => {
+    const source = `
+      query Intro {
+        ...SchemaFields
+      }
+      fragment SchemaFields on Query {
+        __schema { queryType { name } }
+      }
+    `;
+    const { document, operation } = requireOperation(source, 'Intro');
+    expect(isPureIntrospectionOperation(document, operation)).toBe(true);
+    expect(isIntrospectionDocument(document)).toBe(true);
   });
 });

--- a/apps/api/src/common/graphql-query-complexity.plugin.spec.ts
+++ b/apps/api/src/common/graphql-query-complexity.plugin.spec.ts
@@ -1,0 +1,57 @@
+import { buildSchema, GraphQLError, parse } from 'graphql';
+import {
+  assertQueryWithinComplexityLimit,
+  computeQueryComplexity,
+  isIntrospectionDocument,
+  MAX_GRAPHQL_QUERY_COMPLEXITY,
+} from './graphql-query-complexity.plugin';
+
+const schema = buildSchema(`
+  type Query {
+    hello: String
+  }
+`);
+
+describe('graphql query complexity', () => {
+  it('counts each selected field toward the budget', () => {
+    const complexity = computeQueryComplexity({
+      schema,
+      query: parse('{ hello }'),
+    });
+    expect(complexity).toBe(1);
+  });
+
+  it('rejects queries over MAX_GRAPHQL_QUERY_COMPLEXITY', () => {
+    const aliases = Array.from(
+      { length: MAX_GRAPHQL_QUERY_COMPLEXITY + 1 },
+      (_, i) => `a${i}: hello`,
+    ).join('\n');
+    const complexity = computeQueryComplexity({
+      schema,
+      query: parse(`{ ${aliases} }`),
+    });
+    expect(complexity).toBe(MAX_GRAPHQL_QUERY_COMPLEXITY + 1);
+    expect(() => assertQueryWithinComplexityLimit(complexity)).toThrow(
+      GraphQLError,
+    );
+    try {
+      assertQueryWithinComplexityLimit(complexity);
+    } catch (error) {
+      expect(error).toBeInstanceOf(GraphQLError);
+      expect((error as GraphQLError).extensions.code).toBe('QUERY_TOO_COMPLEX');
+    }
+  });
+
+  it('allows queries at the maximum complexity', () => {
+    expect(() =>
+      assertQueryWithinComplexityLimit(MAX_GRAPHQL_QUERY_COMPLEXITY),
+    ).not.toThrow();
+  });
+
+  it('treats GraphQL introspection as exempt', () => {
+    expect(
+      isIntrospectionDocument(parse('{ __schema { queryType { name } } }')),
+    ).toBe(true);
+    expect(isIntrospectionDocument(parse('{ hello }'))).toBe(false);
+  });
+});

--- a/apps/api/src/common/graphql-query-complexity.plugin.ts
+++ b/apps/api/src/common/graphql-query-complexity.plugin.ts
@@ -1,0 +1,86 @@
+import type { ApolloServerPlugin } from '@apollo/server';
+import {
+  GraphQLError,
+  Kind,
+  type DocumentNode,
+  type GraphQLSchema,
+} from 'graphql';
+import {
+  fieldExtensionsEstimator,
+  getComplexity,
+  simpleEstimator,
+} from 'graphql-query-complexity';
+
+/**
+ * Maximum GraphQL query complexity (simpleEstimator: 1 per field by default).
+ * Field-level overrides can be set via GraphQL field extensions `{ complexity }`.
+ * Depth is separately capped at 10 via graphql-depth-limit (#207 / #238).
+ */
+export const MAX_GRAPHQL_QUERY_COMPLEXITY = 1000;
+
+export function isIntrospectionDocument(document: DocumentNode): boolean {
+  return document.definitions.some((definition) => {
+    if (definition.kind !== Kind.OPERATION_DEFINITION) {
+      return false;
+    }
+    return definition.selectionSet.selections.some(
+      (selection) =>
+        selection.kind === Kind.FIELD && selection.name.value.startsWith('__'),
+    );
+  });
+}
+
+export function computeQueryComplexity(options: {
+  schema: GraphQLSchema;
+  query: DocumentNode;
+  variables?: Record<string, unknown> | null;
+  operationName?: string | null;
+}): number {
+  return getComplexity({
+    schema: options.schema,
+    query: options.query,
+    variables: options.variables ?? undefined,
+    operationName: options.operationName ?? undefined,
+    estimators: [
+      fieldExtensionsEstimator(),
+      simpleEstimator({ defaultComplexity: 1 }),
+    ],
+  });
+}
+
+export function assertQueryWithinComplexityLimit(complexity: number): void {
+  if (complexity > MAX_GRAPHQL_QUERY_COMPLEXITY) {
+    throw new GraphQLError(
+      `Query is too complex: ${complexity}. Maximum allowed complexity: ${MAX_GRAPHQL_QUERY_COMPLEXITY}`,
+      {
+        extensions: {
+          code: 'QUERY_TOO_COMPLEX',
+          complexity,
+          maximumComplexity: MAX_GRAPHQL_QUERY_COMPLEXITY,
+        },
+      },
+    );
+  }
+}
+
+export const graphqlQueryComplexityPlugin: ApolloServerPlugin = {
+  requestDidStart() {
+    return Promise.resolve({
+      didResolveOperation({ request, document, schema }) {
+        if (isIntrospectionDocument(document)) {
+          return Promise.resolve();
+        }
+
+        const complexity = computeQueryComplexity({
+          schema,
+          query: document,
+          variables: request.variables,
+          operationName: request.operationName,
+        });
+
+        assertQueryWithinComplexityLimit(complexity);
+        return Promise.resolve();
+      },
+    });
+  },
+};

--- a/apps/api/src/common/graphql-query-complexity.plugin.ts
+++ b/apps/api/src/common/graphql-query-complexity.plugin.ts
@@ -2,8 +2,12 @@ import type { ApolloServerPlugin } from '@apollo/server';
 import {
   GraphQLError,
   Kind,
+  getOperationAST,
   type DocumentNode,
+  type FragmentDefinitionNode,
   type GraphQLSchema,
+  type OperationDefinitionNode,
+  type SelectionSetNode,
 } from 'graphql';
 import {
   fieldExtensionsEstimator,
@@ -18,16 +22,110 @@ import {
  */
 export const MAX_GRAPHQL_QUERY_COMPLEXITY = 1000;
 
-export function isIntrospectionDocument(document: DocumentNode): boolean {
-  return document.definitions.some((definition) => {
-    if (definition.kind !== Kind.OPERATION_DEFINITION) {
-      return false;
+const INTROSPECTION_ROOT_FIELDS = new Set(['__schema', '__type']);
+
+function getFragmentMap(
+  document: DocumentNode,
+): Map<string, FragmentDefinitionNode> {
+  const fragments = new Map<string, FragmentDefinitionNode>();
+  for (const definition of document.definitions) {
+    if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+      fragments.set(definition.name.value, definition);
     }
-    return definition.selectionSet.selections.some(
-      (selection) =>
-        selection.kind === Kind.FIELD && selection.name.value.startsWith('__'),
-    );
-  });
+  }
+  return fragments;
+}
+
+/**
+ * Collects root field names from an operation, resolving fragment spreads.
+ * Returns null when a spread cannot be resolved so callers fail closed.
+ */
+function collectRootFieldNames(
+  selectionSet: SelectionSetNode,
+  fragments: Map<string, FragmentDefinitionNode>,
+  visitedFragments: Set<string> = new Set(),
+): string[] | null {
+  const fieldNames: string[] = [];
+
+  for (const selection of selectionSet.selections) {
+    switch (selection.kind) {
+      case Kind.FIELD:
+        fieldNames.push(selection.name.value);
+        break;
+      case Kind.INLINE_FRAGMENT: {
+        const nested = collectRootFieldNames(
+          selection.selectionSet,
+          fragments,
+          visitedFragments,
+        );
+        if (nested === null) {
+          return null;
+        }
+        fieldNames.push(...nested);
+        break;
+      }
+      case Kind.FRAGMENT_SPREAD: {
+        const fragmentName = selection.name.value;
+        if (visitedFragments.has(fragmentName)) {
+          break;
+        }
+        visitedFragments.add(fragmentName);
+        const fragment = fragments.get(fragmentName);
+        if (!fragment) {
+          return null;
+        }
+        const nested = collectRootFieldNames(
+          fragment.selectionSet,
+          fragments,
+          visitedFragments,
+        );
+        if (nested === null) {
+          return null;
+        }
+        fieldNames.push(...nested);
+        break;
+      }
+      default:
+        return null;
+    }
+  }
+
+  return fieldNames;
+}
+
+/**
+ * True only when every root field on this operation is schema introspection
+ * (`__schema` or `__type`). `__typename` and mixed data queries are not exempt.
+ */
+export function isPureIntrospectionOperation(
+  document: DocumentNode,
+  operation: OperationDefinitionNode,
+): boolean {
+  const fieldNames = collectRootFieldNames(
+    operation.selectionSet,
+    getFragmentMap(document),
+  );
+  if (fieldNames === null || fieldNames.length === 0) {
+    return false;
+  }
+  return fieldNames.every((name) => INTROSPECTION_ROOT_FIELDS.has(name));
+}
+
+/**
+ * True when every operation in the document is pure schema introspection.
+ * Mixed documents (introspection + data) are not exempt.
+ */
+export function isIntrospectionDocument(document: DocumentNode): boolean {
+  const operations = document.definitions.filter(
+    (definition): definition is OperationDefinitionNode =>
+      definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  if (operations.length === 0) {
+    return false;
+  }
+  return operations.every((operation) =>
+    isPureIntrospectionOperation(document, operation),
+  );
 }
 
 export function computeQueryComplexity(options: {
@@ -66,8 +164,26 @@ export function assertQueryWithinComplexityLimit(complexity: number): void {
 export const graphqlQueryComplexityPlugin: ApolloServerPlugin = {
   requestDidStart() {
     return Promise.resolve({
-      didResolveOperation({ request, document, schema }) {
-        if (isIntrospectionDocument(document)) {
+      didResolveOperation({
+        request,
+        document,
+        schema,
+        operation,
+        operationName,
+      }) {
+        const resolvedOperation =
+          operation ??
+          getOperationAST(
+            document,
+            operationName ?? request.operationName ?? undefined,
+          );
+
+        // Skip the budget only for the resolved operation, and only when it is
+        // purely schema introspection. Normal operations always pay complexity.
+        if (
+          resolvedOperation &&
+          isPureIntrospectionOperation(document, resolvedOperation)
+        ) {
           return Promise.resolve();
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       graphql-depth-limit:
         specifier: ^1.1.0
         version: 1.1.0(graphql@16.14.1)
+      graphql-query-complexity:
+        specifier: ^2.0.0
+        version: 2.0.0(graphql@16.14.1)
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -3772,6 +3775,11 @@ packages:
     peerDependencies:
       graphql: '*'
 
+  graphql-query-complexity@2.0.0:
+    resolution: {integrity: sha512-gmdNp8Lq3KbJcWeX9mpIqpIxD2oDEVO5QgZtw7eiDB7Q1RYMlqDFQnGq6ZcaDclBNcwTnyOCHUtEr3qAjnUDVg==}
+    peerDependencies:
+      graphql: ^16.6.0 || ^17.0.0
+
   graphql-tag@2.12.6:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
@@ -4412,6 +4420,10 @@ packages:
 
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -9648,6 +9660,11 @@ snapshots:
       arrify: 1.0.1
       graphql: 16.14.1
 
+  graphql-query-complexity@2.0.0(graphql@16.14.1):
+    dependencies:
+      graphql: 16.14.1
+      lodash.get: 4.4.2
+
   graphql-tag@2.12.6(graphql@16.14.1):
     dependencies:
       graphql: 16.14.1
@@ -10445,6 +10462,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.clonedeep@4.5.0: {}
+
+  lodash.get@4.4.2: {}
 
   lodash.includes@4.3.0: {}
 


### PR DESCRIPTION
## Summary
- Adds `graphql-query-complexity` and an Apollo Server 5 plugin that rejects queries whose field cost exceeds **1000** (`QUERY_TOO_COMPLEX`).
- Keeps existing `depthLimit(10)` and IP throttling from #207; documents the max complexity in `app.module.ts`.
- Introspection queries are exempt so the playground still works in non-production.

Fixes #238

## Test plan
- [ ] API still serves a normal nested GraphQL query (well under 1000 fields)
- [ ] A wide aliased query with 1001+ fields is rejected with `QUERY_TOO_COMPLEX`
- [ ] GraphQL playground/introspection still loads in development
- [ ] `pnpm --filter api exec jest src/common/graphql-query-complexity.plugin.spec.ts` passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GraphQL query complexity controls to help prevent excessively expensive queries.
  * Added structured errors when queries exceed the complexity limit.
  * Schema introspection-only requests remain available without complexity restrictions.

* **Bug Fixes**
  * Improved handling of introspection queries, including fragment-based requests and mixed data selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->