### PR TITLE
Fix P3: pharmacist least-privilege — dedicated pharmacy:write permission (#264)

### DIFF
--- a/apps/api/src/inventory/inventory.resolver.ts
+++ b/apps/api/src/inventory/inventory.resolver.ts
@@ -41,7 +41,7 @@ export class InventoryResolver {
 
   @Mutation(() => InventoryItemType)
   @Roles(...INVENTORY_ROLES)
-  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  @Permissions(PERMISSIONS.PHARMACY_WRITE)
   async createInventoryItem(
     @CurrentUser() user: AuthenticatedUser,
     @Args('input') input: CreateInventoryItemInput,
@@ -60,7 +60,7 @@ export class InventoryResolver {
 
   @Mutation(() => InventoryItemType)
   @Roles(...INVENTORY_ROLES)
-  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  @Permissions(PERMISSIONS.PHARMACY_WRITE)
   async updateInventoryQuantity(
     @CurrentUser() user: AuthenticatedUser,
     @Args('input') input: UpdateInventoryQuantityInput,

--- a/apps/api/src/pharmacy/pharmacy.resolver.ts
+++ b/apps/api/src/pharmacy/pharmacy.resolver.ts
@@ -56,7 +56,7 @@ export class PharmacyResolver {
 
   @Mutation(() => PharmacyStockType)
   @Roles(...PHARMACY_ROLES)
-  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  @Permissions(PERMISSIONS.PHARMACY_WRITE)
   async upsertPharmacyStock(
     @CurrentUser() user: AuthenticatedUser,
     @Args('input') input: UpsertPharmacyStockInput,
@@ -75,7 +75,7 @@ export class PharmacyResolver {
 
   @Mutation(() => PendingPrescriptionType)
   @Roles(...PHARMACY_ROLES)
-  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  @Permissions(PERMISSIONS.PHARMACY_WRITE)
   async dispensePrescription(
     @CurrentUser() user: AuthenticatedUser,
     @Args('input') input: DispensePrescriptionInput,

--- a/apps/web/src/app/(dashboard)/inventory/page.tsx
+++ b/apps/web/src/app/(dashboard)/inventory/page.tsx
@@ -24,7 +24,7 @@ export default function InventoryPage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
-  const canWrite = (meData?.me?.permissions ?? []).includes('patients:write');
+  const canWrite = (meData?.me?.permissions ?? []).includes('pharmacy:write');
 
   const { data, loading, error: listError, refetch } = useQuery(INVENTORY_ITEMS_QUERY, {
     variables: { hospitalId },

--- a/apps/web/src/app/(dashboard)/pharmacy/page.tsx
+++ b/apps/web/src/app/(dashboard)/pharmacy/page.tsx
@@ -22,7 +22,7 @@ export default function PharmacyPage() {
 
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
-  const canWrite = (meData?.me?.permissions ?? []).includes('patients:write');
+  const canWrite = (meData?.me?.permissions ?? []).includes('pharmacy:write');
 
   const { data: rxData, loading: rxLoading, error: rxError, refetch: refetchRx } = useQuery(
     PENDING_PRESCRIPTIONS_QUERY,

--- a/packages/types/src/roles.ts
+++ b/packages/types/src/roles.ts
@@ -27,6 +27,7 @@ export const PERMISSIONS = {
   REPORTS_READ: 'reports:read',
   ROLES_MANAGE: 'roles:manage',
   LAB_WRITE: 'lab:write',
+  PHARMACY_WRITE: 'pharmacy:write',
 } as const;
 
 export type PermissionSlug = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];

--- a/supabase/migrations/20240609000029_pharmacy_write_permission.sql
+++ b/supabase/migrations/20240609000029_pharmacy_write_permission.sql
@@ -1,0 +1,33 @@
+-- Least-privilege for pharmacy operations (#264):
+-- pharmacist was granted patients:write (migration 009) only so pharmacy
+-- resolvers' permission checks passed. Replace it with a dedicated
+-- pharmacy:write slug and grant it to the roles allowed on the pharmacy
+-- and inventory write mutations.
+
+INSERT INTO permissions (slug, name, description)
+VALUES (
+  'pharmacy:write',
+  'Write Pharmacy',
+  'Manage pharmacy stock, dispense prescriptions, and manage inventory'
+)
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE p.slug = 'pharmacy:write'
+  AND r.slug IN (
+    'pharmacist',
+    'hospital_admin',
+    'hospital_manager',
+    'super_admin'
+  )
+ON CONFLICT DO NOTHING;
+
+DELETE FROM role_permissions rp
+USING roles r, permissions p
+WHERE rp.role_id = r.id
+  AND rp.permission_id = p.id
+  AND r.slug = 'pharmacist'
+  AND p.slug = 'patients:write';


### PR DESCRIPTION
Closes #264

## Problem
Migration 009 granted the `pharmacist` role `patients:write` — the patient-chart mutation permission — only so pharmacy resolvers' permission gates would pass. Every future resolver gating on `patients:write` alone would implicitly give pharmacists patient-chart write access.

## Fix (same pattern as `lab:write` from migration 013)
- **New permission slug `pharmacy:write`** in `packages/types` + migration `20240609000029_pharmacy_write_permission.sql`, granted to `pharmacist`, `hospital_admin`, `hospital_manager`, `super_admin`.
- Pharmacy (`upsertPharmacyStock`, `dispensePrescription`) and inventory (`createInventoryItem`, `updateInventoryQuantity`) write resolvers now gate on `pharmacy:write` (their `@Roles` lists are unchanged — identical role set).
- Migration 29 **revokes `patients:write` from pharmacist**. Blast radius check: patient-chart resolvers already exclude pharmacist via `@Roles`; uploads stay `patients:write`/`lab:write` (no pharmacy UI uploads documents, so revoking doesn't break any pharmacist flow).
- Pharmacy/inventory pages gate write buttons on `pharmacy:write` instead of `patients:write`.

## Verification
- `pnpm --filter @careconnect/types build` + `api build` + `api lint`: clean
- `pnpm --filter api test`: 164/164 pass
- web build: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated pharmacy write permission for inventory and pharmacy management.
  * Assigned pharmacy write access to appropriate pharmacy and administrative roles.

* **Bug Fixes**
  * Updated inventory and pharmacy actions to use pharmacy-specific access controls.
  * Removed pharmacists’ dependency on patient write permission for these tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->