### PR TITLE
fix: appointment and follow-up reschedule (#285, #266)

### DIFF
--- a/apps/api/src/appointments/appointments.resolver.ts
+++ b/apps/api/src/appointments/appointments.resolver.ts
@@ -14,6 +14,7 @@ import {
   AppointmentType,
   CancelAppointmentInput,
   CreateAppointmentInput,
+  RescheduleAppointmentInput,
 } from './appointments.types';
 
 @Resolver()
@@ -84,6 +85,21 @@ export class AppointmentsResolver {
       resolvedHospitalId,
       user,
     );
+  }
+
+  @Mutation(() => AppointmentType)
+  @Roles(...STAFF_ROLES)
+  @Permissions(PERMISSIONS.APPOINTMENTS_WRITE)
+  async rescheduleAppointment(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('input') input: RescheduleAppointmentInput,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+  ): Promise<AppointmentType> {
+    const resolvedHospitalId = this.appointmentsService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.appointmentsService.reschedule(resolvedHospitalId, input, user);
   }
 
   @Mutation(() => AppointmentType)

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -233,4 +233,108 @@ describe('AppointmentsService status machine', () => {
       );
     });
   });
+
+  describe('reschedule', () => {
+    it('updates scheduledAt and keeps scheduled status', async () => {
+      mockLockedAppointment({
+        id: 'appt-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        status: 'scheduled',
+        scheduledAt: new Date('2026-08-18T09:00:00.000Z'),
+      });
+
+      const result = await service.reschedule(
+        'hospital-a',
+        { id: 'appt-1', scheduledAt: '2026-08-21T14:00:00.000Z' },
+        actor,
+      );
+
+      expect(result.status).toBe('scheduled');
+      expect(new Date(result.scheduledAt).toISOString()).toBe(
+        '2026-08-21T14:00:00.000Z',
+      );
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'reschedule',
+          resource: 'appointment',
+        }),
+      );
+    });
+
+    it('revives no_show to scheduled at the new time', async () => {
+      mockLockedAppointment({
+        id: 'appt-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        status: 'no_show',
+        scheduledAt: new Date('2026-08-17T09:00:00.000Z'),
+      });
+
+      const result = await service.reschedule(
+        'hospital-a',
+        {
+          id: 'appt-1',
+          scheduledAt: '2026-08-22T11:00:00.000Z',
+          notes: 'Patient called back',
+        },
+        actor,
+      );
+
+      expect(result.status).toBe('scheduled');
+      expect(result.notes).toBe('Patient called back');
+    });
+
+    it('rejects cancelled appointments', async () => {
+      mockLockedAppointment({
+        id: 'appt-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        status: 'cancelled',
+      });
+
+      await expect(
+        service.reschedule(
+          'hospital-a',
+          { id: 'appt-1', scheduledAt: '2026-08-21T14:00:00.000Z' },
+          actor,
+        ),
+      ).rejects.toThrow(/Cannot reschedule a cancelled appointment/);
+    });
+
+    it('rejects completed appointments', async () => {
+      mockLockedAppointment({
+        id: 'appt-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        status: 'completed',
+      });
+
+      await expect(
+        service.reschedule(
+          'hospital-a',
+          { id: 'appt-1', scheduledAt: '2026-08-21T14:00:00.000Z' },
+          actor,
+        ),
+      ).rejects.toThrow(/Cannot reschedule a completed appointment/);
+    });
+
+    it('throws NotFound when appointment is missing', async () => {
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      };
+      apptManager.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.reschedule(
+          'hospital-a',
+          { id: 'missing', scheduledAt: '2026-08-21T14:00:00.000Z' },
+          actor,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
 });

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -15,6 +15,7 @@ import {
   AppointmentType,
   CancelAppointmentInput,
   CreateAppointmentInput,
+  RescheduleAppointmentInput,
 } from './appointments.types';
 
 /**
@@ -22,7 +23,8 @@ import {
  *   scheduled → checked_in → completed
  *            ↘ cancelled / no_show
  *   checked_in → completed / cancelled / no_show
- * Terminal: completed, cancelled, no_show (immutable)
+ * Terminal: completed, cancelled (immutable)
+ * no_show can be revived to scheduled via reschedule (new slot).
  */
 const ALLOWED_TRANSITIONS: Record<string, readonly string[]> = {
   scheduled: ['checked_in', 'cancelled', 'no_show', 'completed'],
@@ -40,6 +42,14 @@ function assertTransition(from: string, to: string) {
       `Cannot transition appointment from "${from}" to "${to}"`,
     );
   }
