### PR TITLE
fix(snyk): exclude abandoned legacy/ prototype from Snyk scans

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file
+#
+# `legacy/` is an abandoned Vite + React prototype (out of support). Do not
+# expand Snyk to scan it — high false-positive risk from unmaintained deps.
+# See CONTRIBUTING.md.
+exclude:
+  global:
+    - legacy/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,14 @@ Do not commit secrets (`.env`, keys, credentials).
 Dependency scanning:
 
 ```bash
-snyk test --all-projects
+snyk test --all-projects --exclude=legacy
 ```
+
+`legacy/` is an abandoned Vite + React prototype: **out of support**, not in the
+pnpm workspace, and **excluded from Snyk**. Do not add it to the workspace or
+to Snyk monitoring (high false-positive risk from unmaintained deps). Path
+excludes for Snyk Code/Secrets live in `.snyk`; `--exclude=legacy` keeps
+`snyk test --all-projects` from treating `legacy/package.json` as a project.
 
 ### Enabling Snyk Code (SAST)
 
@@ -108,5 +114,6 @@ File any new code findings as GitHub issues with severity P0–P4.
 - `packages/types` — Shared types and Zod schemas
 - `supabase/migrations` — Neon-compatible SQL migrations
 - `docs/` — Architecture and API documentation
+- `legacy/` — Abandoned Vite prototype (out of support; excluded from Snyk)
 
 See [docs/architecture.md](docs/architecture.md) and [docs/api.md](docs/api.md) for deeper context.

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,0 +1,1 @@
+Abandoned Vite + React prototype — out of support and excluded from Snyk. See CONTRIBUTING.md.


### PR DESCRIPTION
## Summary
- Treats `legacy/` as out of support: not in the pnpm workspace and not expanded into Snyk monitoring (high false-positive risk).
- Adds a root `.snyk` `exclude.global` for `legacy/**` (Snyk Code/Secrets) and documents `snyk test --all-projects --exclude=legacy` in CONTRIBUTING.md.
- Adds a one-line `legacy/README.md` pointing at CONTRIBUTING.

Closes #268.

## Test plan
- [ ] Confirm `legacy/` is still outside `pnpm-workspace.yaml`
- [ ] Confirm `.snyk` excludes `legacy/**`
- [ ] Confirm CONTRIBUTING.md states `legacy/` is out of support and excluded from Snyk
- [ ] Do **not** add `legacy/` to the workspace or run `snyk test` against it