### PR TITLE
Fix P2: file-type@16.5.4 infinite-loop DoS on crafted uploads (#262)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,7 +37,6 @@
     "@nestjs/typeorm": "^11.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
-    "file-type": "16.5.4",
     "graphql": "^16.14.1",
     "graphql-depth-limit": "^1.1.0",
     "graphql-query-complexity": "^2.0.0",

--- a/apps/api/src/uploads/upload-file-type.ts
+++ b/apps/api/src/uploads/upload-file-type.ts
@@ -1,5 +1,4 @@
 import { BadRequestException } from '@nestjs/common';
-import { fromFile } from 'file-type';
 import { promises as fs } from 'fs';
 import { basename, dirname, extname, join } from 'path';
 
@@ -33,10 +32,79 @@ export const INLINE_MIME = new Set([
   'text/plain',
 ]);
 
+/** OLE compound-file magic ("D0 CF 11 E0 A1 B1 1A E1"). */
+const OLE_CFB_MAGIC = Buffer.from([
+  0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1,
+]);
 /** CFB directory stream name for Word 97–2003 (UTF-16LE). */
 const WORD_OLE_STREAM = Buffer.from('WordDocument', 'utf16le');
+/** ZIP local file header magic. */
+const ZIP_LOCAL_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
 /** OOXML document part stored in ZIP local/central headers as plaintext. */
 const DOCX_ZIP_PART = Buffer.from('word/document.xml');
+
+/** How many leading bytes are enough to distinguish every allowlisted type. */
+const SNIFF_PREFIX_BYTES = 16;
+
+/**
+ * Bounded magic-byte detection over a fixed prefix — no third-party parser,
+ * so a crafted file cannot drive an unbounded parse loop (#262).
+ * Containers (OLE/ZIP) are reported by container type and then
+ * disambiguated by {@link canonicalizeWordContainer}.
+ */
+function detectFromPrefix(buf: Buffer): string | undefined {
+  if (buf.length >= 5 && buf.subarray(0, 5).equals(Buffer.from('%PDF-'))) {
+    return 'application/pdf';
+  }
+  if (
+    buf.length >= 3 &&
+    buf[0] === 0xff &&
+    buf[1] === 0xd8 &&
+    buf[2] === 0xff
+  ) {
+    return 'image/jpeg';
+  }
+  if (
+    buf.length >= 8 &&
+    buf
+      .subarray(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+  ) {
+    return 'image/png';
+  }
+  if (
+    buf.length >= 6 &&
+    (buf.subarray(0, 6).equals(Buffer.from('GIF87a')) ||
+      buf.subarray(0, 6).equals(Buffer.from('GIF89a')))
+  ) {
+    return 'image/gif';
+  }
+  if (
+    buf.length >= 12 &&
+    buf.subarray(0, 4).equals(Buffer.from('RIFF')) &&
+    buf.subarray(8, 12).equals(Buffer.from('WEBP'))
+  ) {
+    return 'image/webp';
+  }
+  if (buf.length >= 8 && buf.subarray(0, 8).equals(OLE_CFB_MAGIC)) {
+    return 'application/x-cfb';
+  }
+  if (buf.length >= 4 && buf.subarray(0, 4).equals(ZIP_LOCAL_MAGIC)) {
+    return 'application/zip';
+  }
+  return undefined;
+}
+
+async function sniffPrefix(filePath: string): Promise<Buffer> {
+  const handle = await fs.open(filePath);
+  try {
+    const buf = Buffer.alloc(SNIFF_PREFIX_BYTES);
+    const { bytesRead } = await handle.read(buf, 0, buf.length, 0);
+    return buf.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
 
 async function unlinkQuiet(filePath: string): Promise<void> {
   try {
@@ -88,8 +156,9 @@ async function containsBytes(
 }
 
 /**
- * file-type reports every OLE container as application/x-cfb (xls/ppt/msg/doc)
- * and may report OOXML as application/zip. Never blanket-alias those containers.
+ * The prefix sniffer reports every OLE container as application/x-cfb and
+ * every ZIP as application/zip (xls/ppt/msg/xlsx/pptx all share those
+ * containers). Never blanket-alias them.
  *
  * Map to Word only when the client claimed a Word MIME *and* a Word-specific
  * marker is present. Residual risk: a polyglot that embeds WordDocument or
@@ -129,6 +198,9 @@ async function canonicalizeWordContainer(
 /**
  * Sniff magic bytes after multer writes the file. Unlink and reject when the
  * real type is missing, not allowlisted, or does not match the claimed MIME.
+ *
+ * Detection is a bounded prefix read — no recursive/looping parser over
+ * untrusted input (#262).
  */
 export async function sniffAndValidateUpload(
   filePath: string,
@@ -136,10 +208,10 @@ export async function sniffAndValidateUpload(
 ): Promise<{ mime: string; ext: string }> {
   let detectedMime: string | undefined;
   try {
-    const detected = await fromFile(filePath);
-    detectedMime = detected?.mime;
+    const prefix = await sniffPrefix(filePath);
+    detectedMime = detectFromPrefix(prefix);
   } catch {
-    // Truncated / unreadable magic — treat as undetected.
+    // Unreadable file — treat as undetected.
     detectedMime = undefined;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       class-validator:
         specifier: ^0.15.1
         version: 0.15.1
-      file-type:
-        specifier: 16.5.4
-        version: 16.5.4
       graphql:
         specifier: ^16.14.1
         version: 16.14.1
@@ -2684,10 +2681,6 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -3535,10 +3528,6 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-
   eventemitter3@3.1.2:
     resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
 
@@ -3609,10 +3598,6 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
-
-  file-type@16.5.4:
-    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
-    engines: {node: '>=10'}
 
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
@@ -4847,10 +4832,6 @@ packages:
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
-  peek-readable@4.1.0:
-    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
-    engines: {node: '>=8'}
-
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
 
@@ -5035,14 +5016,6 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
-
-  readable-stream@4.7.0:
-    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  readable-web-to-node-stream@3.0.4:
-    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
-    engines: {node: '>=8'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -5392,10 +5365,6 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
-  strtok3@6.3.0:
-    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
-    engines: {node: '>=10'}
-
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -5535,10 +5504,6 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  token-types@4.2.1:
-    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
-    engines: {node: '>=10'}
 
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
@@ -8399,10 +8364,6 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -9387,8 +9348,6 @@ snapshots:
 
   etag@1.8.1: {}
 
-  event-target-shim@5.0.1: {}
-
   eventemitter3@3.1.2: {}
 
   events@3.3.0: {}
@@ -9494,12 +9453,6 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  file-type@16.5.4:
-    dependencies:
-      readable-web-to-node-stream: 3.0.4
-      strtok3: 6.3.0
-      token-types: 4.2.1
 
   file-type@21.3.4:
     dependencies:
@@ -10904,8 +10857,6 @@ snapshots:
 
   pause@0.0.1: {}
 
-  peek-readable@4.1.0: {}
-
   pg-cloudflare@1.4.0:
     optional: true
 
@@ -11075,18 +11026,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  readable-stream@4.7.0:
-    dependencies:
-      abort-controller: 3.0.0
-      buffer: 6.0.3
-      events: 3.3.0
-      process: 0.11.10
-      string_decoder: 1.3.0
-
-  readable-web-to-node-stream@3.0.4:
-    dependencies:
-      readable-stream: 4.7.0
 
   readdirp@4.1.2: {}
 
@@ -11543,11 +11482,6 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  strtok3@6.3.0:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      peek-readable: 4.1.0
-
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -11663,11 +11597,6 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
-
-  token-types@4.2.1:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
 
   token-types@6.1.2:
     dependencies:


### PR DESCRIPTION
Closes #262

## Problem
`file-type@16.5.4` (used by upload magic-byte sniffing on the PHI upload path) has a known infinite-loop DoS — SNYK-JS-FILETYPE-15456217. A crafted file uploaded to `POST /uploads/patient-documents` can pin an API event-loop worker.

## Why not just bump the dep
`file-type` ≥17 is ESM-only; this Nest/ts-jest API compiles to CJS, so a bump breaks the build/runtime (per the issue's notes). Instead of fighting the module system, we **remove the dependency entirely**.

## Fix
- New bounded sniffer: detect the existing 8-type allowlist from a **16-byte prefix read** (`%PDF-`, JPEG SOI, PNG sig, GIF87a/89a, RIFF+WEBP, OLE-CFB magic, ZIP local header) — the longest allowlisted signature is WebP at 12 bytes, so 16 is sufficient.
- Containers (OLE/ZIP) still flow through the unchanged `canonicalizeWordContainer` marker checks (WordDocument stream / word/document.xml) before being accepted as .doc/.docx.
- Because detection is now a fixed prefix comparison with no recursive parser over untrusted input, the unbounded-parse attack surface is gone by construction.

## Verification
- `snyk test --file=apps/api/package.json` → **no vulnerable paths found**
- `pnpm --filter api test` → 19 suites, **164/164 passed** (all existing sniff cases — polyglot OLE/ZIP, lied-MIME rejection, text fallback, unlink-on-reject — unchanged)
- `pnpm --filter api lint` and `pnpm --filter api build` → clean
- PR scoped to #262 only (unrelated eslint --fix reformat noise reverted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uploaded file type detection for PDF, image, document, and archive formats.
  * Added safer handling for unreadable or invalid files.
  * Preserved accurate identification of Word-specific document containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->