### PR TITLE
Fix P3: Missing security headers on web and API (#263)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,7 @@
     "graphql": "^16.14.1",
     "graphql-depth-limit": "^1.1.0",
     "graphql-query-complexity": "^2.0.0",
+    "helmet": "^8.3.0",
     "jsonwebtoken": "^9.0.3",
     "jwks-rsa": "^4.0.1",
     "multer": "^2.2.0",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,6 +2,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import helmet from 'helmet';
 import { join } from 'path';
 import { existsSync, mkdirSync } from 'fs';
 import { AppModule } from './app.module';
@@ -13,6 +14,15 @@ async function bootstrap() {
   const uploadDir = join(process.cwd(), 'uploads');
   if (!existsSync(uploadDir)) mkdirSync(uploadDir, { recursive: true });
   // Files are served only via authenticated GET /uploads/:filename — not public static.
+
+  // Baseline security headers for the GraphQL/JSON API + upload endpoints
+  // (#263). CSP is left off: responses are application/json and the
+  // dev-only GraphQL playground loads its assets from its own origin.
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+    }),
+  );
 
   app.enableCors({
     origin: config.get('CORS_ORIGIN', 'http://localhost:3000'),

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,8 +3,62 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000/graphql';
+
+// Clerk hydrates via inline scripts (SSR state + cache signals) and loads
+// clerk-js from its Frontend API, so script-src must keep 'unsafe-inline'
+// and the Clerk domains. Tighten with nonces once verified against a live
+// Clerk instance. `data:`/`blob:` in img-src covers inline images and
+// blob object URLs used to render uploaded documents.
+const CSP = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline' https://*.clerk.accounts.dev https://*.clerk.com`,
+  `style-src 'self' 'unsafe-inline'`,
+  `connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com images.clerk.dev ${API_URL}`,
+  `img-src 'self' data: blob: https://img.clerk.com`,
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self' https://*.clerk.accounts.dev https://*.clerk.com",
+  "frame-ancestors 'self'",
+  // Note: no `upgrade-insecure-requests` — it would rewrite local HTTP API
+  // fetches (http://localhost:4000) to https in development. HSTS (below)
+  // pins HTTPS in production instead.
+].join('; ');
+
+// Baseline security headers on every response (#263). HSTS is only attached
+// to HTTPS requests (via x-forwarded-proto) so local http:// development is
+// not poisoned.
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: CSP },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), payment=()',
+  },
+];
+
 const nextConfig: NextConfig = {
   transpilePackages: ['@careconnect/ui', '@careconnect/types'],
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+      {
+        source: '/:path*',
+        has: [{ type: 'header', key: 'x-forwarded-proto', value: 'https' }],
+        headers: [
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       graphql-query-complexity:
         specifier: ^2.0.0
         version: 2.0.0(graphql@16.14.1)
+      helmet:
+        specifier: ^8.3.0
+        version: 8.3.0
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -3842,6 +3845,10 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  helmet@8.3.0:
+    resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
+    engines: {node: '>=18.0.0'}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -9712,6 +9719,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@8.3.0: {}
 
   hermes-estree@0.25.1: {}
 


### PR DESCRIPTION
Closes #263

## Problem
Neither app set security response headers (CSP, HSTS, X-Frame-Options/X-Content-Type-Options, Referrer-Policy, Permissions-Policy) — flagged in the audit (A02 Security Misconfiguration).

## Fix
**Web — `next.config.ts headers()`** (verified against Next 16 docs bundled in `node_modules/next/dist/docs/`):
- CSP: `default-src 'self'` pinned to app origin + Clerk domains + `NEXT_PUBLIC_API_URL`; object-src/base-uri locked, form-action scoped to self+Clerk; `frame-ancestors 'self'` (clickjacking). Clerk needs `'unsafe-inline'` in script-src for hydration — noted for future nonce-based hardening. No `upgrade-insecure-requests`: it would rewrite local HTTP API fetches in dev.
- `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (camera/mic/geo/payment off).
- HSTS (2y, includeSubDomains) attached **only** to HTTPS requests (x-forwarded-proto matcher) so local http dev isn't poisoned.
- `poweredByHeader: false`.

**API — `helmet` ^8 in `main.ts`**: nosniff, frame-ancestors, HSTS, referrer policy etc. CSP left off (JSON responses; dev-only playground serves its own assets).

## Verification
- `pnpm --filter api build` + lint: clean; helmet CJS import verified
- `pnpm --filter api test`: 164/164 pass
- `pnpm --filter web lint` + build: clean (2 pre-existing warnings, unrelated files)
- Runtime: `curl -I` against `next start` confirmed all headers present, HSTS only over https, no X-Powered-By

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added baseline security headers across the web application and API.
  * Added Content Security Policy configuration for web requests.
  * Added conditional HSTS protection for HTTPS connections.
  * Removed the technology-identifying `X-Powered-By` response header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->