### PR TITLE
fix: MaxLength on GraphQL inputs (#265)

### DIFF
--- a/apps/api/src/admissions/admissions.service.spec.ts
+++ b/apps/api/src/admissions/admissions.service.spec.ts
@@ -324,9 +324,7 @@ describe('AdmissionsService', () => {
       expect(admissionsRepo.createQueryBuilder).toHaveBeenCalledWith(
         'admission',
       );
-      expect(qb.andWhere).toHaveBeenCalledWith(
-        'patient.deleted_at IS NULL',
-      );
+      expect(qb.andWhere).toHaveBeenCalledWith('patient.deleted_at IS NULL');
     });
   });
 });

--- a/apps/api/src/admissions/admissions.types.ts
+++ b/apps/api/src/admissions/admissions.types.ts
@@ -1,5 +1,11 @@
 import { Field, ID, InputType, Int, ObjectType } from '@nestjs/graphql';
-import { IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
+import {
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 import { PatientType } from '../patients/patients.types';
 import { BedType, WardType } from '../facility/facility.types';
 import { UserSummaryType } from '../users/users.types';
@@ -92,6 +98,7 @@ export class AdmitPatientInput {
   @IsUUID()
   bedId: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -104,6 +111,7 @@ export class DischargeAdmissionInput {
   @IsUUID()
   id: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -132,6 +140,7 @@ export class TransferOutAdmissionInput {
   @IsUUID()
   admissionId: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/appointments/appointments.types.ts
+++ b/apps/api/src/appointments/appointments.types.ts
@@ -5,6 +5,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  MaxLength,
   MinLength,
 } from 'class-validator';
 import { APPOINTMENT_STATUSES } from '../database/entities/appointment.entity';
@@ -76,11 +77,13 @@ export class CreateAppointmentInput {
   @IsDateString()
   scheduledAt: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   reason?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -105,6 +108,7 @@ export class CancelAppointmentInput {
   @IsUUID()
   id: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -14,6 +15,18 @@ function isUniqueViolation(error: unknown): boolean {
     error instanceof QueryFailedError &&
     (error as QueryFailedError & { code?: string }).code === '23505'
   );
+}
+
+/** users.full_name is VARCHAR(255); reject oversized names before the DB does. */
+function assertFullName(fullName: string): string {
+  const trimmed = fullName?.trim() ?? '';
+  if (!trimmed) {
+    throw new BadRequestException('Full name is required');
+  }
+  if (trimmed.length > 255) {
+    throw new BadRequestException('Full name must be at most 255 characters');
+  }
+  return trimmed;
 }
 
 @Injectable()
@@ -165,6 +178,7 @@ export class AuthService {
     hospitalId?: string,
     assignHospitalAdmin = false,
   ) {
+    fullName = assertFullName(fullName);
     const user = await this.usersRepo.findOne({ where: { id: actor.id } });
     if (!user) throw new NotFoundException('User not found');
 
@@ -275,6 +289,7 @@ export class AuthService {
 
   /** Patient portal path: assign patient role and mark onboarding complete. */
   async completePatientOnboarding(user: AuthenticatedUser, fullName: string) {
+    fullName = assertFullName(fullName);
     const staffRoles = (user.roles ?? []).filter((role) => role !== 'patient');
     if (user.hospitalId || staffRoles.length > 0) {
       throw new ForbiddenException(

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -254,7 +254,11 @@ export class BillingService {
 
     const patients = await this.patientsRepo
       .createQueryBuilder('patient')
-      .select(['patient.id', 'patient.fullName', 'patient.identificationNumber'])
+      .select([
+        'patient.id',
+        'patient.fullName',
+        'patient.identificationNumber',
+      ])
       .where('patient.hospital_id = :hospitalId', { hospitalId })
       .andWhere('patient.deleted_at IS NULL')
       .andWhere(

--- a/apps/api/src/billing/billing.types.ts
+++ b/apps/api/src/billing/billing.types.ts
@@ -1,13 +1,14 @@
 import { Field, Float, ID, InputType, ObjectType } from '@nestjs/graphql';
 import {
-  IsArray,
   ArrayMaxSize,
   ArrayMinSize,
+  IsArray,
   IsIn,
   IsNumber,
   IsOptional,
   IsString,
   IsUUID,
+  MaxLength,
   Min,
   MinLength,
   ValidateNested,
@@ -97,6 +98,7 @@ export class InvoiceType {
 
 @InputType()
 export class CreateInvoiceItemInput {
+  @MaxLength(2000)
   @Field()
   @IsString()
   @MinLength(1)

--- a/apps/api/src/clinical/clinical.types.ts
+++ b/apps/api/src/clinical/clinical.types.ts
@@ -1,8 +1,8 @@
 import { Field, Float, ID, InputType, Int, ObjectType } from '@nestjs/graphql';
 import {
-  IsArray,
   ArrayMaxSize,
   ArrayMinSize,
+  IsArray,
   IsBoolean,
   IsIn,
   IsInt,
@@ -11,6 +11,7 @@ import {
   IsString,
   IsUUID,
   Max,
+  MaxLength,
   Min,
   MinLength,
   ValidateNested,
@@ -274,6 +275,7 @@ export class CreateVitalInput {
   @IsUUID()
   admissionId?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -301,6 +303,7 @@ export class CreateVitalInput {
   @IsOptional()
   height?: number;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -318,11 +321,13 @@ export class CreateDiagnosisInput {
   @IsUUID()
   admissionId?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   icdCode?: string;
 
+  @MaxLength(2000)
   @Field()
   @IsString()
   @MinLength(1)
@@ -345,21 +350,25 @@ export class CreateClinicalNoteInput {
   @IsUUID()
   admissionId?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   subjective?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   objective?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   assessment?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -368,6 +377,7 @@ export class CreateClinicalNoteInput {
 
 @InputType()
 export class PrescriptionItemInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
@@ -380,21 +390,25 @@ export class PrescriptionItemInput {
   @Max(NUMERIC_10_2_MAX)
   quantity?: number;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   dosage?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   frequency?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   duration?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -412,6 +426,7 @@ export class CreatePrescriptionInput {
   @IsUUID()
   admissionId?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -437,11 +452,13 @@ export class CreateLabOrderInput {
   @IsUUID()
   admissionId?: string;
 
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
   testName: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -454,21 +471,25 @@ export class CompleteLabResultInput {
   @IsUUID()
   labOrderId: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   resultValue?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   referenceRange?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   unit?: string;
 
+  @MaxLength(500)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/discharge/discharge.types.ts
+++ b/apps/api/src/discharge/discharge.types.ts
@@ -5,6 +5,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  MaxLength,
   MinLength,
 } from 'class-validator';
 import { FOLLOW_UP_STATUSES } from '../database/entities/follow-up.entity';
@@ -93,16 +94,19 @@ export class CreateDischargeInput {
   @IsUUID()
   admissionId: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   summary?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   medicationsAtDischarge?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -113,6 +117,7 @@ export class CreateDischargeInput {
   @IsDateString()
   followUpScheduledAt?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -143,11 +148,13 @@ export class CreateFollowUpInput {
   @IsDateString()
   scheduledAt: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   type?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -165,6 +172,7 @@ export class UpdateFollowUpStatusInput {
   @IsIn([...FOLLOW_UP_STATUSES])
   status: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/facility/facility.types.ts
+++ b/apps/api/src/facility/facility.types.ts
@@ -1,5 +1,12 @@
 import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
-import { IsIn, IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
+import {
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 /** Manual bed updates only allow available ↔ maintenance (occupied is admit/discharge). */
 export const MANUAL_BED_STATUSES = ['available', 'maintenance'] as const;
@@ -69,11 +76,13 @@ export class BedType {
 
 @InputType()
 export class CreateDepartmentInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
   name: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -82,6 +91,7 @@ export class CreateDepartmentInput {
 
 @InputType()
 export class CreateWardInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
@@ -92,6 +102,7 @@ export class CreateWardInput {
   @IsUUID()
   departmentId?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -104,6 +115,7 @@ export class CreateBedInput {
   @IsUUID()
   wardId: string;
 
+  @MaxLength(50)
   @Field()
   @IsString()
   @MinLength(1)

--- a/apps/api/src/hospitals/hospitals.types.ts
+++ b/apps/api/src/hospitals/hospitals.types.ts
@@ -1,5 +1,11 @@
 import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
-import { IsBoolean, IsOptional, IsString, MinLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 @ObjectType()
 export class HospitalType {
@@ -39,31 +45,37 @@ export class HospitalType {
 
 @InputType()
 export class CreateHospitalInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(2)
   name: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   email?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   phone?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   address?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   city?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -72,36 +84,43 @@ export class CreateHospitalInput {
 
 @InputType()
 export class UpdateHospitalInput {
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   email?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   phone?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   address?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   city?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   country?: string;
 
+  @MaxLength(500)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/inventory/inventory.types.ts
+++ b/apps/api/src/inventory/inventory.types.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  MaxLength,
   Min,
   MinLength,
 } from 'class-validator';
@@ -40,11 +41,13 @@ export class InventoryItemType {
 
 @InputType()
 export class CreateInventoryItemInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
   name: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -56,6 +59,7 @@ export class CreateInventoryItemInput {
   @Min(0)
   quantity?: number;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -830,7 +830,9 @@ export class PatientsService {
     const patient = await this.findPatientOrThrow(patientId, hospitalId);
 
     if (!patient.userId) {
-      throw new BadRequestException('Patient chart is not linked to a portal account');
+      throw new BadRequestException(
+        'Patient chart is not linked to a portal account',
+      );
     }
 
     const previousUserId = patient.userId;

--- a/apps/api/src/patients/patients.types.ts
+++ b/apps/api/src/patients/patients.types.ts
@@ -414,7 +414,7 @@ export class CreatePatientInput {
   @IsString()
   bloodGroup?: string;
 
-  @MaxLength(100)
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -549,7 +549,7 @@ export class UpdatePatientInput {
   @IsString()
   bloodGroup?: string;
 
-  @MaxLength(100)
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -671,7 +671,7 @@ export class BulkPatientRowInput {
   @Field({ nullable: true })
   bloodGroup?: string;
 
-  @MaxLength(100)
+  @MaxLength(2000)
   @Field({ nullable: true })
   address?: string;
 
@@ -695,7 +695,7 @@ export class BulkPatientRowInput {
   @Field({ nullable: true })
   insurancePolicyNumber?: string;
 
-  @MaxLength(2000)
+  @MaxLength(255)
   @Field({ nullable: true })
   allergies?: string;
 

--- a/apps/api/src/patients/patients.types.ts
+++ b/apps/api/src/patients/patients.types.ts
@@ -6,6 +6,7 @@ import {
   IsIn,
   IsOptional,
   IsString,
+  MaxLength,
   MinLength,
   ValidateNested,
 } from 'class-validator';
@@ -237,16 +238,19 @@ export class BulkImportResultType {
 
 @InputType()
 export class EmergencyContactInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
   name: string;
 
+  @MaxLength(50)
   @Field()
   @IsString()
   @MinLength(1)
   phone: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -255,16 +259,19 @@ export class EmergencyContactInput {
 
 @InputType()
 export class PatientInsuranceInput {
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   provider?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   policyNumber?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -273,21 +280,25 @@ export class PatientInsuranceInput {
 
 @InputType()
 export class PatientAllergyInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
   allergen: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   severity?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   reaction?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -296,21 +307,25 @@ export class PatientAllergyInput {
 
 @InputType()
 export class PatientMedicationInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
   name: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   dosage?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   frequency?: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -324,21 +339,25 @@ export class MedicalHistoryInput {
   @IsIn(['past', 'family', 'surgical'])
   type: string;
 
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
   condition: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   diagnosisDate?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   relation?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -359,76 +378,91 @@ export class PatientConsentInput {
 
 @InputType()
 export class CreatePatientInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(2)
   fullName: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsEmail()
   email?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   phone?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   dateOfBirth?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsIn([...PATIENT_GENDERS])
   gender?: string;
 
+  @MaxLength(10)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   bloodGroup?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   address?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   city?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   state?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   zipCode?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   country?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   occupation?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   identificationType?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   identificationNumber?: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -478,77 +512,92 @@ export class CreatePatientInput {
 
 @InputType()
 export class UpdatePatientInput {
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   @MinLength(2)
   fullName?: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsEmail()
   email?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   phone?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   dateOfBirth?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsIn([...PATIENT_GENDERS])
   gender?: string;
 
+  @MaxLength(10)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   bloodGroup?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   address?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   city?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   state?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   zipCode?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   country?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   occupation?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   identificationType?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   identificationNumber?: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -598,69 +647,88 @@ export class UpdatePatientInput {
 
 @InputType()
 export class BulkPatientRowInput {
+  @MaxLength(255)
   @Field()
   fullName: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   email?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   phone?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   dateOfBirth?: string;
 
+  @MaxLength(20)
   @Field({ nullable: true })
   gender?: string;
 
+  @MaxLength(10)
   @Field({ nullable: true })
   bloodGroup?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   address?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   city?: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   emergencyContactName?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   emergencyContactPhone?: string;
 
+  @MaxLength(255)
   @Field({ nullable: true })
   insuranceProvider?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   insurancePolicyNumber?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   allergies?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   identificationType?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   identificationNumber?: string;
 }
 
 @InputType()
 export class PatientDocumentInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
   name: string;
 
+  @MaxLength(500)
   @Field()
   @IsString()
   @MinLength(1)
   fileUrl: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   fileType?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/pharmacy/pharmacy.types.ts
+++ b/apps/api/src/pharmacy/pharmacy.types.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  MaxLength,
   Min,
   MinLength,
 } from 'class-validator';
@@ -72,6 +73,7 @@ export class PendingPrescriptionType {
 
 @InputType()
 export class UpsertPharmacyStockInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(1)
@@ -89,6 +91,7 @@ export class UpsertPharmacyStockInput {
   @Min(0)
   expectedQuantity?: number;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/staff/staff.types.ts
+++ b/apps/api/src/staff/staff.types.ts
@@ -4,6 +4,7 @@ import {
   IsEmail,
   IsOptional,
   IsString,
+  MaxLength,
   MinLength,
 } from 'class-validator';
 
@@ -54,6 +55,7 @@ export class StaffType {
 
 @InputType()
 export class CreateStaffInput {
+  @MaxLength(255)
   @Field()
   @IsString()
   @MinLength(2)
@@ -63,6 +65,7 @@ export class CreateStaffInput {
   @IsEmail()
   email: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -72,16 +75,19 @@ export class CreateStaffInput {
   @IsString()
   roleSlug: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   department?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   specialization?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -90,11 +96,13 @@ export class CreateStaffInput {
 
 @InputType()
 export class UpdateStaffInput {
+  @MaxLength(255)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   fullName?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
@@ -105,16 +113,19 @@ export class UpdateStaffInput {
   @IsString()
   roleSlug?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   department?: string;
 
+  @MaxLength(100)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   specialization?: string;
 
+  @MaxLength(50)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## Summary
- Add `@MaxLength` on GraphQL `InputType` string fields aligned to column/text limits
- Onboarding names validated in `AuthService` (255) before DB write
- Closes #265

## Test plan
- [ ] Oversized `createPatient.fullName` → 400 Bad Request, not 500
- [ ] Valid existing payloads still succeed
- [ ] API lint/tests pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding validation by rejecting blank names and names exceeding supported limits.
  * Added safeguards against overly long text across admissions, appointments, billing, clinical records, discharge details, facilities, hospitals, inventory, patients, pharmacy, and staff information.
  * Requests now provide clearer validation feedback when text fields exceed their allowed lengths.

* **Quality Improvements**
  * Standardized input constraints for names, contact details, notes, descriptions, identifiers, URLs, and clinical data to improve data consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->