### PR TITLE
fix(auth): remove unused AuthService.assignRole (#267)

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -309,17 +309,4 @@ export class AuthService {
       }
     }
   }
-
-  async assignRole(userId: string, roleSlug: string, hospitalId?: string) {
-    const role = await this.rolesRepo.findOne({ where: { slug: roleSlug } });
-    if (!role) return;
-    const existing = await this.userRolesRepo.findOne({
-      where: { userId, roleId: role.id, hospitalId: hospitalId ?? undefined },
-    });
-    if (!existing) {
-      await this.userRolesRepo.save(
-        this.userRolesRepo.create({ userId, roleId: role.id, hospitalId }),
-      );
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- Delete `AuthService.assignRole`, which had no callers (roles are assigned inline in onboarding and staff invite flows).
- Leave `PaginationInput` unchanged so list pagination in #270 can reuse it.

Closes #267.

## Test plan
- [ ] Confirm grep shows no remaining `assignRole` references besides unrelated copy (landing “assign role-based permissions”).
- [ ] Confirm API still starts and existing auth/onboarding tests pass.
- [ ] Confirm `PaginationInput` remains in `apps/api/src/common/dto/pagination.dto.ts`.


Made with [Cursor](https://cursor.com)