### PR TITLE
fix(web): compute today from local date instead of UTC (#272)

### DIFF
--- a/apps/web/src/app/(dashboard)/appointments/page.tsx
+++ b/apps/web/src/app/(dashboard)/appointments/page.tsx
@@ -13,10 +13,7 @@ import {
   UPDATE_APPOINTMENT_STATUS_MUTATION,
 } from '@/lib/graphql/queries';
 import { QueryError } from '@/components/query-error';
-
-function todayDateString() {
-  return new Date().toISOString().slice(0, 10);
-}
+import { localDateISO } from '@/lib/local-date';
 
 function formatTime(iso: string) {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -37,7 +34,7 @@ const statusVariant = (status: string) => {
 };
 
 export default function AppointmentsPage() {
-  const [selectedDate, setSelectedDate] = useState(todayDateString());
+  const [selectedDate, setSelectedDate] = useState(localDateISO());
   const [statusError, setStatusError] = useState('');
   const { data: meData } = useQuery(ME_QUERY);
   const me = meData?.me;

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
   STAFF_MEMBERS_QUERY,
 } from '@/lib/graphql/queries';
 import { canAccessRoute } from '@/lib/route-access';
+import { localDateISO } from '@/lib/local-date';
 
 const QUICK_ACTIONS = [
   { label: 'Register Patient', href: '/patients/new', anyPermissions: ['patients:write'] },
@@ -44,7 +45,7 @@ function canSeeQuickAction(
 }
 
 function todayDateString() {
-  return new Date().toISOString().slice(0, 10);
+  return localDateISO();
 }
 
 export default function DashboardPage() {

--- a/apps/web/src/app/(dashboard)/doctor/page.tsx
+++ b/apps/web/src/app/(dashboard)/doctor/page.tsx
@@ -7,17 +7,14 @@ import { ClayBadge, ClayButton, ClayCard } from '@careconnect/ui';
 import { DashboardHeader } from '@/components/layout/dashboard-header';
 import { QueryError } from '@/components/query-error';
 import { APPOINTMENTS_QUERY, ME_QUERY } from '@/lib/graphql/queries';
-
-function todayDateString() {
-  return new Date().toISOString().slice(0, 10);
-}
+import { localDateISO } from '@/lib/local-date';
 
 function formatTime(iso: string) {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
 export default function DoctorDashboardPage() {
-  const today = todayDateString();
+  const today = localDateISO();
   const { data: meData } = useQuery(ME_QUERY);
   const hospitalId = meData?.me?.hospitalId;
   const doctorId = meData?.me?.id;

--- a/apps/web/src/lib/local-date.ts
+++ b/apps/web/src/lib/local-date.ts
@@ -1,0 +1,6 @@
+export function localDateISO(d = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}


### PR DESCRIPTION
## Summary
- Add `localDateISO()` so today uses the user local calendar date instead of UTC `toISOString().slice(0, 10)`.
- Use it on the appointments, doctor, and dashboard pages so lists no longer default to yesterday for users ahead of UTC (e.g. IST).
- Dashboard date change is a one-line swap inside `todayDateString()` to keep merge conflicts with #269 small.

Closes #272.

## Test plan
- [ ] In a timezone ahead of UTC (e.g. IST), open `/appointments` between local midnight and UTC midnight — selected date should be today, not yesterday.
- [ ] Doctor home and dashboard appointments-today queries use the same local date.
- [ ] Confirm Getting Started still says "Set up appointment scheduling (Phase 3)" on this branch.