+}
+
+function parseIsoDate(value: string, field: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BadRequestException(`Invalid ${field}`);
+  }
+  return parsed;
 }
 
 @Injectable()
@@ -355,6 +365,68 @@ export class AppointmentsService {
       resource: 'appointment',
       resourceId: saved.id,
       metadata: { reason: input.reason },
+    });
+
+    return this.toAppointmentType(saved);
+  }
+
+  async reschedule(
+    hospitalId: string,
+    input: RescheduleAppointmentInput,
+    actor: AuthenticatedUser,
+  ): Promise<AppointmentType> {
+    const nextScheduledAt = parseIsoDate(input.scheduledAt, 'scheduledAt');
+
+    const appointmentId = await this.appointmentsRepo.manager.transaction(
+      async (manager) => {
+        const appointment = await manager
+          .createQueryBuilder(Appointment, 'appointment')
+          .setLock('pessimistic_write')
+          .where('appointment.id = :id', { id: input.id })
+          .andWhere('appointment.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!appointment) throw new NotFoundException('Appointment not found');
+
+        const patientAlive = await manager.findOne(Patient, {
+          where: { id: appointment.patientId, hospitalId },
+        });
+        if (!patientAlive) throw new NotFoundException('Appointment not found');
+
+        if (
+          appointment.status === 'cancelled' ||
+          appointment.status === 'completed'
+        ) {
+          throw new BadRequestException(
+            `Cannot reschedule a ${appointment.status} appointment`,
+          );
+        }
+
+        appointment.scheduledAt = nextScheduledAt;
+        // A new slot is live again — revive no_show rather than leaving a dead status.
+        if (appointment.status === 'no_show') {
+          appointment.status = 'scheduled';
+        }
+        if (input.reason !== undefined) {
+          appointment.reason = input.reason;
+        }
+        if (input.notes !== undefined) {
+          appointment.notes = input.notes;
+        }
+
+        await manager.save(appointment);
+        return appointment.id;
+      },
+    );
+
+    const saved = await this.findAppointmentOrThrow(appointmentId, hospitalId);
+
+    await this.audit.log({
+      actorId: actor.id,
+      hospitalId,
+      action: 'reschedule',
+      resource: 'appointment',
+      resourceId: saved.id,
+      metadata: { scheduledAt: saved.scheduledAt.toISOString() },
     });
 
     return this.toAppointmentType(saved);

--- a/apps/api/src/appointments/appointments.types.ts
+++ b/apps/api/src/appointments/appointments.types.ts
@@ -126,12 +126,14 @@ export class RescheduleAppointmentInput {
   @IsDateString()
   scheduledAt: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()
   @MinLength(1)
   reason?: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/appointments/appointments.types.ts
+++ b/apps/api/src/appointments/appointments.types.ts
@@ -116,4 +116,27 @@ export class CancelAppointmentInput {
   reason?: string;
 }
 
+@InputType()
+export class RescheduleAppointmentInput {
+  @Field()
+  @IsUUID()
+  id: string;
+
+  @Field()
+  @IsDateString()
+  scheduledAt: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  reason?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  notes?: string;
+}
+
 export { APPOINTMENT_STATUSES };

--- a/apps/api/src/discharge/discharge.resolver.ts
+++ b/apps/api/src/discharge/discharge.resolver.ts
@@ -14,6 +14,7 @@ import {
   CreateFollowUpInput,
   DischargeType,
   FollowUpType,
+  RescheduleFollowUpInput,
   UpdateFollowUpStatusInput,
 } from './discharge.types';
 
@@ -144,6 +145,32 @@ export class DischargeResolver {
       { write: true },
     );
     return this.dischargeService.updateFollowUpStatus(
+      resolvedHospitalId,
+      input,
+      user,
+    );
+  }
+
+  @Mutation(() => FollowUpType)
+  @Roles(
+    ROLES.DOCTOR,
+    ROLES.NURSE,
+    ROLES.RECEPTIONIST,
+    ROLES.HOSPITAL_ADMIN,
+    ROLES.HOSPITAL_MANAGER,
+    ROLES.SUPER_ADMIN,
+  )
+  @Permissions(PERMISSIONS.PATIENTS_WRITE)
+  async rescheduleFollowUp(
+    @CurrentUser() user: AuthenticatedUser,
+    @Args('input') input: RescheduleFollowUpInput,
+    @Args('hospitalId', { nullable: true }) hospitalId?: string,
+  ): Promise<FollowUpType> {
+    const resolvedHospitalId = this.dischargeService.resolveHospitalId(
+      user,
+      hospitalId,
+    );
+    return this.dischargeService.rescheduleFollowUp(
       resolvedHospitalId,
       input,
       user,

--- a/apps/api/src/discharge/discharge.service.spec.ts
+++ b/apps/api/src/discharge/discharge.service.spec.ts
@@ -225,5 +225,115 @@ describe('DischargeService', () => {
         ),
       ).rejects.toThrow(/Cannot transition follow-up/);
     });
+
+    it('rejects marking rescheduled without a new date', async () => {
+      const row = {
+        id: 'fu-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        status: 'scheduled',
+      };
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(row),
+      };
+      followManager.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.updateFollowUpStatus(
+          'hospital-a',
+          { id: 'fu-1', status: 'rescheduled' },
+          actor,
+        ),
+      ).rejects.toThrow(/Use rescheduleFollowUp/);
+    });
+  });
+
+  describe('rescheduleFollowUp', () => {
+    const mockLockedFollowUp = (row: Record<string, unknown>) => {
+      const state = { ...row };
+      const qb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(state),
+      };
+      followManager.createQueryBuilder.mockReturnValue(qb);
+      followManager.save.mockImplementation((r: typeof state) => {
+        Object.assign(state, r);
+        return Promise.resolve(state);
+      });
+      followManager.findOne.mockResolvedValue({
+        id: state.patientId ?? 'patient-1',
+        hospitalId: 'hospital-a',
+      });
+      followUpsRepo.findOne.mockImplementation(() =>
+        Promise.resolve({ ...state, patient: null, doctor: null }),
+      );
+      return state;
+    };
+
+    it('updates due date and keeps status scheduled', async () => {
+      mockLockedFollowUp({
+        id: 'fu-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        status: 'scheduled',
+        scheduledAt: new Date('2026-08-18T10:00:00.000Z'),
+      });
+
+      const result = await service.rescheduleFollowUp(
+        'hospital-a',
+        { id: 'fu-1', scheduledAt: '2026-08-25T09:30:00.000Z' },
+        actor,
+      );
+
+      expect(result.status).toBe('scheduled');
+      expect(new Date(result.scheduledAt).toISOString()).toBe(
+        '2026-08-25T09:30:00.000Z',
+      );
+    });
+
+    it('revives a dead rescheduled row with a new live date', async () => {
+      mockLockedFollowUp({
+        id: 'fu-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        status: 'rescheduled',
+        scheduledAt: new Date('2026-08-18T10:00:00.000Z'),
+      });
+
+      const result = await service.rescheduleFollowUp(
+        'hospital-a',
+        {
+          id: 'fu-1',
+          scheduledAt: '2026-08-26T15:00:00.000Z',
+          notes: 'Moved at patient request',
+        },
+        actor,
+      );
+
+      expect(result.status).toBe('scheduled');
+      expect(result.notes).toBe('Moved at patient request');
+    });
+
+    it('rejects completed follow-ups', async () => {
+      mockLockedFollowUp({
+        id: 'fu-1',
+        hospitalId: 'hospital-a',
+        patientId: 'patient-1',
+        status: 'completed',
+      });
+
+      await expect(
+        service.rescheduleFollowUp(
+          'hospital-a',
+          { id: 'fu-1', scheduledAt: '2026-08-25T09:30:00.000Z' },
+          actor,
+        ),
+      ).rejects.toThrow(/Cannot reschedule a completed follow-up/);
+    });
   });
 });

