### PR TITLE
fix(web): require NEXT_PUBLIC_API_URL instead of localhost fallback

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,10 @@
 import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
+import { getPublicApiUrl } from './src/lib/api-url';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000/graphql';
+const API_URL = getPublicApiUrl();
 
 // Clerk hydrates via inline scripts (SSR state + cache signals) and loads
 // clerk-js from its Frontend API, so script-src must keep 'unsafe-inline'

--- a/apps/web/src/app/(dashboard)/lab/page.tsx
+++ b/apps/web/src/app/(dashboard)/lab/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/lib/graphql/queries';
 import { QueryError } from '@/components/query-error';
 import { canAuthorClinical } from '@/lib/clinical-access';
+import { getApiOrigin } from '@/lib/api-url';
 
 const statusVariant = (status: string) => {
   switch (status) {
@@ -76,9 +77,7 @@ export default function LabPage() {
     permissions.includes('patients:write') && canAuthorClinical(roles);
   const canWriteLab = permissions.includes('lab:write');
 
-  const apiBase = (
-    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql'
-  ).replace(/\/graphql\/?$/, '');
+  const apiBase = getApiOrigin();
 
   const { data, loading, error: listError, refetch } = useQuery(LAB_ORDERS_QUERY, {
     variables: { hospitalId, status: undefined },

--- a/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/patients/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
   canWritePatientDemographics,
 } from '@/lib/clinical-access';
 import { useAuth } from '@clerk/nextjs';
+import { getApiOrigin } from '@/lib/api-url';
 
 /** Free-form status values — admission/discharge flows own admitted/discharged. */
 const EDITABLE_PATIENT_STATUSES = ['registered', 'checked_in', 'inactive'] as const;
@@ -176,9 +177,7 @@ export default function PatientDetailPage() {
     }
   };
 
-  const apiBase = (
-    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql'
-  ).replace(/\/graphql\/?$/, '');
+  const apiBase = getApiOrigin();
 
   const handleOpenDocument = async (fileUrl: string) => {
     const token = await getToken();

--- a/apps/web/src/app/(portal)/portal/documents/page.tsx
+++ b/apps/web/src/app/(portal)/portal/documents/page.tsx
@@ -8,6 +8,7 @@ import { ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { PortalQueryError } from '@/components/portal/portal-query-error';
 import { PORTAL_PATIENT_RECORDS_QUERY } from '@/lib/graphql/queries';
+import { getApiOrigin } from '@/lib/api-url';
 
 export default function PortalDocumentsPage() {
   const { getToken } = useAuth();
@@ -16,9 +17,7 @@ export default function PortalDocumentsPage() {
   const patient = data?.portalPatientRecords?.patient;
   const documents = data?.portalPatientRecords?.documents ?? [];
 
-  const apiBase = (
-    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql'
-  ).replace(/\/graphql\/?$/, '');
+  const apiBase = getApiOrigin();
 
   const handleOpenDocument = async (fileUrl: string) => {
     setFileError('');

--- a/apps/web/src/app/(portal)/portal/lab-results/page.tsx
+++ b/apps/web/src/app/(portal)/portal/lab-results/page.tsx
@@ -8,6 +8,7 @@ import { ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { PortalQueryError } from '@/components/portal/portal-query-error';
 import { PORTAL_PATIENT_RECORDS_QUERY } from '@/lib/graphql/queries';
+import { getApiOrigin } from '@/lib/api-url';
 
 export default function PortalLabResultsPage() {
   const { getToken } = useAuth();
@@ -16,9 +17,7 @@ export default function PortalLabResultsPage() {
   const patient = data?.portalPatientRecords?.patient;
   const labResults = data?.portalPatientRecords?.labResults ?? [];
 
-  const apiBase = (
-    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/graphql'
-  ).replace(/\/graphql\/?$/, '');
+  const apiBase = getApiOrigin();
 
   const handleOpenResultFile = async (fileUrl: string) => {
     setFileError('');

--- a/apps/web/src/lib/api-url.ts
+++ b/apps/web/src/lib/api-url.ts
@@ -1,0 +1,9 @@
+export function getPublicApiUrl(): string {
+  const url = process.env.NEXT_PUBLIC_API_URL;
+  if (!url) throw new Error('NEXT_PUBLIC_API_URL is required');
+  return url;
+}
+
+export function getApiOrigin(): string {
+  return getPublicApiUrl().replace(/\/graphql\/?$/, '');
+}

--- a/apps/web/src/lib/apollo-client.ts
+++ b/apps/web/src/lib/apollo-client.ts
@@ -4,8 +4,9 @@ import { useMemo } from 'react';
 import { ApolloClient, HttpLink, InMemoryCache, from } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { useAuth } from '@clerk/nextjs';
+import { getPublicApiUrl } from '@/lib/api-url';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000/graphql';
+const API_URL = getPublicApiUrl();
 
 /**
  * Returns a memoized Apollo client wired to the current Clerk session.


### PR DESCRIPTION
## Summary
- Fail build and client boot when `NEXT_PUBLIC_API_URL` is unset instead of silently using `http://localhost:4000/graphql`.
- Add a shared `getPublicApiUrl` / `getApiOrigin` helper and use it in Apollo, `next.config`, and upload/fetch call sites.
- CI already sets `NEXT_PUBLIC_API_URL` for the web build, so `next build` continues to succeed; `.env.example` still documents the variable for local setup.

Closes #274

## Test plan
- [ ] Confirm `.github/workflows/ci.yml` still sets `NEXT_PUBLIC_API_URL` on the web build and CI `lint-and-build` passes.
- [ ] With `apps/web/.env.local` copied from `.env.example`, `pnpm --filter web dev` still points Apollo/fetch at the GraphQL origin.
- [ ] Unset `NEXT_PUBLIC_API_URL` and verify `next build` / module init throws `NEXT_PUBLIC_API_URL is required` rather than calling localhost.
- [ ] Open a patient document, portal document, portal lab result, and lab attachment and confirm they still fetch from the API origin.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API endpoint handling across dashboard and portal pages.
  * Ensured document uploads, document retrieval, lab results, and GraphQL requests use a consistent API URL.
  * Added clear configuration validation when the public API URL is unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->