### PR TITLE
fix(rbac): restrict chart GraphQL reads and pharmacist billing:read

### DIFF
--- a/apps/api/src/admissions/admissions.resolver.ts
+++ b/apps/api/src/admissions/admissions.resolver.ts
@@ -17,12 +17,22 @@ import {
   WardOccupancyType,
 } from './admissions.types';
 
+const CHART_READ_ROLES = [
+  ROLES.DOCTOR,
+  ROLES.NURSE,
+  ROLES.RECEPTIONIST,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+  ROLES.SUPER_ADMIN,
+] as const;
+
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class AdmissionsResolver {
   constructor(private readonly admissionsService: AdmissionsService) {}
 
   @Query(() => [AdmissionType])
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async activeAdmissions(
     @CurrentUser() user: AuthenticatedUser,
@@ -36,6 +46,7 @@ export class AdmissionsResolver {
   }
 
   @Query(() => [WardOccupancyType])
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async wardOccupancy(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/billing/billing.resolver.ts
+++ b/apps/api/src/billing/billing.resolver.ts
@@ -1,13 +1,12 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { PERMISSIONS } from '@careconnect/types';
+import { PERMISSIONS, ROLES } from '@careconnect/types';
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
-import { STAFF_ROLES } from '../rbac/staff-roles';
 import { BillingService } from './billing.service';
 import {
   CreateInvoiceInput,
@@ -16,13 +15,26 @@ import {
   BillingPatientLookupType,
 } from './billing.types';
 
+/**
+ * Billing resolvers: finance roles only.
+ * Seed 002 grants billing:read to accountant/hospital_admin/super_admin.
+ * Receptionist does not have billing:read. Pharmacist is excluded (#282).
+ * hospital_manager is listed for defense in depth even without the slug.
+ */
+const BILLING_ROLES = [
+  ROLES.ACCOUNTANT,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+  ROLES.SUPER_ADMIN,
+] as const;
+
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class BillingResolver {
   constructor(private readonly billingService: BillingService) {}
 
   @Query(() => [InvoiceType])
-  @Roles(...STAFF_ROLES)
+  @Roles(...BILLING_ROLES)
   @Permissions(PERMISSIONS.BILLING_READ)
   async invoices(
     @CurrentUser() user: AuthenticatedUser,
@@ -36,7 +48,7 @@ export class BillingResolver {
   }
 
   @Query(() => [BillingPatientLookupType])
-  @Roles(...STAFF_ROLES)
+  @Roles(...BILLING_ROLES)
   @Permissions(PERMISSIONS.BILLING_READ)
   async billingPatientSearch(
     @CurrentUser() user: AuthenticatedUser,
@@ -56,7 +68,7 @@ export class BillingResolver {
   }
 
   @Query(() => InvoiceType)
-  @Roles(...STAFF_ROLES)
+  @Roles(...BILLING_ROLES)
   @Permissions(PERMISSIONS.BILLING_READ)
   async invoice(
     @CurrentUser() user: AuthenticatedUser,
@@ -71,7 +83,7 @@ export class BillingResolver {
   }
 
   @Mutation(() => InvoiceType)
-  @Roles(...STAFF_ROLES)
+  @Roles(...BILLING_ROLES)
   @Permissions(PERMISSIONS.BILLING_WRITE)
   async createInvoice(
     @CurrentUser() user: AuthenticatedUser,
@@ -86,7 +98,7 @@ export class BillingResolver {
   }
 
   @Mutation(() => InvoiceType)
-  @Roles(...STAFF_ROLES)
+  @Roles(...BILLING_ROLES)
   @Permissions(PERMISSIONS.BILLING_WRITE)
   async recordPayment(
     @CurrentUser() user: AuthenticatedUser,
@@ -101,7 +113,7 @@ export class BillingResolver {
   }
 
   @Mutation(() => InvoiceType)
-  @Roles(...STAFF_ROLES)
+  @Roles(...BILLING_ROLES)
   @Permissions(PERMISSIONS.BILLING_WRITE)
   async voidInvoice(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/clinical/clinical.resolver.ts
+++ b/apps/api/src/clinical/clinical.resolver.ts
@@ -39,12 +39,33 @@ const CLINICAL_AUTHOR_ROLES = [
   ROLES.HOSPITAL_MANAGER,
 ] as const;
 
+/** Chart reads: clinical staff, not pharmacist or lab_technician. */
+const CHART_READ_ROLES = [
+  ROLES.DOCTOR,
+  ROLES.NURSE,
+  ROLES.RECEPTIONIST,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+  ROLES.SUPER_ADMIN,
+] as const;
+
+/** Lab worklist: lab techs plus clinical staff. Pharmacist is excluded. */
+const LAB_ORDER_READ_ROLES = [
+  ROLES.LAB_TECHNICIAN,
+  ROLES.DOCTOR,
+  ROLES.NURSE,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+  ROLES.SUPER_ADMIN,
+] as const;
+
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class ClinicalResolver {
   constructor(private readonly clinicalService: ClinicalService) {}
 
   @Query(() => [LabOrderType])
+  @Roles(...LAB_ORDER_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async labOrders(
     @CurrentUser() user: AuthenticatedUser,
@@ -59,6 +80,7 @@ export class ClinicalResolver {
   }
 
   @Query(() => [VitalSignType])
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async vitalSigns(
     @CurrentUser() user: AuthenticatedUser,
@@ -73,6 +95,7 @@ export class ClinicalResolver {
   }
 
   @Query(() => [ClinicalNoteType])
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async clinicalNotes(
     @CurrentUser() user: AuthenticatedUser,
@@ -90,6 +113,7 @@ export class ClinicalResolver {
   }
 
   @Query(() => [DiagnosisType])
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async diagnoses(
     @CurrentUser() user: AuthenticatedUser,
@@ -104,6 +128,7 @@ export class ClinicalResolver {
   }
 
   @Query(() => [PrescriptionType])
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async prescriptions(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/discharge/discharge.resolver.ts
+++ b/apps/api/src/discharge/discharge.resolver.ts
@@ -16,12 +16,23 @@ import {
   UpdateFollowUpStatusInput,
 } from './discharge.types';
 
+/** Chart reads: clinical staff, not pharmacist or lab_technician. */
+const CHART_READ_ROLES = [
+  ROLES.DOCTOR,
+  ROLES.NURSE,
+  ROLES.RECEPTIONIST,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+  ROLES.SUPER_ADMIN,
+] as const;
+
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class DischargeResolver {
   constructor(private readonly dischargeService: DischargeService) {}
 
   @Query(() => [FollowUpType])
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async followUps(
     @CurrentUser() user: AuthenticatedUser,
@@ -36,6 +47,7 @@ export class DischargeResolver {
   }
 
   @Query(() => [DischargeType])
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async discharges(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/patients/patients.resolver.ts
+++ b/apps/api/src/patients/patients.resolver.ts
@@ -20,12 +20,23 @@ import {
   UpdatePatientInput,
 } from './patients.types';
 
+/** Chart/directory reads: clinical staff, not pharmacist or lab_technician. */
+const CHART_READ_ROLES = [
+  ROLES.DOCTOR,
+  ROLES.NURSE,
+  ROLES.RECEPTIONIST,
+  ROLES.HOSPITAL_ADMIN,
+  ROLES.HOSPITAL_MANAGER,
+  ROLES.SUPER_ADMIN,
+] as const;
+
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class PatientsResolver {
   constructor(private readonly patientsService: PatientsService) {}
 
   @Query(() => PatientsPageType)
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async patients(
     @CurrentUser() user: AuthenticatedUser,
@@ -47,6 +58,7 @@ export class PatientsResolver {
   }
 
   @Query(() => PatientDetailType)
+  @Roles(...CHART_READ_ROLES)
   @Permissions(PERMISSIONS.PATIENTS_READ)
   async patient(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/web/src/lib/route-access.ts
+++ b/apps/web/src/lib/route-access.ts
@@ -77,9 +77,19 @@ const ROUTE_RULES: RouteRule[] = [
     requireAll: true,
   },
   { prefix: '/appointments', anyPermissions: ['appointments:read'] },
-  { prefix: '/admissions', anyPermissions: ['patients:read'] },
+  {
+    prefix: '/admissions',
+    anyPermissions: ['patients:read'],
+    anyRoles: CLINICAL_STAFF_ROLES,
+    requireAll: true,
+  },
   { prefix: '/wards', anyPermissions: ['hospitals:read', 'patients:read'] },
-  { prefix: '/follow-ups', anyPermissions: ['patients:read'] },
+  {
+    prefix: '/follow-ups',
+    anyPermissions: ['patients:read'],
+    anyRoles: CLINICAL_STAFF_ROLES,
+    requireAll: true,
+  },
   { prefix: '/finance', anyPermissions: ['billing:read'] },
   {
     prefix: '/pharmacy',

--- a/apps/web/src/lib/route-access.ts
+++ b/apps/web/src/lib/route-access.ts
@@ -13,10 +13,12 @@ type RouteRule = {
   prefix: string;
   anyPermissions?: string[];
   anyRoles?: string[];
+  /** When both are set, require permission AND role (e.g. patient directory). */
+  requireAll?: boolean;
 };
 
-/** Roles allowed to create/edit/import patient charts (excludes pharmacist). */
-const PATIENT_DEMOGRAPHIC_WRITE_ROLES = [
+/** Clinical staff who may browse/edit patient charts (excludes pharmacist, lab_technician). */
+const CLINICAL_STAFF_ROLES = [
   'doctor',
   'nurse',
   'receptionist',
@@ -32,13 +34,13 @@ const WRITE_ROUTE_RULES: (RouteRule & { requireAll?: boolean })[] = [
   {
     prefix: '/patients/import',
     anyPermissions: ['patients:write'],
-    anyRoles: PATIENT_DEMOGRAPHIC_WRITE_ROLES,
+    anyRoles: CLINICAL_STAFF_ROLES,
     requireAll: true,
   },
   {
     prefix: '/patients/new',
     anyPermissions: ['patients:write'],
-    anyRoles: PATIENT_DEMOGRAPHIC_WRITE_ROLES,
+    anyRoles: CLINICAL_STAFF_ROLES,
     requireAll: true,
   },
   { prefix: '/staff/new', anyPermissions: ['staff:write'] },
@@ -54,7 +56,7 @@ const WRITE_ROUTE_PATTERNS: {
   {
     pattern: /^\/patients\/[^/]+\/edit$/,
     anyPermissions: ['patients:write'],
-    anyRoles: PATIENT_DEMOGRAPHIC_WRITE_ROLES,
+    anyRoles: CLINICAL_STAFF_ROLES,
     requireAll: true,
   },
   {
@@ -68,7 +70,12 @@ const WRITE_ROUTE_PATTERNS: {
 
 const ROUTE_RULES: RouteRule[] = [
   { prefix: '/staff', anyPermissions: ['staff:read'] },
-  { prefix: '/patients', anyPermissions: ['patients:read'] },
+  {
+    prefix: '/patients',
+    anyPermissions: ['patients:read'],
+    anyRoles: CLINICAL_STAFF_ROLES,
+    requireAll: true,
+  },
   { prefix: '/appointments', anyPermissions: ['appointments:read'] },
   { prefix: '/admissions', anyPermissions: ['patients:read'] },
   { prefix: '/wards', anyPermissions: ['hospitals:read', 'patients:read'] },
@@ -166,11 +173,7 @@ export function canAccessRoute(pathname: string, ctx: AccessContext): boolean {
   );
   if (!rule) return false;
 
-  if (rule.anyRoles?.some((role) => ctx.roles.includes(role))) return true;
-  if (rule.anyPermissions?.some((perm) => ctx.permissions.includes(perm))) {
-    return true;
-  }
-  return false;
+  return hasWriteAccess(rule, ctx);
 }
 
 /** Whether a nav href should be shown for this user */

--- a/supabase/migrations/20240609000030_revoke_pharmacist_billing_read.sql
+++ b/supabase/migrations/20240609000030_revoke_pharmacist_billing_read.sql
@@ -1,0 +1,12 @@
+-- Least-privilege (#282): pharmacists do not need hospital-wide invoice access.
+-- Seed 002 did not grant pharmacist billing:read; wave0 (004) added it so they
+-- could pass BillingResolver's STAFF_ROLES + billing:read gate. Finance PHI
+-- (invoices, nested patient identity) is not part of dispense/stock work.
+-- After this revoke, Permissions(BILLING_READ) fails for pharmacist.
+
+DELETE FROM role_permissions rp
+USING roles r, permissions p
+WHERE rp.role_id = r.id
+  AND rp.permission_id = p.id
+  AND r.slug = 'pharmacist'
+  AND p.slug = 'billing:read';


### PR DESCRIPTION
## Summary
- Gate patient/clinical/discharge **read** queries with `@Roles` (clinical staff) while keeping `patients:read`. Lab techs keep `labOrders`; pharmacists keep `pendingPrescriptions` and cannot browse `/patients` or full charts.
- Revoke pharmacist `billing:read` (wave0 leftover) and replace billing resolver `STAFF_ROLES` with `BILLING_ROLES` (`accountant`, `hospital_admin`, `hospital_manager`, `super_admin`). Receptionist never had `billing:read` in seed 002.
- `/patients` nav/route now requires clinical roles **and** `patients:read`. `/finance` still uses `billing:read` (hidden after the seed revoke).

Closes #281
Closes #282

## Test plan
- [ ] As pharmacist: `patients`, `patient(id)`, `clinicalNotes`, `diagnoses`, `vitals`, `prescriptions`, `labOrders`, `followUps`, `discharges` return 403; `pendingPrescriptions` still works; `/patients` and `/finance` hidden
- [ ] As lab technician: full chart queries 403; `labOrders` still works; `/lab` still shown; `/patients` hidden
- [ ] As doctor/nurse/receptionist/admin: patient directory and chart reads still work
- [ ] As accountant/hospital_admin: invoices and `/finance` still work
- [ ] Apply migration `20240609000030_revoke_pharmacist_billing_read.sql` on a local DB and confirm pharmacist has no `billing:read`


Made with [Cursor](https://cursor.com)