### PR TITLE
fix: sniff upload magic bytes instead of trusting client MIME (#241)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,6 +37,7 @@
     "@nestjs/typeorm": "^11.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
+    "file-type": "16.5.4",
     "graphql": "^16.14.1",
     "graphql-depth-limit": "^1.1.0",
     "graphql-query-complexity": "^2.0.0",

--- a/apps/api/src/uploads/upload-file-type.spec.ts
+++ b/apps/api/src/uploads/upload-file-type.spec.ts
@@ -3,11 +3,15 @@ import { mkdtemp, writeFile, rm, access } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { constants as fsConstants } from 'fs';
+import { crc32 } from 'zlib';
 import {
   sniffAndValidateUpload,
   ensureStoredExtension,
   MIME_TO_EXT,
 } from './upload-file-type';
+
+const OOXML_WORD =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 
 const PNG = Buffer.from([
   0x89,
@@ -31,17 +35,55 @@ const WEBP = Buffer.concat([
 const HTML = Buffer.from('<!DOCTYPE html><html><body>hi</body></html>');
 const EXE = Buffer.concat([Buffer.from('MZ'), Buffer.alloc(64)]);
 const TEXT = Buffer.from('Patient intake notes — plain text.');
-const OLE = Buffer.from([
-  0xd0,
-  0xcf,
-  0x11,
-  0xe0,
-  0xa1,
-  0xb1,
-  0x1a,
-  0xe1,
-  ...Buffer.alloc(64),
+const OLE_MAGIC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+/** OLE container with no Word stream — same magic as xls/ppt/msg. */
+const OLE_GENERIC = Buffer.concat([OLE_MAGIC, Buffer.alloc(64)]);
+const OLE_WORD = Buffer.concat([
+  OLE_MAGIC,
+  Buffer.alloc(64),
+  Buffer.from('WordDocument', 'utf16le'),
 ]);
+const OLE_EXCEL = Buffer.concat([
+  OLE_MAGIC,
+  Buffer.alloc(64),
+  Buffer.from('Workbook', 'utf16le'),
+]);
+const OLE_PPT = Buffer.concat([
+  OLE_MAGIC,
+  Buffer.alloc(64),
+  Buffer.from('PowerPoint Document', 'utf16le'),
+]);
+
+function storedZip(filename: string, content: Buffer): Buffer {
+  const name = Buffer.from(filename);
+  const crc = crc32(content) >>> 0;
+  const local = Buffer.alloc(30);
+  local.writeUInt32LE(0x04034b50, 0);
+  local.writeUInt16LE(20, 4);
+  local.writeUInt32LE(crc, 14);
+  local.writeUInt32LE(content.length, 18);
+  local.writeUInt32LE(content.length, 22);
+  local.writeUInt16LE(name.length, 26);
+  const central = Buffer.alloc(46);
+  central.writeUInt32LE(0x02014b50, 0);
+  central.writeUInt16LE(20, 4);
+  central.writeUInt16LE(20, 6);
+  central.writeUInt32LE(crc, 16);
+  central.writeUInt32LE(content.length, 20);
+  central.writeUInt32LE(content.length, 24);
+  central.writeUInt16LE(name.length, 28);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(46 + name.length, 12);
+  eocd.writeUInt32LE(30 + name.length + content.length, 16);
+  return Buffer.concat([local, name, content, central, name, eocd]);
+}
+
+const DOCX_ZIP = storedZip('word/document.xml', Buffer.from('<w:document/>'));
+const XLSX_ZIP = storedZip('xl/workbook.xml', Buffer.from('<workbook/>'));
+const GENERIC_ZIP = storedZip('readme.txt', Buffer.from('not office'));
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -101,11 +143,69 @@ describe('sniffAndValidateUpload', () => {
     });
   });
 
-  it('maps OLE compound files to application/msword', async () => {
-    const path = await write('letter.doc', OLE);
+  it('accepts OLE CFB as Word only when claimed msword and WordDocument stream exists', async () => {
+    const path = await write('letter.doc', OLE_WORD);
     await expect(
       sniffAndValidateUpload(path, 'application/msword'),
     ).resolves.toEqual({ mime: 'application/msword', ext: '.doc' });
+    expect(await exists(path)).toBe(true);
+  });
+
+  it('rejects generic OLE claimed as msword (xls/ppt/msg share x-cfb)', async () => {
+    const path = await write('letter.doc', OLE_GENERIC);
+    await expect(
+      sniffAndValidateUpload(path, 'application/msword'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('rejects Excel OLE claimed as application/msword', async () => {
+    const path = await write('sheet.doc', OLE_EXCEL);
+    await expect(
+      sniffAndValidateUpload(path, 'application/msword'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('rejects PowerPoint OLE claimed as application/msword', async () => {
+    const path = await write('deck.doc', OLE_PPT);
+    await expect(
+      sniffAndValidateUpload(path, 'application/msword'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('rejects Word OLE claimed as a non-Word MIME', async () => {
+    const path = await write('letter.pdf', OLE_WORD);
+    await expect(
+      sniffAndValidateUpload(path, 'application/pdf'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('accepts ZIP as docx only when claimed OOXML Word and word/document.xml is present', async () => {
+    const path = await write('letter.docx', DOCX_ZIP);
+    await expect(sniffAndValidateUpload(path, OOXML_WORD)).resolves.toEqual({
+      mime: OOXML_WORD,
+      ext: '.docx',
+    });
+    expect(await exists(path)).toBe(true);
+  });
+
+  it('rejects xlsx ZIP claimed as OOXML Word', async () => {
+    const path = await write('sheet.docx', XLSX_ZIP);
+    await expect(
+      sniffAndValidateUpload(path, OOXML_WORD),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('rejects generic ZIP claimed as OOXML Word', async () => {
+    const path = await write('archive.docx', GENERIC_ZIP);
+    await expect(
+      sniffAndValidateUpload(path, OOXML_WORD),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
   });
 
   it('rejects HTML claimed as PDF and unlinks the file', async () => {

--- a/apps/api/src/uploads/upload-file-type.spec.ts
+++ b/apps/api/src/uploads/upload-file-type.spec.ts
@@ -1,0 +1,193 @@
+import { BadRequestException } from '@nestjs/common';
+import { mkdtemp, writeFile, rm, access } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { constants as fsConstants } from 'fs';
+import {
+  sniffAndValidateUpload,
+  ensureStoredExtension,
+  MIME_TO_EXT,
+} from './upload-file-type';
+
+const PNG = Buffer.from([
+  0x89,
+  0x50,
+  0x4e,
+  0x47,
+  0x0d,
+  0x0a,
+  0x1a,
+  0x0a,
+  ...Buffer.alloc(24),
+]);
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, ...Buffer.alloc(16)]);
+const PDF = Buffer.from('%PDF-1.4\n%\xE2\xE3\xCF\xD3\ntrailer');
+const GIF = Buffer.from('GIF89a' + '\0'.repeat(20));
+const WEBP = Buffer.concat([
+  Buffer.from('RIFF'),
+  Buffer.from([16, 0, 0, 0]),
+  Buffer.from('WEBP'),
+]);
+const HTML = Buffer.from('<!DOCTYPE html><html><body>hi</body></html>');
+const EXE = Buffer.concat([Buffer.from('MZ'), Buffer.alloc(64)]);
+const TEXT = Buffer.from('Patient intake notes — plain text.');
+const OLE = Buffer.from([
+  0xd0,
+  0xcf,
+  0x11,
+  0xe0,
+  0xa1,
+  0xb1,
+  0x1a,
+  0xe1,
+  ...Buffer.alloc(64),
+]);
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('sniffAndValidateUpload', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'upload-sniff-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const write = async (name: string, buf: Buffer) => {
+    const path = join(dir, name);
+    await writeFile(path, buf);
+    return path;
+  };
+
+  it('accepts PNG content claimed as image/png', async () => {
+    const path = await write('a.png', PNG);
+    await expect(sniffAndValidateUpload(path, 'image/png')).resolves.toEqual({
+      mime: 'image/png',
+      ext: '.png',
+    });
+    expect(await exists(path)).toBe(true);
+  });
+
+  it('accepts JPEG, PDF, GIF, and WebP when claim matches sniff', async () => {
+    await expect(
+      sniffAndValidateUpload(await write('a.jpg', JPEG), 'image/jpeg'),
+    ).resolves.toEqual({ mime: 'image/jpeg', ext: '.jpg' });
+    await expect(
+      sniffAndValidateUpload(await write('a.pdf', PDF), 'application/pdf'),
+    ).resolves.toEqual({ mime: 'application/pdf', ext: '.pdf' });
+    await expect(
+      sniffAndValidateUpload(await write('a.gif', GIF), 'image/gif'),
+    ).resolves.toEqual({ mime: 'image/gif', ext: '.gif' });
+    await expect(
+      sniffAndValidateUpload(await write('a.webp', WEBP), 'image/webp'),
+    ).resolves.toEqual({ mime: 'image/webp', ext: '.webp' });
+  });
+
+  it('accepts text/plain when there is no binary magic', async () => {
+    const path = await write('notes.txt', TEXT);
+    await expect(sniffAndValidateUpload(path, 'text/plain')).resolves.toEqual({
+      mime: 'text/plain',
+      ext: '.txt',
+    });
+  });
+
+  it('maps OLE compound files to application/msword', async () => {
+    const path = await write('letter.doc', OLE);
+    await expect(
+      sniffAndValidateUpload(path, 'application/msword'),
+    ).resolves.toEqual({ mime: 'application/msword', ext: '.doc' });
+  });
+
+  it('rejects HTML claimed as PDF and unlinks the file', async () => {
+    const path = await write('evil.pdf', HTML);
+    await expect(
+      sniffAndValidateUpload(path, 'application/pdf'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('rejects an executable claimed as PNG and unlinks the file', async () => {
+    const path = await write('evil.png', EXE);
+    await expect(
+      sniffAndValidateUpload(path, 'image/png'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('rejects PNG content claimed as JPEG (lied MIME)', async () => {
+    const path = await write('lied.jpg', PNG);
+    await expect(
+      sniffAndValidateUpload(path, 'image/jpeg'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('rejects text claimed as PDF (no magic)', async () => {
+    const path = await write('notes.pdf', TEXT);
+    await expect(
+      sniffAndValidateUpload(path, 'application/pdf'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('rejects unknown binary claimed as text/plain', async () => {
+    const path = await write('notes.txt', Buffer.from([0, 1, 2, 3, 4, 5]));
+    await expect(
+      sniffAndValidateUpload(path, 'text/plain'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('allowlist keys match MIME_TO_EXT', () => {
+    expect(Object.keys(MIME_TO_EXT).sort()).toEqual(
+      [
+        'application/msword',
+        'application/pdf',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'image/gif',
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'text/plain',
+      ].sort(),
+    );
+  });
+});
+
+describe('ensureStoredExtension', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'upload-ext-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('renames when the stored extension does not match sniffed type', async () => {
+    const path = join(dir, 'abc.jpg');
+    await writeFile(path, PNG);
+    const name = await ensureStoredExtension(path, '.png');
+    expect(name).toBe('abc.png');
+    expect(await exists(join(dir, 'abc.png'))).toBe(true);
+    expect(await exists(path)).toBe(false);
+  });
+
+  it('keeps the name when the extension already matches', async () => {
+    const path = join(dir, 'abc.png');
+    await writeFile(path, PNG);
+    await expect(ensureStoredExtension(path, '.png')).resolves.toBe('abc.png');
+    expect(await exists(path)).toBe(true);
+  });
+});

--- a/apps/api/src/uploads/upload-file-type.ts
+++ b/apps/api/src/uploads/upload-file-type.ts
@@ -1,0 +1,123 @@
+import { BadRequestException } from '@nestjs/common';
+import { fromFile } from 'file-type';
+import { promises as fs } from 'fs';
+import { basename, dirname, extname, join } from 'path';
+
+/** MIME → allowed extension (server-chosen; never trust client extension alone). */
+export const MIME_TO_EXT: Record<string, string> = {
+  'application/pdf': '.pdf',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+  'text/plain': '.txt',
+  'application/msword': '.doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    '.docx',
+};
+
+export const EXT_TO_MIME: Record<string, string> = Object.fromEntries(
+  Object.entries(MIME_TO_EXT).map(([mime, ext]) => [ext, mime]),
+);
+
+/** Preview-safe types may be inline; everything else downloads as attachment. */
+export const INLINE_MIME = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'text/plain',
+]);
+
+/**
+ * file-type reports OLE Compound File Binary as application/x-cfb, not
+ * application/msword. Canonicalize so .doc uploads still match the allowlist.
+ */
+const SNIFF_MIME_ALIASES: Record<string, string> = {
+  'application/x-cfb': 'application/msword',
+};
+
+async function unlinkQuiet(filePath: string): Promise<void> {
+  try {
+    await fs.unlink(filePath);
+  } catch {
+    // already removed
+  }
+}
+
+/** Reject unknown binaries claimed as text/plain (NUL in the first 8KiB). */
+async function looksLikeText(filePath: string): Promise<boolean> {
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(8192);
+    const { bytesRead } = await handle.read(buf, 0, buf.length, 0);
+    if (bytesRead === 0) return true;
+    return !buf.subarray(0, bytesRead).includes(0);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Sniff magic bytes after multer writes the file. Unlink and reject when the
+ * real type is missing, not allowlisted, or does not match the claimed MIME.
+ */
+export async function sniffAndValidateUpload(
+  filePath: string,
+  claimedMime: string,
+): Promise<{ mime: string; ext: string }> {
+  let detectedMime: string | undefined;
+  try {
+    const detected = await fromFile(filePath);
+    detectedMime = detected?.mime;
+  } catch {
+    // Truncated / unreadable magic — treat as undetected.
+    detectedMime = undefined;
+  }
+
+  if (detectedMime && SNIFF_MIME_ALIASES[detectedMime]) {
+    detectedMime = SNIFF_MIME_ALIASES[detectedMime];
+  }
+
+  if (
+    !detectedMime &&
+    claimedMime === 'text/plain' &&
+    (await looksLikeText(filePath))
+  ) {
+    detectedMime = 'text/plain';
+  }
+
+  const ext = detectedMime ? MIME_TO_EXT[detectedMime] : undefined;
+  if (!detectedMime || !ext) {
+    await unlinkQuiet(filePath);
+    throw new BadRequestException(
+      detectedMime
+        ? `Unsupported file type: ${detectedMime}`
+        : 'Could not determine file type from content',
+    );
+  }
+
+  if (claimedMime !== detectedMime) {
+    await unlinkQuiet(filePath);
+    throw new BadRequestException(
+      `File content type ${detectedMime} does not match claimed type ${claimedMime}`,
+    );
+  }
+
+  return { mime: detectedMime, ext };
+}
+
+/** Rename the stored file so its extension matches the sniffed MIME. */
+export async function ensureStoredExtension(
+  filePath: string,
+  desiredExt: string,
+): Promise<string> {
+  const currentExt = extname(filePath).toLowerCase();
+  const name = basename(filePath);
+  if (currentExt === desiredExt) return name;
+
+  const newName = `${name.slice(0, name.length - currentExt.length)}${desiredExt}`;
+  await fs.rename(filePath, join(dirname(filePath), newName));
+  return newName;
+}

--- a/apps/api/src/uploads/upload-file-type.ts
+++ b/apps/api/src/uploads/upload-file-type.ts
@@ -160,25 +160,25 @@ export async function sniffAndValidateUpload(
   }
 
   if (!detectedMime) {
-    await rejectUpload(
-      filePath,
-      'Could not determine file type from content',
-    );
+    await unlinkQuiet(filePath);
+    throw new BadRequestException('Could not determine file type from content');
   }
 
-  const ext = MIME_TO_EXT[detectedMime];
+  const mime: string = detectedMime;
+  const ext = MIME_TO_EXT[mime];
   if (!ext) {
-    await rejectUpload(filePath, `Unsupported file type: ${detectedMime}`);
+    await unlinkQuiet(filePath);
+    throw new BadRequestException(`Unsupported file type: ${mime}`);
   }
 
-  if (claimedMime !== detectedMime) {
-    await rejectUpload(
-      filePath,
-      `File content type ${detectedMime} does not match claimed type ${claimedMime}`,
+  if (claimedMime !== mime) {
+    await unlinkQuiet(filePath);
+    throw new BadRequestException(
+      `File content type ${mime} does not match claimed type ${claimedMime}`,
     );
   }
 
-  return { mime: detectedMime, ext };
+  return { mime, ext };
 }
 
 /** Rename the stored file so its extension matches the sniffed MIME. */

--- a/apps/api/src/uploads/upload-file-type.ts
+++ b/apps/api/src/uploads/upload-file-type.ts
@@ -3,6 +3,10 @@ import { fromFile } from 'file-type';
 import { promises as fs } from 'fs';
 import { basename, dirname, extname, join } from 'path';
 
+const MS_WORD = 'application/msword';
+const OOXML_WORD =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
 /** MIME → allowed extension (server-chosen; never trust client extension alone). */
 export const MIME_TO_EXT: Record<string, string> = {
   'application/pdf': '.pdf',
@@ -11,9 +15,8 @@ export const MIME_TO_EXT: Record<string, string> = {
   'image/webp': '.webp',
   'image/gif': '.gif',
   'text/plain': '.txt',
-  'application/msword': '.doc',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-    '.docx',
+  [MS_WORD]: '.doc',
+  [OOXML_WORD]: '.docx',
 };
 
 export const EXT_TO_MIME: Record<string, string> = Object.fromEntries(
@@ -30,13 +33,10 @@ export const INLINE_MIME = new Set([
   'text/plain',
 ]);
 
-/**
- * file-type reports OLE Compound File Binary as application/x-cfb, not
- * application/msword. Canonicalize so .doc uploads still match the allowlist.
- */
-const SNIFF_MIME_ALIASES: Record<string, string> = {
-  'application/x-cfb': 'application/msword',
-};
+/** CFB directory stream name for Word 97–2003 (UTF-16LE). */
+const WORD_OLE_STREAM = Buffer.from('WordDocument', 'utf16le');
+/** OOXML document part stored in ZIP local/central headers as plaintext. */
+const DOCX_ZIP_PART = Buffer.from('word/document.xml');
 
 async function unlinkQuiet(filePath: string): Promise<void> {
   try {
@@ -44,6 +44,11 @@ async function unlinkQuiet(filePath: string): Promise<void> {
   } catch {
     // already removed
   }
+}
+
+async function rejectUpload(filePath: string, message: string): Promise<never> {
+  await unlinkQuiet(filePath);
+  throw new BadRequestException(message);
 }
 
 /** Reject unknown binaries claimed as text/plain (NUL in the first 8KiB). */
@@ -57,6 +62,68 @@ async function looksLikeText(filePath: string): Promise<boolean> {
   } finally {
     await handle.close();
   }
+}
+
+/** Chunked search so OLE directory / ZIP headers at EOF are still visible. */
+async function containsBytes(
+  filePath: string,
+  needle: Buffer,
+): Promise<boolean> {
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const chunk = Buffer.alloc(64 * 1024);
+    let overlap = Buffer.alloc(0);
+    let position = 0;
+    for (;;) {
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, position);
+      if (bytesRead === 0) return false;
+      const window = Buffer.concat([overlap, chunk.subarray(0, bytesRead)]);
+      if (window.includes(needle)) return true;
+      overlap = window.subarray(Math.max(0, window.length - needle.length + 1));
+      position += bytesRead;
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * file-type reports every OLE container as application/x-cfb (xls/ppt/msg/doc)
+ * and may report OOXML as application/zip. Never blanket-alias those containers.
+ *
+ * Map to Word only when the client claimed a Word MIME *and* a Word-specific
+ * marker is present. Residual risk: a polyglot that embeds WordDocument or
+ * word/document.xml while also being xls/ppt/xlsx/pptx, claimed as Word.
+ */
+async function canonicalizeWordContainer(
+  filePath: string,
+  sniffed: string,
+  claimed: string,
+): Promise<string> {
+  if (sniffed === 'application/x-cfb' || sniffed === MS_WORD) {
+    if (claimed !== MS_WORD) {
+      return sniffed;
+    }
+    if (!(await containsBytes(filePath, WORD_OLE_STREAM))) {
+      await rejectUpload(filePath, 'OLE compound file is not a Word document');
+    }
+    return MS_WORD;
+  }
+
+  if (sniffed === 'application/zip' || sniffed === OOXML_WORD) {
+    if (claimed !== OOXML_WORD) {
+      return sniffed;
+    }
+    if (
+      sniffed === 'application/zip' &&
+      !(await containsBytes(filePath, DOCX_ZIP_PART))
+    ) {
+      await rejectUpload(filePath, 'ZIP archive is not a Word document');
+    }
+    return OOXML_WORD;
+  }
+
+  return sniffed;
 }
 
 /**
@@ -76,8 +143,12 @@ export async function sniffAndValidateUpload(
     detectedMime = undefined;
   }
 
-  if (detectedMime && SNIFF_MIME_ALIASES[detectedMime]) {
-    detectedMime = SNIFF_MIME_ALIASES[detectedMime];
+  if (detectedMime) {
+    detectedMime = await canonicalizeWordContainer(
+      filePath,
+      detectedMime,
+      claimedMime,
+    );
   }
 
   if (
@@ -90,8 +161,8 @@ export async function sniffAndValidateUpload(
 
   const ext = detectedMime ? MIME_TO_EXT[detectedMime] : undefined;
   if (!detectedMime || !ext) {
-    await unlinkQuiet(filePath);
-    throw new BadRequestException(
+    await rejectUpload(
+      filePath,
       detectedMime
         ? `Unsupported file type: ${detectedMime}`
         : 'Could not determine file type from content',
@@ -99,8 +170,8 @@ export async function sniffAndValidateUpload(
   }
 
   if (claimedMime !== detectedMime) {
-    await unlinkQuiet(filePath);
-    throw new BadRequestException(
+    await rejectUpload(
+      filePath,
       `File content type ${detectedMime} does not match claimed type ${claimedMime}`,
     );
   }

--- a/apps/api/src/uploads/upload-file-type.ts
+++ b/apps/api/src/uploads/upload-file-type.ts
@@ -159,14 +159,16 @@ export async function sniffAndValidateUpload(
     detectedMime = 'text/plain';
   }
 
-  const ext = detectedMime ? MIME_TO_EXT[detectedMime] : undefined;
-  if (!detectedMime || !ext) {
+  if (!detectedMime) {
     await rejectUpload(
       filePath,
-      detectedMime
-        ? `Unsupported file type: ${detectedMime}`
-        : 'Could not determine file type from content',
+      'Could not determine file type from content',
     );
+  }
+
+  const ext = MIME_TO_EXT[detectedMime];
+  if (!ext) {
+    await rejectUpload(filePath, `Unsupported file type: ${detectedMime}`);
   }
 
   if (claimedMime !== detectedMime) {

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -26,35 +26,15 @@ import { AllowAuthenticated } from '../rbac/allow-authenticated.decorator';
 import { PermissionsAny } from '../rbac/permissions-any.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { UploadsService } from './uploads.service';
+import {
+  MIME_TO_EXT,
+  EXT_TO_MIME,
+  INLINE_MIME,
+  sniffAndValidateUpload,
+  ensureStoredExtension,
+} from './upload-file-type';
 
 const UPLOAD_DIR = join(process.cwd(), 'uploads');
-
-/** MIME → allowed extension (server-chosen; never trust client extension alone). */
-const MIME_TO_EXT: Record<string, string> = {
-  'application/pdf': '.pdf',
-  'image/jpeg': '.jpg',
-  'image/png': '.png',
-  'image/webp': '.webp',
-  'image/gif': '.gif',
-  'text/plain': '.txt',
-  'application/msword': '.doc',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-    '.docx',
-};
-
-const EXT_TO_MIME: Record<string, string> = Object.fromEntries(
-  Object.entries(MIME_TO_EXT).map(([mime, ext]) => [ext, mime]),
-);
-
-/** Preview-safe types may be inline; everything else downloads as attachment. */
-const INLINE_MIME = new Set([
-  'application/pdf',
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-  'text/plain',
-]);
 
 type AuthedRequest = Request & { user?: AuthenticatedUser };
 
@@ -126,16 +106,21 @@ export class UploadsController {
     await this.uploadsService.assertCanUpload(req.user, hospitalId);
 
     if (!file) throw new BadRequestException('file is required');
+
+    const storedPath = file.path || join(UPLOAD_DIR, file.filename);
+    const sniffed = await sniffAndValidateUpload(storedPath, file.mimetype);
+    const filename = await ensureStoredExtension(storedPath, sniffed.ext);
+
     // Prefer configured public base; otherwise return a stable relative path
     // so client-controlled Host headers cannot poison stored document URLs.
     const configured = process.env.API_PUBLIC_URL?.replace(/\/$/, '');
     const url = configured
-      ? `${configured}/uploads/${file.filename}`
-      : `/uploads/${file.filename}`;
+      ? `${configured}/uploads/${filename}`
+      : `/uploads/${filename}`;
     return {
       url,
       fileName: file.originalname,
-      fileType: file.mimetype,
+      fileType: sniffed.mime,
       size: file.size,
     };
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       class-validator:
         specifier: ^0.15.1
         version: 0.15.1
+      file-type:
+        specifier: 16.5.4
+        version: 16.5.4
       graphql:
         specifier: ^16.14.1
         version: 16.14.1
@@ -2681,6 +2684,10 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -3528,6 +3535,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@3.1.2:
     resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
 
@@ -3598,6 +3609,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-type@16.5.4:
+    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
+    engines: {node: '>=10'}
 
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
@@ -4832,6 +4847,10 @@ packages:
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
+  peek-readable@4.1.0:
+    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
+    engines: {node: '>=8'}
+
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
 
@@ -5016,6 +5035,14 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readable-web-to-node-stream@3.0.4:
+    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
+    engines: {node: '>=8'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -5365,6 +5392,10 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
+  strtok3@6.3.0:
+    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
+    engines: {node: '>=10'}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -5504,6 +5535,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  token-types@4.2.1:
+    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
+    engines: {node: '>=10'}
 
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
@@ -8364,6 +8399,10 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -9348,6 +9387,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@3.1.2: {}
 
   events@3.3.0: {}
@@ -9453,6 +9494,12 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-type@16.5.4:
+    dependencies:
+      readable-web-to-node-stream: 3.0.4
+      strtok3: 6.3.0
+      token-types: 4.2.1
 
   file-type@21.3.4:
     dependencies:
@@ -10857,6 +10904,8 @@ snapshots:
 
   pause@0.0.1: {}
 
+  peek-readable@4.1.0: {}
+
   pg-cloudflare@1.4.0:
     optional: true
 
@@ -11026,6 +11075,18 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readable-web-to-node-stream@3.0.4:
+    dependencies:
+      readable-stream: 4.7.0
 
   readdirp@4.1.2: {}
 
@@ -11482,6 +11543,11 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  strtok3@6.3.0:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      peek-readable: 4.1.0
+
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -11597,6 +11663,11 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  token-types@4.2.1:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   token-types@6.1.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Sniff uploaded file magic bytes with `file-type@16.5.4` after multer writes to disk, instead of trusting the client `Content-Type`.
- Unlink and reject files whose sniffed MIME is missing, not allowlisted, or does not match the claimed type; store/return the sniffed type (including OLE `.doc` → `application/msword`).
- Adds unit tests for matching types, lied MIME, HTML/exe polyglots, and extension rename.

## Test plan
- [ ] `pnpm --filter api exec jest src/uploads --no-coverage` passes
- [ ] Upload a real PNG/PDF with matching Content-Type — succeeds; stored extension and `fileType` match sniffed MIME
- [ ] Upload HTML (or random bytes) claimed as `application/pdf` — 400 and file is not left on disk
- [ ] Upload a `.txt` notes file as `text/plain` — still accepted
- [ ] Upload a `.doc` (OLE) as `application/msword` — still accepted

Fixes #241

Made with [Cursor](https://cursor.com)