### PR TITLE
fix(web): drop leftover (Phase 3) from dashboard getting-started copy

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -169,7 +169,7 @@ export default function DashboardPage() {
               { done: !!meData?.me?.onboardingCompleted, text: 'Complete onboarding' },
               { done: hasStaff, text: 'Add your first staff member' },
               { done: hasPatients, text: 'Register your first patient' },
-              { done: hasAppointments, text: 'Set up appointment scheduling (Phase 3)' },
+              { done: hasAppointments, text: 'Set up appointment scheduling' },
             ].map((item) => (
               <li key={item.text} className="flex items-center gap-3 text-sm">
                 <span


### PR DESCRIPTION
## Summary
- Removes the stale `(Phase 3)` label from the dashboard Getting Started card.
- Appointments already shipped; the checklist item itself is unchanged.

Closes #269.

## Test plan
- [ ] Open `/dashboard` and confirm Getting Started still lists “Set up appointment scheduling”
- [ ] Confirm the parenthetical “(Phase 3)” is gone
- [ ] Confirm the rest of the dashboard UI is unchanged