### PR TITLE
fix: pharmacy dispense quantity and stock OCC (#243, #245)

### DIFF
--- a/apps/api/src/clinical/clinical.service.ts
+++ b/apps/api/src/clinical/clinical.service.ts
@@ -217,6 +217,7 @@ export class ClinicalService {
       items: (prescription.items ?? []).map((item) => ({
         id: item.id,
         drugName: item.drugName,
+        quantity: Number(item.quantity) || 1,
         dosage: item.dosage,
         frequency: item.frequency,
         duration: item.duration,
@@ -412,6 +413,7 @@ export class ClinicalService {
             manager.create(PrescriptionItem, {
               prescriptionId: prescription.id,
               drugName: item.drugName,
+              quantity: (item.quantity ?? 1).toFixed(2),
               dosage: item.dosage,
               frequency: item.frequency,
               duration: item.duration,

--- a/apps/api/src/clinical/clinical.types.ts
+++ b/apps/api/src/clinical/clinical.types.ts
@@ -10,11 +10,13 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  Max,
   Min,
   MinLength,
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { NUMERIC_10_2_MAX } from '../common/money';
 import { PatientType } from '../patients/patients.types';
 import { UserSummaryType } from '../users/users.types';
 import { LAB_ORDER_STATUSES } from '../database/entities/lab-order.entity';
@@ -375,6 +377,7 @@ export class PrescriptionItemInput {
   @IsOptional()
   @IsNumber()
   @Min(0.01)
+  @Max(NUMERIC_10_2_MAX)
   quantity?: number;
 
   @Field({ nullable: true })

--- a/apps/api/src/clinical/clinical.types.ts
+++ b/apps/api/src/clinical/clinical.types.ts
@@ -6,9 +6,11 @@ import {
   IsBoolean,
   IsIn,
   IsInt,
+  IsNumber,
   IsOptional,
   IsString,
   IsUUID,
+  Min,
   MinLength,
   ValidateNested,
 } from 'class-validator';
@@ -131,6 +133,9 @@ export class PrescriptionItemType {
 
   @Field()
   drugName: string;
+
+  @Field(() => Float)
+  quantity: number;
 
   @Field({ nullable: true })
   dosage?: string;
@@ -365,6 +370,12 @@ export class PrescriptionItemInput {
   @IsString()
   @MinLength(1)
   drugName: string;
+
+  @Field(() => Float, { nullable: true })
+  @IsOptional()
+  @IsNumber()
+  @Min(0.01)
+  quantity?: number;
 
   @Field({ nullable: true })
   @IsOptional()

--- a/apps/api/src/common/money.spec.ts
+++ b/apps/api/src/common/money.spec.ts
@@ -1,0 +1,21 @@
+import { NUMERIC_10_2_MAX, roundMoney } from './money';
+
+describe('roundMoney', () => {
+  it('rounds classic float sums to 2 decimal places', () => {
+    expect(roundMoney(0.1 + 0.2)).toBe(0.3);
+  });
+
+  it('preserves exact hundredths', () => {
+    expect(roundMoney(10.1)).toBe(10.1);
+    expect(roundMoney(10.12)).toBe(10.12);
+  });
+
+  it('rounds to the nearest cent', () => {
+    expect(roundMoney(1.006)).toBe(1.01);
+    expect(roundMoney(1.004)).toBe(1);
+  });
+
+  it('matches NUMERIC(10, 2) max after rounding', () => {
+    expect(roundMoney(NUMERIC_10_2_MAX)).toBe(99_999_999.99);
+  });
+});

--- a/apps/api/src/common/money.ts
+++ b/apps/api/src/common/money.ts
@@ -1,0 +1,7 @@
+/** Maximum value storable in PostgreSQL NUMERIC(10, 2). */
+export const NUMERIC_10_2_MAX = 99_999_999.99;
+
+/** Round to 2 decimal places (NUMERIC(10, 2) / money scale). */
+export function roundMoney(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/apps/api/src/database/entities/prescription-item.entity.ts
+++ b/apps/api/src/database/entities/prescription-item.entity.ts
@@ -22,6 +22,9 @@ export class PrescriptionItem {
   @Column({ name: 'drug_name', length: 255 })
   drugName: string;
 
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 1 })
+  quantity: string;
+
   @Column({ length: 100, nullable: true })
   dosage?: string;
 

--- a/apps/api/src/pharmacy/pharmacy.service.spec.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { PharmacyStock, Prescription } from '../database/entities';
@@ -16,6 +16,7 @@ describe('PharmacyService', () => {
       id: 'patient-1',
       hospitalId: 'hospital-a',
     }),
+    create: jest.fn((_entity: unknown, data: unknown) => data),
   };
 
   const pharmacyStockRepo = {
@@ -24,6 +25,11 @@ describe('PharmacyService', () => {
     save: jest.fn(),
     create: jest.fn(),
     createQueryBuilder: jest.fn(),
+    manager: {
+      transaction: jest.fn((cb: (m: typeof manager) => unknown) =>
+        Promise.resolve(cb(manager)),
+      ),
+    },
   };
   const prescriptionsRepo = {
     find: jest.fn(),
@@ -79,7 +85,7 @@ describe('PharmacyService', () => {
           hospitalId: 'hospital-a',
           patientId: 'patient-1',
           status: 'pending',
-          items: [{ drugName: 'Amoxicillin' }],
+          items: [{ drugName: 'Amoxicillin', quantity: '1.00' }],
         }),
       };
       const stockQb = {
@@ -101,7 +107,7 @@ describe('PharmacyService', () => {
       ).rejects.toThrow('No pharmacy stock found for "Amoxicillin"');
     });
 
-    it('rejects when stock quantity is insufficient', async () => {
+    it('rejects when stock quantity is insufficient for line quantities', async () => {
       const rxQb = {
         setLock: jest.fn().mockReturnThis(),
         leftJoinAndSelect: jest.fn().mockReturnThis(),
@@ -112,7 +118,7 @@ describe('PharmacyService', () => {
           hospitalId: 'hospital-a',
           patientId: 'patient-1',
           status: 'pending',
-          items: [{ drugName: 'Amoxicillin' }, { drugName: 'Amoxicillin' }],
+          items: [{ drugName: 'Amoxicillin', quantity: '3.00' }],
         }),
       };
       const stockQb = {
@@ -138,7 +144,63 @@ describe('PharmacyService', () => {
       ).rejects.toThrow(/Insufficient stock/);
     });
 
-    it('decrements stock and marks dispensed when sufficient', async () => {
+    it('decrements stock by prescription item quantity when sufficient', async () => {
+      const stock = {
+        id: 'stock-1',
+        drugName: 'Amoxicillin',
+        quantity: '10.00',
+      };
+      const rxQb = {
+        setLock: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          patientId: 'patient-1',
+          status: 'pending',
+          items: [{ drugName: 'Amoxicillin', quantity: '3.00' }],
+          patient: null,
+        }),
+      };
+      const stockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(stock),
+      };
+      manager.createQueryBuilder
+        .mockReturnValueOnce(rxQb)
+        .mockReturnValueOnce(stockQb);
+      manager.save
+        .mockResolvedValueOnce({ ...stock, quantity: '7.00' })
+        .mockResolvedValueOnce({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          status: 'dispensed',
+          items: [{ drugName: 'Amoxicillin', quantity: '3.00' }],
+        });
+      prescriptionsRepo.findOne.mockResolvedValue({
+        id: 'rx-1',
+        hospitalId: 'hospital-a',
+        status: 'dispensed',
+        items: [{ drugName: 'Amoxicillin', quantity: '3.00' }],
+        patient: null,
+      });
+
+      const result = await service.dispensePrescription(
+        'hospital-a',
+        { prescriptionId: 'rx-1' },
+        actor,
+      );
+
+      expect(stock.quantity).toBe('7.00');
+      expect(result.status).toBe('dispensed');
+      expect(audit.log).toHaveBeenCalled();
+    });
+
+    it('defaults missing item quantity to 1 when decrementing', async () => {
       const stock = {
         id: 'stock-1',
         drugName: 'Amoxicillin',
@@ -183,15 +245,13 @@ describe('PharmacyService', () => {
         patient: null,
       });
 
-      const result = await service.dispensePrescription(
+      await service.dispensePrescription(
         'hospital-a',
         { prescriptionId: 'rx-1' },
         actor,
       );
 
       expect(stock.quantity).toBe('4.00');
-      expect(result.status).toBe('dispensed');
-      expect(audit.log).toHaveBeenCalled();
     });
 
     it('throws NotFound when prescription missing', async () => {
@@ -211,6 +271,72 @@ describe('PharmacyService', () => {
           actor,
         ),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('upsertPharmacyStock optimistic concurrency', () => {
+    it('throws ConflictException when expectedQuantity mismatches', async () => {
+      const stockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'stock-1',
+          drugName: 'Amoxicillin',
+          quantity: '9.00',
+          unit: 'each',
+        }),
+      };
+      manager.createQueryBuilder.mockReturnValueOnce(stockQb);
+
+      await expect(
+        service.upsertPharmacyStock(
+          'hospital-a',
+          {
+            drugName: 'Amoxicillin',
+            quantity: 20,
+            expectedQuantity: 10,
+          },
+          actor,
+        ),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('updates when expectedQuantity matches locked row', async () => {
+      const existing = {
+        id: 'stock-1',
+        hospitalId: 'hospital-a',
+        drugName: 'Amoxicillin',
+        quantity: '10.00',
+        unit: 'each',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const stockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(existing),
+      };
+      manager.createQueryBuilder.mockReturnValueOnce(stockQb);
+      manager.save.mockResolvedValue({
+        ...existing,
+        quantity: '20.00',
+      });
+
+      const result = await service.upsertPharmacyStock(
+        'hospital-a',
+        {
+          drugName: 'Amoxicillin',
+          quantity: 20,
+          expectedQuantity: 10,
+        },
+        actor,
+      );
+
+      expect(existing.quantity).toBe('20.00');
+      expect(result.quantity).toBe(20);
+      expect(audit.log).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/pharmacy/pharmacy.service.spec.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.spec.ts
@@ -254,6 +254,69 @@ describe('PharmacyService', () => {
       expect(stock.quantity).toBe('4.00');
     });
 
+    it('aggregates same-drug line quantities at 2 decimal places', async () => {
+      const stock = {
+        id: 'stock-1',
+        drugName: 'Amoxicillin',
+        quantity: '0.30',
+      };
+      const rxQb = {
+        setLock: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          patientId: 'patient-1',
+          status: 'pending',
+          items: [
+            { drugName: 'Amoxicillin', quantity: '0.10' },
+            { drugName: 'Amoxicillin', quantity: '0.20' },
+          ],
+          patient: null,
+        }),
+      };
+      const stockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(stock),
+      };
+      manager.createQueryBuilder
+        .mockReturnValueOnce(rxQb)
+        .mockReturnValueOnce(stockQb);
+      manager.save
+        .mockResolvedValueOnce({ ...stock, quantity: '0.00' })
+        .mockResolvedValueOnce({
+          id: 'rx-1',
+          hospitalId: 'hospital-a',
+          status: 'dispensed',
+          items: [
+            { drugName: 'Amoxicillin', quantity: '0.10' },
+            { drugName: 'Amoxicillin', quantity: '0.20' },
+          ],
+        });
+      prescriptionsRepo.findOne.mockResolvedValue({
+        id: 'rx-1',
+        hospitalId: 'hospital-a',
+        status: 'dispensed',
+        items: [
+          { drugName: 'Amoxicillin', quantity: '0.10' },
+          { drugName: 'Amoxicillin', quantity: '0.20' },
+        ],
+        patient: null,
+      });
+
+      await service.dispensePrescription(
+        'hospital-a',
+        { prescriptionId: 'rx-1' },
+        actor,
+      );
+
+      expect(stock.quantity).toBe('0.00');
+    });
+
     it('throws NotFound when prescription missing', async () => {
       const rxQb = {
         setLock: jest.fn().mockReturnThis(),
@@ -337,6 +400,42 @@ describe('PharmacyService', () => {
       expect(existing.quantity).toBe('20.00');
       expect(result.quantity).toBe(20);
       expect(audit.log).toHaveBeenCalled();
+    });
+
+    it('treats expectedQuantity as equal at 2 decimal places', async () => {
+      const existing = {
+        id: 'stock-1',
+        hospitalId: 'hospital-a',
+        drugName: 'Amoxicillin',
+        quantity: '0.30',
+        unit: 'each',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const stockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(existing),
+      };
+      manager.createQueryBuilder.mockReturnValueOnce(stockQb);
+      manager.save.mockResolvedValue({
+        ...existing,
+        quantity: '1.00',
+      });
+
+      const result = await service.upsertPharmacyStock(
+        'hospital-a',
+        {
+          drugName: 'Amoxicillin',
+          quantity: 1,
+          expectedQuantity: 0.1 + 0.2,
+        },
+        actor,
+      );
+
+      expect(existing.quantity).toBe('1.00');
+      expect(result.quantity).toBe(1);
     });
   });
 });

--- a/apps/api/src/pharmacy/pharmacy.service.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.ts
@@ -10,6 +10,7 @@ import { Repository } from 'typeorm';
 import { PharmacyStock, Prescription, Patient } from '../database/entities';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuditService } from '../audit/audit.service';
+import { roundMoney } from '../common/money';
 import {
   DispensePrescriptionInput,
   PendingPrescriptionType,
@@ -44,7 +45,15 @@ export class PharmacyService {
 
   private toNumber(value: string | number | undefined | null): number {
     if (value == null) return 0;
-    return Number(value);
+    return roundMoney(Number(value));
+  }
+
+  /** NUMERIC(10, 2) equality — avoids raw float `!==` on quantities. */
+  private quantitiesEqual(
+    a: string | number | undefined | null,
+    b: string | number | undefined | null,
+  ): boolean {
+    return roundMoney(this.toNumber(a)) === roundMoney(this.toNumber(b));
   }
 
   toPharmacyStockType(stock: PharmacyStock): PharmacyStockType {
@@ -87,7 +96,7 @@ export class PharmacyService {
       items: (prescription.items ?? []).map((item) => ({
         id: item.id,
         drugName: item.drugName,
-        quantity: Number(item.quantity) || 1,
+        quantity: roundMoney(Number(item.quantity) || 1),
         dosage: item.dosage,
         frequency: item.frequency,
         duration: item.duration,
@@ -129,14 +138,13 @@ export class PharmacyService {
         if (existing) {
           if (
             input.expectedQuantity != null &&
-            this.toNumber(existing.quantity) !==
-              this.toNumber(input.expectedQuantity)
+            !this.quantitiesEqual(existing.quantity, input.expectedQuantity)
           ) {
             throw new ConflictException(
               'Pharmacy stock was modified concurrently; refresh and try again',
             );
           }
-          existing.quantity = input.quantity.toFixed(2);
+          existing.quantity = roundMoney(input.quantity).toFixed(2);
           if (input.unit) existing.unit = input.unit;
           return { stock: await manager.save(existing), created: false };
         }
@@ -146,7 +154,7 @@ export class PharmacyService {
             manager.create(PharmacyStock, {
               hospitalId,
               drugName,
-              quantity: input.quantity.toFixed(2),
+              quantity: roundMoney(input.quantity).toFixed(2),
               unit: input.unit ?? 'each',
             }),
           );
@@ -171,14 +179,13 @@ export class PharmacyService {
           if (!raced) throw error;
           if (
             input.expectedQuantity != null &&
-            this.toNumber(raced.quantity) !==
-              this.toNumber(input.expectedQuantity)
+            !this.quantitiesEqual(raced.quantity, input.expectedQuantity)
           ) {
             throw new ConflictException(
               'Pharmacy stock was modified concurrently; refresh and try again',
             );
           }
-          raced.quantity = input.quantity.toFixed(2);
+          raced.quantity = roundMoney(input.quantity).toFixed(2);
           if (input.unit) raced.unit = input.unit;
           return { stock: await manager.save(raced), created: false };
         }
@@ -256,10 +263,10 @@ export class PharmacyService {
         >();
         for (const item of items) {
           const key = item.drugName.trim().toLowerCase();
-          const lineQty = Number(item.quantity) || 1;
+          const lineQty = roundMoney(Number(item.quantity) || 1);
           const existing = requiredByDrug.get(key);
           if (existing) {
-            existing.qty += lineQty;
+            existing.qty = roundMoney(existing.qty + lineQty);
           } else {
             requiredByDrug.set(key, {
               label: item.drugName.trim(),
@@ -282,14 +289,15 @@ export class PharmacyService {
             );
           }
 
-          const available = this.toNumber(stock.quantity);
-          if (available < qty) {
+          const available = roundMoney(this.toNumber(stock.quantity));
+          const needed = roundMoney(qty);
+          if (available < needed) {
             throw new BadRequestException(
-              `Insufficient stock for "${label}": need ${qty}, have ${available}`,
+              `Insufficient stock for "${label}": need ${needed}, have ${available}`,
             );
           }
 
-          stock.quantity = (available - qty).toFixed(2);
+          stock.quantity = roundMoney(available - needed).toFixed(2);
           await manager.save(stock);
         }
 

--- a/apps/api/src/pharmacy/pharmacy.service.ts
+++ b/apps/api/src/pharmacy/pharmacy.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -86,6 +87,7 @@ export class PharmacyService {
       items: (prescription.items ?? []).map((item) => ({
         id: item.id,
         drugName: item.drugName,
+        quantity: Number(item.quantity) || 1,
         dosage: item.dosage,
         frequency: item.frequency,
         duration: item.duration,
@@ -125,6 +127,15 @@ export class PharmacyService {
           .getOne();
 
         if (existing) {
+          if (
+            input.expectedQuantity != null &&
+            this.toNumber(existing.quantity) !==
+              this.toNumber(input.expectedQuantity)
+          ) {
+            throw new ConflictException(
+              'Pharmacy stock was modified concurrently; refresh and try again',
+            );
+          }
           existing.quantity = input.quantity.toFixed(2);
           if (input.unit) existing.unit = input.unit;
           return { stock: await manager.save(existing), created: false };
@@ -158,6 +169,15 @@ export class PharmacyService {
             .andWhere('LOWER(stock.drug_name) = LOWER(:drugName)', { drugName })
             .getOne();
           if (!raced) throw error;
+          if (
+            input.expectedQuantity != null &&
+            this.toNumber(raced.quantity) !==
+              this.toNumber(input.expectedQuantity)
+          ) {
+            throw new ConflictException(
+              'Pharmacy stock was modified concurrently; refresh and try again',
+            );
+          }
           raced.quantity = input.quantity.toFixed(2);
           if (input.unit) raced.unit = input.unit;
           return { stock: await manager.save(raced), created: false };
@@ -229,18 +249,22 @@ export class PharmacyService {
           );
         }
 
-        // Aggregate required units by normalized drug name (1 unit per line item)
+        // Aggregate required units by normalized drug name using line quantity
         const requiredByDrug = new Map<
           string,
           { label: string; qty: number }
         >();
         for (const item of items) {
           const key = item.drugName.trim().toLowerCase();
+          const lineQty = Number(item.quantity) || 1;
           const existing = requiredByDrug.get(key);
           if (existing) {
-            existing.qty += 1;
+            existing.qty += lineQty;
           } else {
-            requiredByDrug.set(key, { label: item.drugName.trim(), qty: 1 });
+            requiredByDrug.set(key, {
+              label: item.drugName.trim(),
+              qty: lineQty,
+            });
           }
         }
 

--- a/apps/api/src/pharmacy/pharmacy.types.ts
+++ b/apps/api/src/pharmacy/pharmacy.types.ts
@@ -82,6 +82,13 @@ export class UpsertPharmacyStockInput {
   @Min(0)
   quantity: number;
 
+  /** When set on update, must match the locked row quantity (optimistic concurrency). */
+  @Field(() => Float, { nullable: true })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  expectedQuantity?: number;
+
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/web/src/app/(dashboard)/pharmacy/page.tsx
+++ b/apps/web/src/app/(dashboard)/pharmacy/page.tsx
@@ -69,6 +69,10 @@ export default function PharmacyPage() {
       return;
     }
     try {
+      const existing = stock.find(
+        (item: { drugName: string; quantity: number }) =>
+          item.drugName.trim().toLowerCase() === drugName.trim().toLowerCase(),
+      );
       await upsertStock({
         variables: {
           hospitalId,
@@ -76,6 +80,9 @@ export default function PharmacyPage() {
             drugName: drugName.trim(),
             quantity: Number(quantity),
             unit: unit || 'each',
+            ...(existing
+              ? { expectedQuantity: Number(existing.quantity) }
+              : {}),
           },
         },
       });
@@ -121,7 +128,7 @@ export default function PharmacyPage() {
                   id: string;
                   createdAt: string;
                   patient?: { fullName: string };
-                  items: { drugName: string; dosage?: string }[];
+                  items: { drugName: string; quantity?: number; dosage?: string }[];
                 }) => (
                   <div key={rx.id} className="flex items-start gap-4 px-6 py-4">
                     <div className="min-w-0 flex-1">
@@ -135,6 +142,7 @@ export default function PharmacyPage() {
                         {rx.items.map((item, i) => (
                           <li key={i} className="text-sm text-clay-text">
                             {item.drugName}
+                            {item.quantity != null ? ` × ${item.quantity}` : ''}
                             {item.dosage ? ` · ${item.dosage}` : ''}
                           </li>
                         ))}

--- a/apps/web/src/components/clinical/patient-clinical-actions.tsx
+++ b/apps/web/src/components/clinical/patient-clinical-actions.tsx
@@ -263,6 +263,7 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
             items: [
               {
                 drugName: form.get('drugName') as string,
+                quantity: Number(form.get('quantity') || 1),
                 dosage: form.get('dosage') as string,
                 frequency: form.get('frequency') as string,
                 duration: (form.get('duration') as string) || undefined,
@@ -508,6 +509,15 @@ export function PatientClinicalActions({ patientId, hospitalId }: PatientClinica
                 {key === 'prescription' ? (
                   <form onSubmit={handlePrescription} className="grid gap-3 sm:grid-cols-2">
                     <ClayInput name="drugName" label="Drug Name *" required />
+                    <ClayInput
+                      name="quantity"
+                      label="Quantity *"
+                      type="number"
+                      min="0.01"
+                      step="0.01"
+                      defaultValue="1"
+                      required
+                    />
                     <ClayInput name="dosage" label="Dosage *" required placeholder="500mg" />
                     <ClayInput name="frequency" label="Frequency *" required placeholder="Twice daily" />
                     <ClayInput name="duration" label="Duration" placeholder="7 days" />

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -1054,6 +1054,7 @@ export const PENDING_PRESCRIPTIONS_QUERY = gql`
       items {
         id
         drugName
+        quantity
         dosage
         frequency
         duration

--- a/supabase/migrations/20240609000028_prescription_item_quantity.sql
+++ b/supabase/migrations/20240609000028_prescription_item_quantity.sql
@@ -1,0 +1,9 @@
+-- Dispense must decrement by prescribed quantity, not 1 unit per Rx line (#245).
+ALTER TABLE prescription_items
+  ADD COLUMN IF NOT EXISTS quantity NUMERIC(10, 2) NOT NULL DEFAULT 1;
+
+ALTER TABLE prescription_items
+  DROP CONSTRAINT IF EXISTS prescription_items_quantity_positive;
+
+ALTER TABLE prescription_items
+  ADD CONSTRAINT prescription_items_quantity_positive CHECK (quantity > 0);


### PR DESCRIPTION
## Summary
- **#245:** Add `quantity` on `prescription_items` (migration + entity + GraphQL), persist it on create (default 1), and decrement pharmacy stock by line quantity on dispense.
- **#243:** Add optional `expectedQuantity` to `UpsertPharmacyStockInput`; on update, throw `ConflictException` when it does not match the locked row. Pharmacy UI sends the currently loaded stock quantity as `expectedQuantity`.

## Test plan
- [ ] Run `pnpm exec jest src/pharmacy/pharmacy.service.spec.ts` in `apps/api` (dispense qty + OCC cases)
- [ ] Apply migration `20240609000028_prescription_item_quantity.sql`
- [ ] Create a prescription with quantity > 1 and confirm dispense decrements stock by that amount
- [ ] Edit pharmacy stock after another dispense changed quantity; confirm conflict when stale expected quantity is sent
- [ ] Confirm Rx form still works with default quantity 1

Closes #243
Closes #245

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prescriptions now support item quantities, defaulting to one.
  - Pharmacy dispensing uses requested quantities and displays them with pending prescriptions.
  - Stock updates can detect quantity conflicts before saving changes.

- **Bug Fixes**
  - Improved monetary rounding and quantity precision.
  - Prevented dispensing when available stock is insufficient.
  - Duplicate prescription items are combined accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->