--- a/apps/api/src/discharge/discharge.service.ts
+++ b/apps/api/src/discharge/discharge.service.ts
@@ -21,6 +21,7 @@ import {
   CreateFollowUpInput,
   DischargeType,
   FollowUpType,
+  RescheduleFollowUpInput,
   UpdateFollowUpStatusInput,
 } from './discharge.types';
 
@@ -33,12 +34,14 @@ function isUniqueViolation(error: unknown): boolean {
 
 /**
  * Follow-up status machine:
- *   scheduled → completed | missed | rescheduled
- *   rescheduled → scheduled | completed | missed
- * Terminal: completed, missed (immutable)
+ *   scheduled → completed | missed
+ *   rescheduled → scheduled | completed | missed (legacy rows only)
+ * Terminal: completed (immutable)
+ * missed can be revived to scheduled via rescheduleFollowUp (new due date).
+ * Do not mark status "rescheduled" without a new date — use rescheduleFollowUp.
  */
 const FOLLOW_UP_TRANSITIONS: Record<string, readonly string[]> = {
-  scheduled: ['completed', 'missed', 'rescheduled'],
+  scheduled: ['completed', 'missed'],
   rescheduled: ['scheduled', 'completed', 'missed'],
   completed: [],
   missed: [],
@@ -46,12 +49,25 @@ const FOLLOW_UP_TRANSITIONS: Record<string, readonly string[]> = {
 
 function assertFollowUpTransition(from: string, to: string) {
   if (from === to) return;
+  if (to === 'rescheduled') {
+    throw new BadRequestException(
+      'Cannot mark a follow-up as rescheduled without a new date. Use rescheduleFollowUp.',
+    );
+  }
   const allowed = FOLLOW_UP_TRANSITIONS[from] ?? [];
   if (!allowed.includes(to)) {
     throw new BadRequestException(
       `Cannot transition follow-up from "${from}" to "${to}"`,
     );
   }
+}
+
+function parseIsoDate(value: string, field: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BadRequestException(`Invalid ${field}`);
+  }
+  return parsed;
 }
 
 @Injectable()
@@ -350,6 +366,63 @@ export class DischargeService {
       resource: 'follow_up',
       resourceId: saved.id,
       metadata: { status: saved.status },
+    });
+
+    return this.toFollowUpType(saved);
+  }
+
+  async rescheduleFollowUp(
+    hospitalId: string,
+    input: RescheduleFollowUpInput,
+    actor: AuthenticatedUser,
+  ): Promise<FollowUpType> {
+    const nextScheduledAt = parseIsoDate(input.scheduledAt, 'scheduledAt');
+
+    const followUpId = await this.followUpsRepo.manager.transaction(
+      async (manager) => {
+        const followUp = await manager
+          .createQueryBuilder(FollowUp, 'followUp')
+          .setLock('pessimistic_write')
+          .where('followUp.id = :id', { id: input.id })
+          .andWhere('followUp.hospital_id = :hospitalId', { hospitalId })
+          .getOne();
+        if (!followUp) throw new NotFoundException('Follow-up not found');
+
+        const patient = await manager.findOne(Patient, {
+          where: { id: followUp.patientId, hospitalId },
+        });
+        if (!patient) throw new NotFoundException('Follow-up not found');
+
+        if (followUp.status === 'completed') {
+          throw new BadRequestException(
+            'Cannot reschedule a completed follow-up',
+          );
+        }
+
+        followUp.scheduledAt = nextScheduledAt;
+        // Keep a live status with the new due date — never park on "rescheduled".
+        followUp.status = 'scheduled';
+        if (input.notes !== undefined) {
+          followUp.notes = input.notes;
+        }
+        await manager.save(followUp);
+        return followUp.id;
+      },
+    );
+
+    const saved = await this.followUpsRepo.findOne({
+      where: { id: followUpId, hospitalId },
+      relations: ['patient', 'doctor'],
+    });
+    if (!saved) throw new NotFoundException('Follow-up not found');
+
+    await this.audit.log({
+      actorId: actor.id,
+      hospitalId,
+      action: 'reschedule',
+      resource: 'follow_up',
+      resourceId: saved.id,
+      metadata: { scheduledAt: saved.scheduledAt.toISOString() },
     });
 
     return this.toFollowUpType(saved);

--- a/apps/api/src/discharge/discharge.types.ts
+++ b/apps/api/src/discharge/discharge.types.ts
@@ -190,6 +190,7 @@ export class RescheduleFollowUpInput {
   @IsDateString()
   scheduledAt: string;
 
+  @MaxLength(2000)
   @Field({ nullable: true })
   @IsOptional()
   @IsString()

--- a/apps/api/src/discharge/discharge.types.ts
+++ b/apps/api/src/discharge/discharge.types.ts
@@ -180,4 +180,21 @@ export class UpdateFollowUpStatusInput {
   notes?: string;
 }
 
+@InputType()
+export class RescheduleFollowUpInput {
+  @Field()
+  @IsUUID()
+  id: string;
+
+  @Field()
+  @IsDateString()
+  scheduledAt: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  notes?: string;
+}
+
 export { FOLLOW_UP_STATUSES };

--- a/apps/web/src/app/(dashboard)/appointments/page.tsx
+++ b/apps/web/src/app/(dashboard)/appointments/page.tsx
@@ -10,6 +10,7 @@ import {
   APPOINTMENTS_QUERY,
   CANCEL_APPOINTMENT_MUTATION,
   ME_QUERY,
+  RESCHEDULE_APPOINTMENT_MUTATION,
   UPDATE_APPOINTMENT_STATUS_MUTATION,
 } from '@/lib/graphql/queries';
 import { QueryError } from '@/components/query-error';
@@ -17,6 +18,17 @@ import { localDateISO } from '@/lib/local-date';
 
 function formatTime(iso: string) {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function toDateTimeLocalValue(iso: string) {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function canRescheduleAppointment(status: string) {
+  return status === 'scheduled' || status === 'checked_in' || status === 'no_show';
 }
 
 const statusVariant = (status: string) => {
@@ -36,6 +48,8 @@ const statusVariant = (status: string) => {
 export default function AppointmentsPage() {
   const [selectedDate, setSelectedDate] = useState(localDateISO());
   const [statusError, setStatusError] = useState('');
+  const [reschedulingId, setReschedulingId] = useState<string | null>(null);
+  const [rescheduleAt, setRescheduleAt] = useState('');
   const { data: meData } = useQuery(ME_QUERY);
   const me = meData?.me;
   const hospitalId = me?.hospitalId;
@@ -62,6 +76,12 @@ export default function AppointmentsPage() {
   const [cancelAppointment] = useMutation(CANCEL_APPOINTMENT_MUTATION, {
     onCompleted: () => refetch(),
   });
+  const [rescheduleAppointment] = useMutation(RESCHEDULE_APPOINTMENT_MUTATION, {
+    onCompleted: () => {
+      setReschedulingId(null);
+      refetch();
+    },
+  });
 
   const appointments = data?.appointments ?? [];
 
@@ -77,6 +97,24 @@ export default function AppointmentsPage() {
       await updateStatus({ variables: { id, status, hospitalId } });
     } catch (err) {
       setStatusError(err instanceof Error ? err.message : 'Failed to update appointment status');
+    }
+  };
+
+  const handleReschedule = async (id: string) => {
+    setStatusError('');
+    if (!rescheduleAt) {
+      setStatusError('Choose a new date and time to reschedule');
+      return;
+    }
+    try {
+      await rescheduleAppointment({
+        variables: {
+          hospitalId,
+          input: { id, scheduledAt: new Date(rescheduleAt).toISOString() },
+        },
+      });
+    } catch (err) {
+      setStatusError(err instanceof Error ? err.message : 'Failed to reschedule appointment');
     }
   };
 
@@ -112,7 +150,9 @@ export default function AppointmentsPage() {
       </div>
 
       {statusError ? (
-        <p className="mb-4 rounded-2xl bg-red-50 px-4 py-2 text-sm text-clay-error">{statusError}</p>
+        <p className="mb-4 rounded-2xl bg-red-50 px-4 py-2 text-sm text-clay-error">
+          {statusError}
+        </p>
       ) : null}
 
       <ClayCard padding="none" className="overflow-hidden">
@@ -130,7 +170,10 @@ export default function AppointmentsPage() {
             <Calendar className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />
             <p className="text-clay-text-muted">No appointments scheduled for today.</p>
             {canWriteAppointments ? (
-              <Link href="/appointments/new" className="mt-3 inline-block text-sm text-clay-primary hover:underline">
+              <Link
+                href="/appointments/new"
+                className="mt-3 inline-block text-sm text-clay-primary hover:underline"
+              >
                 Schedule one now
               </Link>
             ) : null}
@@ -165,29 +208,60 @@ export default function AppointmentsPage() {
                   <ClayBadge variant={statusVariant(appt.status)}>
                     {appt.status.replace(/_/g, ' ')}
                   </ClayBadge>
-                  {canWriteAppointments && appt.status === 'scheduled' ? (
-                    <div className="flex gap-2">
-                      <ClayButton
-                        size="sm"
-                        variant="secondary"
-                        onClick={() => handleStatus(appt.id, 'checked_in')}
-                      >
-                        Check In
+                  {canWriteAppointments && reschedulingId === appt.id ? (
+                    <div className="flex flex-wrap items-center gap-2">
+                      <input
+                        type="datetime-local"
+                        value={rescheduleAt}
+                        onChange={(e) => setRescheduleAt(e.target.value)}
+                        className="rounded-2xl border border-white/60 bg-clay-surface px-3 py-2 text-sm shadow-clay-inset"
+                      />
+                      <ClayButton size="sm" onClick={() => void handleReschedule(appt.id)}>
+                        Save
                       </ClayButton>
-                      <ClayButton
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => handleStatus(appt.id, 'cancelled')}
-                      >
-                        Cancel
+                      <ClayButton size="sm" variant="ghost" onClick={() => setReschedulingId(null)}>
+                        Close
                       </ClayButton>
                     </div>
-                  ) : null}
-                  {canWriteAppointments && appt.status === 'checked_in' ? (
-                    <ClayButton size="sm" onClick={() => handleStatus(appt.id, 'completed')}>
-                      Complete
-                    </ClayButton>
-                  ) : null}
+                  ) : (
+                    <>
+                      {canWriteAppointments && appt.status === 'scheduled' ? (
+                        <div className="flex gap-2">
+                          <ClayButton
+                            size="sm"
+                            variant="secondary"
+                            onClick={() => handleStatus(appt.id, 'checked_in')}
+                          >
+                            Check In
+                          </ClayButton>
+                          <ClayButton
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => handleStatus(appt.id, 'cancelled')}
+                          >
+                            Cancel
+                          </ClayButton>
+                        </div>
+                      ) : null}
+                      {canWriteAppointments && appt.status === 'checked_in' ? (
+                        <ClayButton size="sm" onClick={() => handleStatus(appt.id, 'completed')}>
+                          Complete
+                        </ClayButton>
+                      ) : null}
+                      {canWriteAppointments && canRescheduleAppointment(appt.status) ? (
+                        <ClayButton
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => {
+                            setReschedulingId(appt.id);
+                            setRescheduleAt(toDateTimeLocalValue(appt.scheduledAt));
+                          }}
+                        >
+                          Reschedule
+                        </ClayButton>
+                      ) : null}
+                    </>
+                  )}
                 </div>
               ),
             )}

--- a/apps/web/src/app/(dashboard)/follow-ups/page.tsx
+++ b/apps/web/src/app/(dashboard)/follow-ups/page.tsx
@@ -10,6 +10,7 @@ import {
   FOLLOW_UPS_QUERY,
   ME_QUERY,
   PATIENTS_QUERY,
+  RESCHEDULE_FOLLOW_UP_MUTATION,
   STAFF_MEMBERS_QUERY,
   UPDATE_FOLLOW_UP_STATUS_MUTATION,
 } from '@/lib/graphql/queries';
@@ -24,6 +25,17 @@ function formatDateTime(iso: string) {
     hour: '2-digit',
     minute: '2-digit',
   });
+}
+
+function toDateTimeLocalValue(iso: string) {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function canRescheduleFollowUp(status: string) {
+  return status === 'scheduled' || status === 'rescheduled' || status === 'missed';
 }
 
 const statusVariant = (status: string) => {
@@ -52,19 +64,27 @@ export default function FollowUpsPage() {
   const [scheduledAt, setScheduledAt] = useState('');
   const [type, setType] = useState('outpatient');
   const [error, setError] = useState('');
+  const [reschedulingId, setReschedulingId] = useState<string | null>(null);
+  const [rescheduleAt, setRescheduleAt] = useState('');
 
-  const { data, loading, error: listError, refetch } = useQuery(FOLLOW_UPS_QUERY, {
+  const {
+    data,
+    loading,
+    error: listError,
+    refetch,
+  } = useQuery(FOLLOW_UPS_QUERY, {
     variables: { hospitalId },
     skip: !hospitalId,
   });
 
-  const { data: patientsData, error: patientsError, refetch: refetchPatients } = useQuery(
-    PATIENTS_QUERY,
-    {
-      variables: { search: patientSearch, limit: 8, hospitalId },
-      skip: !hospitalId || patientSearch.length < 2,
-    },
-  );
+  const {
+    data: patientsData,
+    error: patientsError,
+    refetch: refetchPatients,
+  } = useQuery(PATIENTS_QUERY, {
+    variables: { search: patientSearch, limit: 8, hospitalId },
+    skip: !hospitalId || patientSearch.length < 2,
+  });
 
   const {
     data: staffData,
@@ -86,6 +106,12 @@ export default function FollowUpsPage() {
   const [updateStatus] = useMutation(UPDATE_FOLLOW_UP_STATUS_MUTATION, {
     onCompleted: () => refetch(),
   });
+  const [rescheduleFollowUp] = useMutation(RESCHEDULE_FOLLOW_UP_MUTATION, {
+    onCompleted: () => {
+      setReschedulingId(null);
+      refetch();
+    },
+  });
   const [createFollowUp, { loading: creating }] = useMutation(CREATE_FOLLOW_UP_MUTATION, {
     onCompleted: () => {
       refetch();
@@ -106,6 +132,24 @@ export default function FollowUpsPage() {
       await updateStatus({ variables: { hospitalId, input: { id, status } } });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update follow-up status');
+    }
+  };
+
+  const handleReschedule = async (id: string) => {
+    setError('');
+    if (!rescheduleAt) {
+      setError('Choose a new date and time to reschedule');
+      return;
+    }
+    try {
+      await rescheduleFollowUp({
+        variables: {
+          hospitalId,
+          input: { id, scheduledAt: new Date(rescheduleAt).toISOString() },
+        },
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reschedule follow-up');
     }
   };
 
@@ -146,16 +190,14 @@ export default function FollowUpsPage() {
 
       <div className="mb-6 flex justify-end">
         {canWriteFollowUp ? (
-        <ClayButton onClick={() => setShowForm((v) => !v)}>
-          <Plus className="mr-2 h-4 w-4" />
-          {showForm ? 'Hide form' : 'Schedule follow-up'}
-        </ClayButton>
+          <ClayButton onClick={() => setShowForm((v) => !v)}>
+            <Plus className="mr-2 h-4 w-4" />
+            {showForm ? 'Hide form' : 'Schedule follow-up'}
+          </ClayButton>
         ) : null}
       </div>
 
-      {error && !showForm ? (
-        <p className="mb-4 text-sm text-clay-error">{error}</p>
-      ) : null}
+      {error && !showForm ? <p className="mb-4 text-sm text-clay-error">{error}</p> : null}
 
       {showForm ? (
         <ClayCard className="mb-6 max-w-xl space-y-4">
@@ -263,9 +305,9 @@ export default function FollowUpsPage() {
             <CalendarClock className="mx-auto mb-3 h-10 w-10 text-clay-text-muted/50" />
             <p className="text-clay-text-muted">No follow-ups scheduled.</p>
             {canWriteFollowUp ? (
-            <ClayButton className="mt-4" size="sm" onClick={() => setShowForm(true)}>
-              Schedule one
-            </ClayButton>
+              <ClayButton className="mt-4" size="sm" onClick={() => setShowForm(true)}>
+                Schedule one
+              </ClayButton>
             ) : null}
           </div>
         ) : (
@@ -298,20 +340,51 @@ export default function FollowUpsPage() {
                   <ClayBadge variant={statusVariant(item.status)}>
                     {item.status.replace(/_/g, ' ')}
                   </ClayBadge>
-                  {item.status === 'scheduled' && canWriteFollowUp ? (
-                    <div className="flex gap-2">
-                      <ClayButton size="sm" onClick={() => handleStatus(item.id, 'completed')}>
-                        Complete
+                  {canWriteFollowUp && reschedulingId === item.id ? (
+                    <div className="flex flex-wrap items-center gap-2">
+                      <input
+                        type="datetime-local"
+                        value={rescheduleAt}
+                        onChange={(e) => setRescheduleAt(e.target.value)}
+                        className="rounded-2xl border border-white/60 bg-clay-surface px-3 py-2 text-sm shadow-clay-inset"
+                      />
+                      <ClayButton size="sm" onClick={() => void handleReschedule(item.id)}>
+                        Save
                       </ClayButton>
-                      <ClayButton
-                        size="sm"
-                        variant="secondary"
-                        onClick={() => handleStatus(item.id, 'missed')}
-                      >
-                        Missed
+                      <ClayButton size="sm" variant="ghost" onClick={() => setReschedulingId(null)}>
+                        Close
                       </ClayButton>
                     </div>
-                  ) : null}
+                  ) : (
+                    <>
+                      {item.status === 'scheduled' && canWriteFollowUp ? (
+                        <div className="flex gap-2">
+                          <ClayButton size="sm" onClick={() => handleStatus(item.id, 'completed')}>
+                            Complete
+                          </ClayButton>
+                          <ClayButton
+                            size="sm"
+                            variant="secondary"
+                            onClick={() => handleStatus(item.id, 'missed')}
+                          >
+                            Missed
+                          </ClayButton>
+                        </div>
+                      ) : null}
+                      {canWriteFollowUp && canRescheduleFollowUp(item.status) ? (
+                        <ClayButton
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => {
+                            setReschedulingId(item.id);
+                            setRescheduleAt(toDateTimeLocalValue(item.scheduledAt));
+                          }}
+                        >
+                          Reschedule
+                        </ClayButton>
+                      ) : null}
+                    </>
+                  )}
                 </div>
               ),
             )}

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -397,7 +397,11 @@ export const IMPORT_PATIENTS_MUTATION = gql`
 `;
 
 export const ADD_PATIENT_DOCUMENT_MUTATION = gql`
-  mutation AddPatientDocument($patientId: String!, $input: PatientDocumentInput!, $hospitalId: String) {
+  mutation AddPatientDocument(
+    $patientId: String!
+    $input: PatientDocumentInput!
+    $hospitalId: String
+  ) {
     addPatientDocument(patientId: $patientId, input: $input, hospitalId: $hospitalId) {
       id
       name
@@ -448,18 +452,8 @@ export const DASHBOARD_STATS_QUERY = gql`
 `;
 
 export const APPOINTMENTS_QUERY = gql`
-  query Appointments(
-    $hospitalId: String
-    $date: String
-    $status: String
-    $doctorId: String
-  ) {
-    appointments(
-      hospitalId: $hospitalId
-      date: $date
-      status: $status
-      doctorId: $doctorId
-    ) {
+  query Appointments($hospitalId: String, $date: String, $status: String, $doctorId: String) {
+    appointments(hospitalId: $hospitalId, date: $date, status: $status, doctorId: $doctorId) {
       id
       patientId
       patient {
@@ -497,6 +491,18 @@ export const UPDATE_APPOINTMENT_STATUS_MUTATION = gql`
     updateAppointmentStatus(id: $id, status: $status, hospitalId: $hospitalId) {
       id
       status
+    }
+  }
+`;
+
+export const RESCHEDULE_APPOINTMENT_MUTATION = gql`
+  mutation RescheduleAppointment($input: RescheduleAppointmentInput!, $hospitalId: String) {
+    rescheduleAppointment(input: $input, hospitalId: $hospitalId) {
+      id
+      scheduledAt
+      status
+      reason
+      notes
     }
   }
 `;
@@ -830,6 +836,17 @@ export const UPDATE_FOLLOW_UP_STATUS_MUTATION = gql`
   mutation UpdateFollowUpStatus($input: UpdateFollowUpStatusInput!, $hospitalId: String) {
     updateFollowUpStatus(input: $input, hospitalId: $hospitalId) {
       id
+      status
+      notes
+    }
+  }
+`;
+
+export const RESCHEDULE_FOLLOW_UP_MUTATION = gql`
+  mutation RescheduleFollowUp($input: RescheduleFollowUpInput!, $hospitalId: String) {
+    rescheduleFollowUp(input: $input, hospitalId: $hospitalId) {
+      id
+      scheduledAt
       status
       notes
     }


### PR DESCRIPTION
## Summary
- Add `rescheduleAppointment` so staff with `appointments:write` can move an existing visit to a new `scheduledAt` (optional reason/notes). Cancelled and completed appointments stay blocked; a `no_show` is revived to `scheduled` at the new time.
- Add `rescheduleFollowUp` that always writes a new due date (`scheduledAt`) and keeps the follow-up in live `scheduled` status. Marking `rescheduled` via `updateFollowUpStatus` without a date is rejected so the old dead-end cannot be reintroduced.
- Wire Reschedule row actions with a datetime picker on the appointments and follow-ups dashboards.

Closes #285
Closes #266

## Test plan
- [ ] As receptionist/doctor with `appointments:write`, reschedule a scheduled appointment from the list (datetime picker → Save) and confirm the new time is stored.
- [ ] Confirm cancelled and completed appointments cannot be rescheduled.
- [ ] Reschedule a `no_show` appointment and confirm status returns to `scheduled`.
- [ ] On Follow-ups, use Reschedule on a scheduled (or legacy `rescheduled`) row: new date is saved and status is `scheduled`, not a date-less `rescheduled`.
- [ ] Confirm Complete / Missed still work; `updateFollowUpStatus` with `rescheduled` is rejected.
- [ ] `pnpm --filter api exec jest src/appointments/appointments.service.spec.ts src/discharge/discharge.service.spec.ts`