### PR TITLE
fix(uploads): schedule orphan-upload sweep every 6 hours

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,6 +33,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.1",
     "class-transformer": "^0.5.1",

--- a/apps/api/src/uploads/uploads.module.ts
+++ b/apps/api/src/uploads/uploads.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import {
@@ -13,6 +14,7 @@ import { UploadsService } from './uploads.service';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     AuthModule,
     TypeOrmModule.forFeature([
       PatientDocument,

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -533,4 +533,17 @@ describe('UploadsService', () => {
       expect(queryRunner.release).toHaveBeenCalled();
     });
   });
+
+  describe('scheduled orphan sweep', () => {
+    it('uses a 6-hour interval and the same removeOrphanUploads path', () => {
+      expect(UploadsService.ORPHAN_SWEEP_INTERVAL_MS).toBe(6 * 60 * 60 * 1000);
+      const spy = jest
+        .spyOn(service, 'removeOrphanUploads')
+        .mockResolvedValue(undefined);
+
+      service.sweepOrphanUploadsOnInterval();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -5,6 +5,7 @@ import {
   NotFoundException,
   OnApplicationBootstrap,
 } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { promises as fs } from 'fs';
 import { basename, extname, join } from 'path';
@@ -19,12 +20,17 @@ import {
   PatientDocument,
 } from '../database/entities';
 
+/** Re-run the boot sweep every 6 hours (same TTL/lock logic; not aggressive). */
+const ORPHAN_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
 @Injectable()
 export class UploadsService implements OnApplicationBootstrap {
   private readonly logger = new Logger(UploadsService.name);
 
   /** Time an uploaded file may sit unlinked before the sweep removes it. */
   static readonly ORPHAN_TTL_HOURS = 24;
+
+  static readonly ORPHAN_SWEEP_INTERVAL_MS = ORPHAN_SWEEP_INTERVAL_MS;
 
   /** Arbitrary Postgres advisory lock id for the orphan sweep. */
   private static readonly ORPHAN_SWEEP_LOCK_KEY = 727003;
@@ -47,8 +53,8 @@ export class UploadsService implements OnApplicationBootstrap {
   /**
    * Delete uploads/ files that are older than the TTL and have never been
    * linked to a patient_documents or lab_results row. Runs on application
-   * bootstrap; a Postgres advisory lock prevents concurrent sweeps when
-   * multiple instances boot together.
+   * bootstrap and on a 6-hour interval; a Postgres advisory lock prevents
+   * concurrent sweeps when multiple instances overlap.
    *
    * Uses a dedicated QueryRunner so lock + unlock share one pooled connection
    * (session advisory locks are connection-scoped).
@@ -142,13 +148,23 @@ export class UploadsService implements OnApplicationBootstrap {
   /** Run the orphan sweep after the app is listening (never blocks boot). */
   onApplicationBootstrap(): void {
     setImmediate(() => {
-      this.removeOrphanUploads().catch((err: unknown) => {
-        this.logger.warn(
-          `Orphan upload sweep failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      });
+      this.sweepOrphanUploadsSafely();
+    });
+  }
+
+  /** Same sweep as boot, so long-lived instances still drop unlinked PHI. */
+  @Interval(ORPHAN_SWEEP_INTERVAL_MS)
+  sweepOrphanUploadsOnInterval(): void {
+    this.sweepOrphanUploadsSafely();
+  }
+
+  private sweepOrphanUploadsSafely(): void {
+    this.removeOrphanUploads().catch((err: unknown) => {
+      this.logger.warn(
+        `Orphan upload sweep failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.26(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)
+      '@nestjs/schedule':
+        specifier: ^6.1.3
+        version: 6.1.3(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)
       '@nestjs/throttler':
         specifier: ^6.5.0
         version: 6.5.0(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(reflect-metadata@0.2.2)
@@ -1515,6 +1518,12 @@ packages:
       '@nestjs/common': ^11.0.0
       '@nestjs/core': ^11.0.0
 
+  '@nestjs/schedule@6.1.3':
+    resolution: {integrity: sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@11.1.0':
     resolution: {integrity: sha512-lVxGZ46tcdItFMoXr6vyKWlnOsm1SZm/GUqAEDvy2RL4Q4O+3bkziAhrO7Y8JLssFUUvNFEGqAizI52WAxhjDw==}
     peerDependencies:
@@ -2370,6 +2379,9 @@ packages:
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
+  '@types/luxon@3.7.4':
+    resolution: {integrity: sha512-V536ZAd6ZJztrrBlLcDFaaZrXNAL2E5uGmssWf/dpSiLkmkLScXUYhUBnWPmtW+cIqnNHzf6//TCMpIc9SCRRQ==}
+
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
 
@@ -3144,6 +3156,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cron@4.4.0:
+    resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
+    engines: {node: '>=18.x'}
 
   cross-inspect@1.0.1:
     resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
@@ -4500,6 +4516,10 @@ packages:
     resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
@@ -7291,6 +7311,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/schedule@6.1.3(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)':
+    dependencies:
+      '@nestjs/common': 11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.26(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 4.4.0
+
   '@nestjs/schematics@11.1.0(chokidar@4.0.3)(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 19.2.24(chokidar@4.0.3)
@@ -8028,6 +8054,8 @@ snapshots:
       '@types/node': 24.13.1
 
   '@types/long@4.0.2': {}
+
+  '@types/luxon@3.7.4': {}
 
   '@types/mdx@2.0.14': {}
 
@@ -8842,6 +8870,11 @@ snapshots:
       typescript: 5.9.3
 
   create-require@1.1.1: {}
+
+  cron@4.4.0:
+    dependencies:
+      '@types/luxon': 3.7.4
+      luxon: 3.7.2
 
   cross-inspect@1.0.1:
     dependencies:
@@ -10527,6 +10560,8 @@ snapshots:
   lucide-react@0.511.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  luxon@3.7.2: {}
 
   magic-string@0.27.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Keeps the existing boot-time orphan-upload sweep.
- Adds a Nest `@Interval` every 6 hours that reuses the same TTL and Postgres advisory-lock logic so long-lived instances still drop unlinked PHI.

Closes #275.

## Test plan
- [ ] API still sweeps orphans on bootstrap
- [ ] `UploadsService.ORPHAN_SWEEP_INTERVAL_MS` is 6 hours
- [ ] Interval handler calls `removeOrphanUploads` (existing lock + 24h TTL unchanged)
- [ ] `pnpm --filter api test -- src/uploads/uploads.service.spec.ts` passes