### PR TITLE
docs: record residual SNYK-CODE-0005 (Snyk Code still disabled)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,13 +87,18 @@ Snyk Code cannot be turned on from application code or CI alone. For org
 4. Confirm billing/plan allows Snyk Code if prompted.
 
 Until that is done, `snyk code test` returns **SNYK-CODE-0005** / 403 and OWASP/AI
-code analysis stays unavailable. After an admin enables it, re-run:
+code analysis stays unavailable. This cannot be fixed in application code or CI.
+
+**Status (rescan 2026-08-08, `main` @ `0f3840d`):** `snyk test --all-projects` is
+clean. `snyk code test --all-projects` is still **SNYK-CODE-0005** / 403 for org
+`kkshettigar24`. Tracked in GitHub issue #246; leave that issue open until an
+org admin enables Snyk Code. After enablement, re-run:
 
 ```bash
 snyk code test --all-projects
 ```
 
-File any new findings as GitHub issues with severity P0–P4.
+File any new code findings as GitHub issues with severity P0–P4.
 
 ## Project layout
 


### PR DESCRIPTION
## Summary
- Documents that the 2026-08-08 rescan of `main` (`0f3840d`) is still blocked by **SNYK-CODE-0005** / 403 for org `kkshettigar24`.
- Enablement steps in `CONTRIBUTING.md` (from #221) are unchanged; this only adds a dated status note that Snyk Code cannot be fixed in-repo.
- **Does not close #246** — org admin action is still required. After Snyk Code is enabled, re-run `snyk code test --all-projects` and file any findings as issues.

Related: #246 (leave open). Residual of #221.

## Test plan
- [ ] Confirm `CONTRIBUTING.md` still has org-admin enablement steps for `kkshettigar24`
- [ ] Confirm the 2026-08-08 status note does not claim Snyk Code is fixed
- [ ] Leave #246 open until `snyk code test` succeeds


Made with [Cursor](https://cursor.com)