### PR TITLE
fix: last hospital_admin lockout and replacement invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,10 @@ pnpm --filter @careconnect/ui storybook
 
 Do not commit secrets (`.env`, keys, credentials).
 
+## Hospital admin succession
+
+Each hospital has **one** `hospital_admin` role (`idx_user_roles_one_hospital_admin`, including inactive rows). Sitting `hospital_admin` or platform `super_admin` may invite a replacement. The invite creates the user, staff profile, and pending invite — it does **not** insert a `user_roles` row, so it does not consume the unique slot. When the invite is accepted, `StaffService.acceptInvite` transfers the role atomically: delete other `hospital_admin` rows for that hospital, then insert the successor's. The last active admin cannot be deactivated until a successor has accepted. If zero *active* admins remain, first-time / re-bootstrap in `AuthService.completeOnboarding` may assign a new admin.
+
 ## Security scanning (Snyk)
 
 Dependency scanning:

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -47,7 +47,12 @@ describe('AuthService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    manager.query.mockResolvedValue(undefined);
+    manager.query.mockImplementation((sql: string) => {
+      if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
+        return Promise.resolve([{ count: 0 }]);
+      }
+      return Promise.resolve(undefined);
+    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -304,7 +309,7 @@ describe('AuthService', () => {
       );
     });
 
-    it('rejects bootstrap when an admin already exists under the lock', async () => {
+    it('ignores inactive leftover hospital_admins when counting the slot', async () => {
       usersRepo.findOne.mockResolvedValue({
         id: 'user-1',
         hospitalId: 'hospital-a',
@@ -314,7 +319,37 @@ describe('AuthService', () => {
         id: 'role-admin',
         slug: 'hospital_admin',
       });
-      manager.count.mockResolvedValue(1);
+      manager.find.mockResolvedValue([]);
+
+      await service.completeOnboarding(actor, 'Founder', 'hospital-a', true);
+
+      expect(manager.query).toHaveBeenCalledWith(
+        expect.stringContaining('u.is_active = true'),
+        ['hospital-a'],
+      );
+      expect(manager.query).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM user_roles'),
+        ['hospital-a'],
+      );
+      expect(manager.save).toHaveBeenCalled();
+    });
+
+    it('rejects bootstrap when an active admin already exists under the lock', async () => {
+      usersRepo.findOne.mockResolvedValue({
+        id: 'user-1',
+        hospitalId: 'hospital-a',
+      });
+      hospitalsRepo.findOne.mockResolvedValue({ id: 'hospital-a' });
+      manager.findOne.mockResolvedValue({
+        id: 'role-admin',
+        slug: 'hospital_admin',
+      });
+      manager.query.mockImplementation((sql: string) => {
+        if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
+          return Promise.resolve([{ count: 1 }]);
+        }
+        return Promise.resolve(undefined);
+      });
 
       await expect(
         service.completeOnboarding(actor, 'Founder', 'hospital-a', true),

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -240,15 +240,37 @@ export class AuthService {
           }
 
           if (!isSuperAdmin) {
-            const existingAdmins = await manager.count(UserRole, {
-              where: { roleId: adminRole.id, hospitalId },
-            });
+            const rows = (await manager.query(
+              `SELECT COUNT(*)::int AS count
+               FROM user_roles ur
+               INNER JOIN users u ON u.id = ur.user_id
+               INNER JOIN roles r ON r.id = ur.role_id
+               WHERE r.slug = 'hospital_admin'
+                 AND ur.hospital_id = $1
+                 AND u.is_active = true
+                 AND u.deleted_at IS NULL`,
+              [hospitalId],
+            )) as Array<{ count: number | string }>;
+            const existingAdmins = Number(rows[0]?.count ?? 0);
             if (existingAdmins > 0) {
               throw new ForbiddenException(
                 'Hospital already has an administrator; join via staff invite',
               );
             }
           }
+
+          // Unique index covers inactive hospital_admin rows too; drop leftovers
+          // so bootstrap can assign a replacement when none are active.
+          await manager.query(
+            `DELETE FROM user_roles ur
+             USING users u, roles r
+             WHERE ur.user_id = u.id
+               AND ur.role_id = r.id
+               AND r.slug = 'hospital_admin'
+               AND ur.hospital_id = $1
+               AND (u.is_active = false OR u.deleted_at IS NOT NULL)`,
+            [hospitalId],
+          );
 
           await manager.update(User, user.id, {
             fullName,

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -170,7 +170,10 @@ export class AuthService {
    * Tenancy rules:
    * - Cannot switch to a different hospital once hospitalId is set (unless super_admin).
    * - Joining an existing hospital requires assignHospitalAdmin bootstrap OR invite flow.
-   * - Bootstrap admin only when that hospital has zero hospital_admin members yet.
+   * - Bootstrap admin only when that hospital has zero *active* hospital_admin
+   *   members yet (re-bootstrap after lockout). Sitting-admin succession is
+   *   StaffService.acceptInvite: the unique role transfers when the invite
+   *   is accepted, not here.
    */
   async completeOnboarding(
     actor: AuthenticatedUser,

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -551,42 +551,7 @@ describe('StaffService', () => {
   });
 
   describe('hospital_admin replacement invite', () => {
-    it('rejects hospital_admin invite from hospital_manager', async () => {
-      await expect(
-        service.create(
-          'hospital-a',
-          {
-            email: 'new-admin@hospital.com',
-            fullName: 'New Admin',
-            roleSlug: 'hospital_admin',
-          },
-          hospitalManager,
-        ),
-      ).rejects.toThrow(/cannot be assigned via staff invite/);
-
-      expect(rolesRepo.findOne).not.toHaveBeenCalled();
-    });
-
-    it('rejects hospital_admin invite when an active hospital_admin exists', async () => {
-      mockActiveAdminCount(1);
-
-      await expect(
-        service.create(
-          'hospital-a',
-          {
-            email: 'new-admin@hospital.com',
-            fullName: 'New Admin',
-            roleSlug: 'hospital_admin',
-          },
-          hospitalAdmin,
-        ),
-      ).rejects.toThrow(/already has an active hospital_admin/);
-
-      expect(staffRepo.manager.transaction).not.toHaveBeenCalled();
-    });
-
-    it('allows hospital_admin invite when there are zero active hospital_admins', async () => {
-      mockActiveAdminCount(0);
+    function setupHospitalAdminInviteCreate() {
       rolesRepo.findOne.mockResolvedValue({
         id: 'role-admin',
         slug: 'hospital_admin',
@@ -603,7 +568,7 @@ describe('StaffService', () => {
         user: {
           fullName: 'New Admin',
           email: 'new-admin@hospital.com',
-          userRoles: [{ role: { slug: 'hospital_admin' } }],
+          userRoles: [],
         },
       });
       staffRepo.create.mockImplementation((row: unknown) => row);
@@ -612,7 +577,53 @@ describe('StaffService', () => {
       userRolesRepo.create.mockImplementation((row: unknown) => row);
       invitesRepo.create.mockImplementation((row: unknown) => row);
       invitesRepo.save.mockResolvedValue({});
-      const { query } = mockCreateTransaction(null);
+      return mockCreateTransaction(null);
+    }
+
+    it('rejects hospital_admin invite from hospital_manager', async () => {
+      await expect(
+        service.create(
+          'hospital-a',
+          {
+            email: 'new-admin@hospital.com',
+            fullName: 'New Admin',
+            roleSlug: 'hospital_admin',
+          },
+          hospitalManager,
+        ),
+      ).rejects.toThrow(/cannot be assigned via staff invite/);
+
+      expect(rolesRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('allows a sitting hospital_admin to invite a successor while remaining active', async () => {
+      mockActiveAdminCount(1);
+      const { query } = setupHospitalAdminInviteCreate();
+
+      await service.create(
+        'hospital-a',
+        {
+          email: 'new-admin@hospital.com',
+          fullName: 'New Admin',
+          roleSlug: 'hospital_admin',
+        },
+        hospitalAdmin,
+      );
+
+      expect(staffRepo.save).toHaveBeenCalled();
+      expect(invitesRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roleSlug: 'hospital_admin',
+          email: 'new-admin@hospital.com',
+        }),
+      );
+      expect(userRolesRepo.save).not.toHaveBeenCalled();
+      expect(query).not.toHaveBeenCalled();
+    });
+
+    it('allows super_admin to invite a successor while an active hospital_admin exists', async () => {
+      mockActiveAdminCount(1);
+      setupHospitalAdminInviteCreate();
 
       await service.create(
         'hospital-a',
@@ -624,11 +635,163 @@ describe('StaffService', () => {
         superAdmin,
       );
 
+      expect(userRolesRepo.save).not.toHaveBeenCalled();
+      expect(staffRepo.save).toHaveBeenCalled();
+    });
+
+    it('still blocks deactivating the last admin after inviting a pending successor', async () => {
+      const lastAdminStaff = {
+        id: 'staff-admin',
+        userId: 'admin-1',
+        hospitalId: 'hospital-a',
+        isActive: true,
+        user: {
+          email: 'admin@hospital.com',
+          userRoles: [
+            { role: { slug: 'hospital_admin' }, hospitalId: 'hospital-a' },
+          ],
+        },
+      };
+      staffRepo.findOne.mockResolvedValue({ ...lastAdminStaff });
+      mockActiveAdminCount(0);
+
+      await expect(
+        service.remove('staff-admin', hospitalAdmin),
+      ).rejects.toThrow(/Invite a replacement administrator first/);
+    });
+  });
+
+  describe('acceptInvite — hospital_admin succession', () => {
+    function mockAcceptTransaction(invite: Record<string, unknown>) {
+      const query = jest.fn().mockResolvedValue(undefined);
+      const pendingStaff = {
+        id: 'staff-new',
+        userId: 'user-new',
+        hospitalId: 'hospital-a',
+        isActive: true,
+        user: { email: 'new-admin@hospital.com', isActive: true },
+      };
+      invitesRepo.manager.transaction.mockImplementation(
+        (cb: (m: Record<string, unknown>) => unknown) => {
+          const manager = {
+            query,
+            getRepository: (entity: unknown) => {
+              if (entity === StaffInvite) {
+                return {
+                  createQueryBuilder: () => ({
+                    setLock: jest.fn().mockReturnThis(),
+                    where: jest.fn().mockReturnThis(),
+                    getOne: jest.fn().mockResolvedValue(invite),
+                  }),
+                  save: invitesRepo.save,
+                };
+              }
+              if (entity === User) {
+                return {
+                  findOne: jest.fn().mockResolvedValue({
+                    id: 'user-new',
+                    isActive: true,
+                    hospitalId: 'hospital-a',
+                  }),
+                  update: usersRepo.update,
+                };
+              }
+              if (entity === StaffProfile) {
+                return {
+                  findOne: jest.fn().mockResolvedValue(pendingStaff),
+                };
+              }
+              if (entity === Role) {
+                return {
+                  findOne: jest.fn().mockResolvedValue({
+                    id: 'role-admin',
+                    slug: 'hospital_admin',
+                  }),
+                };
+              }
+              if (entity === UserRole) return userRolesRepo;
+              return {};
+            },
+          };
+          return Promise.resolve(cb(manager));
+        },
+      );
+      return { query, pendingStaff };
+    }
+
+    it('transfers the unique hospital_admin role to the invitee and removes the inviter', async () => {
+      const invite = {
+        token: 'tok',
+        email: 'new-admin@hospital.com',
+        hospitalId: 'hospital-a',
+        staffProfileId: 'staff-new',
+        roleSlug: 'hospital_admin',
+        acceptedAt: null,
+        expiresAt: new Date(Date.now() + 86400000),
+      };
+      const { query } = mockAcceptTransaction(invite);
+      userRolesRepo.findOne.mockResolvedValue(null);
+      userRolesRepo.create.mockImplementation((row: unknown) => row);
+      userRolesRepo.save.mockResolvedValue({});
+      invitesRepo.save.mockResolvedValue({});
+      staffRepo.findOne.mockResolvedValue({
+        id: 'staff-new',
+        userId: 'user-new',
+        hospitalId: 'hospital-a',
+        user: {
+          fullName: 'New Admin',
+          email: 'new-admin@hospital.com',
+          userRoles: [{ role: { slug: 'hospital_admin' } }],
+        },
+      });
+
+      await service.acceptInvite('tok', 'auth-new', 'new-admin@hospital.com');
+
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining('pg_advisory_xact_lock'),
+        ['hospital-admin-transfer:hospital-a'],
+      );
       expect(query).toHaveBeenCalledWith(
         expect.stringContaining('DELETE FROM user_roles'),
-        ['hospital-a'],
+        ['hospital-a', 'user-new'],
       );
-      expect(userRolesRepo.save).toHaveBeenCalled();
+      expect(userRolesRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-new',
+          roleId: 'role-admin',
+          hospitalId: 'hospital-a',
+        }),
+      );
+      expect(invite.acceptedAt).toBeInstanceOf(Date);
+    });
+
+    it('does not transfer roles for non-admin invites', async () => {
+      const invite = {
+        token: 'tok',
+        email: 'doc@example.com',
+        hospitalId: 'hospital-a',
+        staffProfileId: 'staff-new',
+        roleSlug: 'doctor',
+        acceptedAt: null,
+        expiresAt: new Date(Date.now() + 86400000),
+      };
+      const { query } = mockAcceptTransaction(invite);
+      invitesRepo.save.mockResolvedValue({});
+      staffRepo.findOne.mockResolvedValue({
+        id: 'staff-new',
+        userId: 'user-new',
+        hospitalId: 'hospital-a',
+        user: {
+          fullName: 'Doc',
+          email: 'doc@example.com',
+          userRoles: [{ role: { slug: 'doctor' } }],
+        },
+      });
+
+      await service.acceptInvite('tok', 'auth-new', 'doc@example.com');
+
+      expect(query).not.toHaveBeenCalled();
+      expect(userRolesRepo.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/staff/staff.service.spec.ts
+++ b/apps/api/src/staff/staff.service.spec.ts
@@ -42,6 +42,9 @@ describe('StaffService', () => {
     save: jest.fn(),
     create: jest.fn(),
     delete: jest.fn(),
+    manager: {
+      query: jest.fn().mockResolvedValue([{ count: 0 }]),
+    },
   };
   const invitesRepo = {
     save: jest.fn(),
@@ -73,6 +76,12 @@ describe('StaffService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    userRolesRepo.manager.query.mockImplementation((sql: string) => {
+      if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
+        return Promise.resolve([{ count: 0 }]);
+      }
+      return Promise.resolve(undefined);
+    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -100,6 +109,65 @@ describe('StaffService', () => {
     permissions: [],
     onboardingCompleted: true,
   };
+
+  const hospitalManager: AuthenticatedUser = {
+    ...hospitalAdmin,
+    id: 'manager-1',
+    authId: 'auth-manager',
+    email: 'manager@hospital.com',
+    fullName: 'Manager',
+    roles: ['hospital_manager'],
+  };
+
+  const superAdmin: AuthenticatedUser = {
+    ...hospitalAdmin,
+    id: 'super-1',
+    authId: 'auth-super',
+    email: 'super@platform.com',
+    fullName: 'Super',
+    hospitalId: undefined,
+    roles: ['super_admin'],
+  };
+
+  function mockActiveAdminCount(count: number) {
+    userRolesRepo.manager.query.mockImplementation((sql: string) => {
+      if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
+        return Promise.resolve([{ count }]);
+      }
+      return Promise.resolve(undefined);
+    });
+  }
+
+  function mockCreateTransaction(existingUser: Record<string, unknown> | null) {
+    const query = jest.fn().mockResolvedValue(undefined);
+    staffRepo.manager.transaction.mockImplementation(
+      (cb: (m: Record<string, unknown>) => unknown) => {
+        const manager = {
+          query,
+          getRepository: (entity: unknown) => {
+            if (entity === User) {
+              return {
+                createQueryBuilder: () => ({
+                  leftJoinAndSelect: jest.fn().mockReturnThis(),
+                  where: jest.fn().mockReturnThis(),
+                  getOne: jest.fn().mockResolvedValue(existingUser),
+                }),
+                update: usersRepo.update,
+                save: usersRepo.save,
+                create: usersRepo.create,
+              };
+            }
+            if (entity === UserRole) return userRolesRepo;
+            if (entity === StaffProfile) return staffRepo;
+            if (entity === StaffInvite) return invitesRepo;
+            return {};
+          },
+        };
+        return Promise.resolve(cb(manager));
+      },
+    );
+    return { query };
+  }
 
   describe('assertHospitalAccess', () => {
     it('allows super_admin for any hospital', () => {
@@ -146,36 +214,6 @@ describe('StaffService', () => {
   });
 
   describe('create — cross-hospital invite', () => {
-    function mockCreateTransaction(
-      existingUser: Record<string, unknown> | null,
-    ) {
-      staffRepo.manager.transaction.mockImplementation(
-        (cb: (m: Record<string, unknown>) => unknown) => {
-          const manager = {
-            getRepository: (entity: unknown) => {
-              if (entity === User) {
-                return {
-                  createQueryBuilder: () => ({
-                    leftJoinAndSelect: jest.fn().mockReturnThis(),
-                    where: jest.fn().mockReturnThis(),
-                    getOne: jest.fn().mockResolvedValue(existingUser),
-                  }),
-                  update: usersRepo.update,
-                  save: usersRepo.save,
-                  create: usersRepo.create,
-                };
-              }
-              if (entity === UserRole) return userRolesRepo;
-              if (entity === StaffProfile) return staffRepo;
-              if (entity === StaffInvite) return invitesRepo;
-              return {};
-            },
-          };
-          return Promise.resolve(cb(manager));
-        },
-      );
-    }
-
     it('rejects inviting a user who already belongs to another hospital', async () => {
       rolesRepo.findOne.mockResolvedValue({
         id: 'role-doctor',
@@ -425,6 +463,172 @@ describe('StaffService', () => {
       await expect(
         service.resendStaffInvite('missing', hospitalAdmin),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('hospital_admin last-admin lockout', () => {
+    const lastAdminStaff = {
+      id: 'staff-admin',
+      userId: 'admin-1',
+      hospitalId: 'hospital-a',
+      isActive: true,
+      user: {
+        email: 'admin@hospital.com',
+        userRoles: [
+          { role: { slug: 'hospital_admin' }, hospitalId: 'hospital-a' },
+        ],
+      },
+    };
+
+    it('rejects removing the last active hospital_admin', async () => {
+      staffRepo.findOne.mockResolvedValue({ ...lastAdminStaff });
+      mockActiveAdminCount(0);
+      usersRepo.findOne.mockResolvedValue({
+        id: 'admin-1',
+        authId: 'user_live_admin',
+      });
+
+      await expect(
+        service.remove('staff-admin', hospitalAdmin),
+      ).rejects.toThrow(/Invite a replacement administrator first/);
+
+      expect(staffRepo.save).not.toHaveBeenCalled();
+      expect(usersRepo.update).not.toHaveBeenCalled();
+      expect(clerkAdmin.deactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('allows removing a hospital_admin when another remains active', async () => {
+      staffRepo.findOne.mockResolvedValue({ ...lastAdminStaff });
+      mockActiveAdminCount(1);
+      staffRepo.save.mockImplementation((row: { isActive: boolean }) =>
+        Promise.resolve(row),
+      );
+      usersRepo.findOne.mockResolvedValue({
+        id: 'admin-1',
+        authId: 'pending_abc',
+      });
+
+      await expect(service.remove('staff-admin', superAdmin)).resolves.toBe(
+        true,
+      );
+
+      expect(usersRepo.update).toHaveBeenCalledWith('admin-1', {
+        isActive: false,
+      });
+    });
+
+    it('rejects deactivating the last active hospital_admin', async () => {
+      staffRepo.findOne.mockResolvedValue({ ...lastAdminStaff });
+      mockActiveAdminCount(0);
+
+      await expect(
+        service.update('staff-admin', { isActive: false }, hospitalAdmin),
+      ).rejects.toThrow(/Invite a replacement administrator first/);
+
+      expect(staffRepo.save).not.toHaveBeenCalled();
+      expect(clerkAdmin.deactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects demoting the last active hospital_admin', async () => {
+      staffRepo.findOne.mockResolvedValue({ ...lastAdminStaff });
+      mockActiveAdminCount(0);
+
+      await expect(
+        service.update('staff-admin', { roleSlug: 'doctor' }, hospitalAdmin),
+      ).rejects.toThrow(/Invite a replacement administrator first/);
+
+      expect(userRolesRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('does not treat super_admin as filling the hospital_admin slot', async () => {
+      staffRepo.findOne.mockResolvedValue({ ...lastAdminStaff });
+      mockActiveAdminCount(0);
+
+      await expect(service.remove('staff-admin', superAdmin)).rejects.toThrow(
+        /Invite a replacement administrator first/,
+      );
+    });
+  });
+
+  describe('hospital_admin replacement invite', () => {
+    it('rejects hospital_admin invite from hospital_manager', async () => {
+      await expect(
+        service.create(
+          'hospital-a',
+          {
+            email: 'new-admin@hospital.com',
+            fullName: 'New Admin',
+            roleSlug: 'hospital_admin',
+          },
+          hospitalManager,
+        ),
+      ).rejects.toThrow(/cannot be assigned via staff invite/);
+
+      expect(rolesRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('rejects hospital_admin invite when an active hospital_admin exists', async () => {
+      mockActiveAdminCount(1);
+
+      await expect(
+        service.create(
+          'hospital-a',
+          {
+            email: 'new-admin@hospital.com',
+            fullName: 'New Admin',
+            roleSlug: 'hospital_admin',
+          },
+          hospitalAdmin,
+        ),
+      ).rejects.toThrow(/already has an active hospital_admin/);
+
+      expect(staffRepo.manager.transaction).not.toHaveBeenCalled();
+    });
+
+    it('allows hospital_admin invite when there are zero active hospital_admins', async () => {
+      mockActiveAdminCount(0);
+      rolesRepo.findOne.mockResolvedValue({
+        id: 'role-admin',
+        slug: 'hospital_admin',
+      });
+      usersRepo.create.mockImplementation((row: unknown) => row);
+      usersRepo.save.mockResolvedValue({
+        id: 'user-new',
+        hospitalId: 'hospital-a',
+      });
+      staffRepo.findOne.mockResolvedValueOnce(null).mockResolvedValue({
+        id: 'staff-new',
+        userId: 'user-new',
+        hospitalId: 'hospital-a',
+        user: {
+          fullName: 'New Admin',
+          email: 'new-admin@hospital.com',
+          userRoles: [{ role: { slug: 'hospital_admin' } }],
+        },
+      });
+      staffRepo.create.mockImplementation((row: unknown) => row);
+      staffRepo.save.mockResolvedValue({ id: 'staff-new' });
+      userRolesRepo.findOne.mockResolvedValue(null);
+      userRolesRepo.create.mockImplementation((row: unknown) => row);
+      invitesRepo.create.mockImplementation((row: unknown) => row);
+      invitesRepo.save.mockResolvedValue({});
+      const { query } = mockCreateTransaction(null);
+
+      await service.create(
+        'hospital-a',
+        {
+          email: 'new-admin@hospital.com',
+          fullName: 'New Admin',
+          roleSlug: 'hospital_admin',
+        },
+        superAdmin,
+      );
+
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM user_roles'),
+        ['hospital-a'],
+      );
+      expect(userRolesRepo.save).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -28,6 +28,8 @@ function isUniqueViolation(error: unknown): boolean {
   );
 }
 
+const HOSPITAL_ADMIN_ROLE = 'hospital_admin';
+
 const ASSIGNABLE_STAFF_ROLES = new Set([
   'hospital_manager',
   'doctor',
@@ -36,7 +38,38 @@ const ASSIGNABLE_STAFF_ROLES = new Set([
   'lab_technician',
   'pharmacist',
   'accountant',
+  // hospital_admin is assignable only by hospital_admin / super_admin, and
+  // only when the hospital currently has zero active hospital_admins.
+  HOSPITAL_ADMIN_ROLE,
 ]);
+
+const LAST_ACTIVE_HOSPITAL_ADMIN_MESSAGE =
+  'Hospital must keep at least one active hospital_admin. Invite a replacement administrator first.';
+
+const HOSPITAL_ADMIN_SLOT_TAKEN_MESSAGE =
+  'This hospital already has an active hospital_admin. A replacement can only be invited when none are active.';
+
+/** Platform super_admin is not a hospital_admin and must not occupy this slot. */
+const COUNT_ACTIVE_HOSPITAL_ADMINS_SQL = `
+  SELECT COUNT(*)::int AS count
+  FROM user_roles ur
+  INNER JOIN users u ON u.id = ur.user_id
+  INNER JOIN roles r ON r.id = ur.role_id
+  WHERE r.slug = 'hospital_admin'
+    AND ur.hospital_id = $1
+    AND u.is_active = true
+    AND u.deleted_at IS NULL
+`;
+
+const RELEASE_INACTIVE_HOSPITAL_ADMIN_SLOTS_SQL = `
+  DELETE FROM user_roles ur
+  USING users u, roles r
+  WHERE ur.user_id = u.id
+    AND ur.role_id = r.id
+    AND r.slug = 'hospital_admin'
+    AND ur.hospital_id = $1
+    AND (u.is_active = false OR u.deleted_at IS NOT NULL)
+`;
 
 @Injectable()
 export class StaffService {
@@ -57,11 +90,73 @@ export class StaffService {
 
   private assertAssignableRole(roleSlug: string, actor: AuthenticatedUser) {
     if (actor.roles.includes('super_admin')) return;
+    if (roleSlug === HOSPITAL_ADMIN_ROLE) {
+      if (!actor.roles.includes('hospital_admin')) {
+        throw new BadRequestException(
+          `Role "${roleSlug}" cannot be assigned via staff invite`,
+        );
+      }
+      return;
+    }
     if (!ASSIGNABLE_STAFF_ROLES.has(roleSlug)) {
       throw new BadRequestException(
         `Role "${roleSlug}" cannot be assigned via staff invite`,
       );
     }
+  }
+
+  private isHospitalAdmin(staff: StaffProfile): boolean {
+    return (staff.user?.userRoles ?? []).some(
+      (ur) =>
+        ur.role?.slug === HOSPITAL_ADMIN_ROLE &&
+        (ur.hospitalId == null || ur.hospitalId === staff.hospitalId),
+    );
+  }
+
+  private async countActiveHospitalAdmins(
+    hospitalId: string,
+    excludeUserId?: string,
+  ): Promise<number> {
+    const params: string[] = [hospitalId];
+    let sql = COUNT_ACTIVE_HOSPITAL_ADMINS_SQL;
+    if (excludeUserId) {
+      sql += ` AND ur.user_id <> $2`;
+      params.push(excludeUserId);
+    }
+    const rows = (await this.userRolesRepo.manager.query(sql, params)) as Array<{
+      count: number | string;
+    }>;
+    return Number(rows[0]?.count ?? 0);
+  }
+
+  private async assertNotLastActiveHospitalAdmin(staff: StaffProfile) {
+    const others = await this.countActiveHospitalAdmins(
+      staff.hospitalId,
+      staff.userId,
+    );
+    if (others === 0) {
+      throw new BadRequestException(LAST_ACTIVE_HOSPITAL_ADMIN_MESSAGE);
+    }
+  }
+
+  private async assertHospitalAdminSlotAvailable(
+    hospitalId: string,
+    excludeUserId?: string,
+  ) {
+    const active = await this.countActiveHospitalAdmins(
+      hospitalId,
+      excludeUserId,
+    );
+    if (active > 0) {
+      throw new BadRequestException(HOSPITAL_ADMIN_SLOT_TAKEN_MESSAGE);
+    }
+  }
+
+  private async releaseInactiveHospitalAdminSlots(
+    hospitalId: string,
+    runner: { query: (sql: string, parameters?: unknown[]) => Promise<unknown> },
+  ) {
+    await runner.query(RELEASE_INACTIVE_HOSPITAL_ADMIN_SLOTS_SQL, [hospitalId]);
   }
 
   assertHospitalAccess(user: AuthenticatedUser, hospitalId: string) {
@@ -104,6 +199,9 @@ export class StaffService {
   ): Promise<StaffProfile> {
     this.assertHospitalAccess(actor, hospitalId);
     this.assertAssignableRole(input.roleSlug, actor);
+    if (input.roleSlug === HOSPITAL_ADMIN_ROLE) {
+      await this.assertHospitalAdminSlotAvailable(hospitalId);
+    }
 
     const role = await this.rolesRepo.findOne({
       where: { slug: input.roleSlug },
@@ -193,6 +291,12 @@ export class StaffService {
           );
         }
 
+        if (input.roleSlug === HOSPITAL_ADMIN_ROLE) {
+          // Unique index is on all hospital_admin rows (including inactive).
+          // Free the slot so a replacement invite can succeed when count is 0.
+          await this.releaseInactiveHospitalAdminSlots(hospitalId, manager);
+        }
+
         const existingRole = await userRolesRepo.findOne({
           where: { userId: user.id, roleId: role.id, hospitalId },
         });
@@ -243,6 +347,15 @@ export class StaffService {
       });
     } catch (error) {
       if (isUniqueViolation(error)) {
+        const constraint =
+          (error as QueryFailedError & { constraint?: string }).constraint ??
+          '';
+        if (
+          input.roleSlug === HOSPITAL_ADMIN_ROLE ||
+          constraint.includes('one_hospital_admin')
+        ) {
+          throw new ConflictException(HOSPITAL_ADMIN_SLOT_TAKEN_MESSAGE);
+        }
         throw new ConflictException(
           'Staff profile or pending invite already exists for this email',
         );
@@ -272,9 +385,7 @@ export class StaffService {
     const staff = await this.findByIdForUser(id, actor);
     if (!staff) throw new NotFoundException('Staff member not found');
 
-    const targetIsHospitalAdmin = (staff.user?.userRoles ?? []).some(
-      (ur) => ur.role?.slug === 'hospital_admin',
-    );
+    const targetIsHospitalAdmin = this.isHospitalAdmin(staff);
     const actorIsAdmin =
       actor.roles.includes('hospital_admin') ||
       actor.roles.includes('super_admin');
@@ -286,12 +397,32 @@ export class StaffService {
       );
     }
 
+    const demotingAdmin =
+      targetIsHospitalAdmin &&
+      input.roleSlug !== undefined &&
+      input.roleSlug !== HOSPITAL_ADMIN_ROLE;
+    const deactivatingAdmin =
+      targetIsHospitalAdmin && input.isActive === false;
+    if (demotingAdmin || deactivatingAdmin) {
+      await this.assertNotLastActiveHospitalAdmin(staff);
+    }
+
     if (input.fullName) {
       await this.usersRepo.update(staff.userId, { fullName: input.fullName });
     }
 
     if (input.roleSlug) {
       this.assertAssignableRole(input.roleSlug, actor);
+      if (input.roleSlug === HOSPITAL_ADMIN_ROLE) {
+        await this.assertHospitalAdminSlotAvailable(
+          staff.hospitalId,
+          staff.userId,
+        );
+        await this.releaseInactiveHospitalAdminSlots(
+          staff.hospitalId,
+          this.userRolesRepo.manager,
+        );
+      }
       const role = await this.rolesRepo.findOne({
         where: { slug: input.roleSlug },
       });
@@ -349,6 +480,10 @@ export class StaffService {
   async remove(id: string, actor: AuthenticatedUser): Promise<boolean> {
     const staff = await this.findByIdForUser(id, actor);
     if (!staff) throw new NotFoundException('Staff member not found');
+
+    if (this.isHospitalAdmin(staff)) {
+      await this.assertNotLastActiveHospitalAdmin(staff);
+    }
 
     await this.syncClerkActiveState(staff.userId, false);
 

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomBytes, randomUUID } from 'crypto';
-import { QueryFailedError, Repository } from 'typeorm';
+import { EntityManager, QueryFailedError, Repository } from 'typeorm';
 import {
   Role,
   StaffInvite,
@@ -38,8 +38,8 @@ const ASSIGNABLE_STAFF_ROLES = new Set([
   'lab_technician',
   'pharmacist',
   'accountant',
-  // hospital_admin is assignable only by hospital_admin / super_admin, and
-  // only when the hospital currently has zero active hospital_admins.
+  // hospital_admin: sitting hospital_admin or super_admin may invite a successor.
+  // The unique user_roles row is not inserted until accept (see transfer below).
   HOSPITAL_ADMIN_ROLE,
 ]);
 
@@ -47,7 +47,18 @@ const LAST_ACTIVE_HOSPITAL_ADMIN_MESSAGE =
   'Hospital must keep at least one active hospital_admin. Invite a replacement administrator first.';
 
 const HOSPITAL_ADMIN_SLOT_TAKEN_MESSAGE =
-  'This hospital already has an active hospital_admin. A replacement can only be invited when none are active.';
+  'This hospital already has a hospital_admin. Invite a successor instead; the role transfers when they accept.';
+
+/**
+ * One hospital_admin role per hospital (UNIQUE idx_user_roles_one_hospital_admin,
+ * including inactive rows). Succession: current admin or super_admin invites a
+ * replacement. The invite does not consume the unique user_roles slot. When the
+ * invite is accepted, the unique hospital_admin role transfers atomically
+ * (delete other hospital_admin rows for that hospital, insert the successor).
+ * Last active admin cannot be deactivated until a successor has accepted, so
+ * the tenant never has zero. Re-bootstrap when zero *active* admins remain is
+ * handled in AuthService.completeOnboarding.
+ */
 
 /** Platform super_admin is not a hospital_admin and must not occupy this slot. */
 const COUNT_ACTIVE_HOSPITAL_ADMINS_SQL = `
@@ -69,6 +80,15 @@ const RELEASE_INACTIVE_HOSPITAL_ADMIN_SLOTS_SQL = `
     AND r.slug = 'hospital_admin'
     AND ur.hospital_id = $1
     AND (u.is_active = false OR u.deleted_at IS NOT NULL)
+`;
+
+const TRANSFER_HOSPITAL_ADMIN_ROLE_SQL = `
+  DELETE FROM user_roles ur
+  USING roles r
+  WHERE ur.role_id = r.id
+    AND r.slug = 'hospital_admin'
+    AND ur.hospital_id = $1
+    AND ur.user_id <> $2
 `;
 
 @Injectable()
@@ -123,9 +143,8 @@ export class StaffService {
       sql += ` AND ur.user_id <> $2`;
       params.push(excludeUserId);
     }
-    const rows = (await this.userRolesRepo.manager.query(sql, params)) as Array<{
-      count: number | string;
-    }>;
+    const raw: unknown = await this.userRolesRepo.manager.query(sql, params);
+    const rows = raw as Array<{ count: number | string }>;
     return Number(rows[0]?.count ?? 0);
   }
 
@@ -154,9 +173,53 @@ export class StaffService {
 
   private async releaseInactiveHospitalAdminSlots(
     hospitalId: string,
-    runner: { query: (sql: string, parameters?: unknown[]) => Promise<unknown> },
+    runner: {
+      query: (sql: string, parameters?: unknown[]) => Promise<unknown>;
+    },
   ) {
     await runner.query(RELEASE_INACTIVE_HOSPITAL_ADMIN_SLOTS_SQL, [hospitalId]);
+  }
+
+  /** Atomically move the unique hospital_admin slot to successorUserId. */
+  private async transferHospitalAdminRole(
+    manager: EntityManager,
+    hospitalId: string,
+    successorUserId: string,
+  ) {
+    await manager.query(`SELECT pg_advisory_xact_lock(hashtext($1::text))`, [
+      `hospital-admin-transfer:${hospitalId}`,
+    ]);
+
+    const rolesRepo = manager.getRepository(Role);
+    const userRolesRepo = manager.getRepository(UserRole);
+    const adminRole = await rolesRepo.findOne({
+      where: { slug: HOSPITAL_ADMIN_ROLE },
+    });
+    if (!adminRole) {
+      throw new NotFoundException(`Role ${HOSPITAL_ADMIN_ROLE} not found`);
+    }
+
+    await manager.query(TRANSFER_HOSPITAL_ADMIN_ROLE_SQL, [
+      hospitalId,
+      successorUserId,
+    ]);
+
+    const existingRole = await userRolesRepo.findOne({
+      where: {
+        userId: successorUserId,
+        roleId: adminRole.id,
+        hospitalId,
+      },
+    });
+    if (!existingRole) {
+      await userRolesRepo.save(
+        userRolesRepo.create({
+          userId: successorUserId,
+          roleId: adminRole.id,
+          hospitalId,
+        }),
+      );
+    }
   }
 
   assertHospitalAccess(user: AuthenticatedUser, hospitalId: string) {
@@ -199,9 +262,6 @@ export class StaffService {
   ): Promise<StaffProfile> {
     this.assertHospitalAccess(actor, hospitalId);
     this.assertAssignableRole(input.roleSlug, actor);
-    if (input.roleSlug === HOSPITAL_ADMIN_ROLE) {
-      await this.assertHospitalAdminSlotAvailable(hospitalId);
-    }
 
     const role = await this.rolesRepo.findOne({
       where: { slug: input.roleSlug },
@@ -291,23 +351,22 @@ export class StaffService {
           );
         }
 
-        if (input.roleSlug === HOSPITAL_ADMIN_ROLE) {
-          // Unique index is on all hospital_admin rows (including inactive).
-          // Free the slot so a replacement invite can succeed when count is 0.
-          await this.releaseInactiveHospitalAdminSlots(hospitalId, manager);
-        }
-
-        const existingRole = await userRolesRepo.findOne({
-          where: { userId: user.id, roleId: role.id, hospitalId },
-        });
-        if (!existingRole) {
-          await userRolesRepo.save(
-            userRolesRepo.create({
-              userId: user.id,
-              roleId: role.id,
-              hospitalId,
-            }),
-          );
+        // hospital_admin invite is a pending successor: do not insert user_roles
+        // here. The unique index would collide with the sitting admin; the slot
+        // transfers atomically in acceptInvite.
+        if (input.roleSlug !== HOSPITAL_ADMIN_ROLE) {
+          const existingRole = await userRolesRepo.findOne({
+            where: { userId: user.id, roleId: role.id, hospitalId },
+          });
+          if (!existingRole) {
+            await userRolesRepo.save(
+              userRolesRepo.create({
+                userId: user.id,
+                roleId: role.id,
+                hospitalId,
+              }),
+            );
+          }
         }
 
         // Expire any prior pending invite for this email so the unique index allows a new one.
@@ -350,10 +409,7 @@ export class StaffService {
         const constraint =
           (error as QueryFailedError & { constraint?: string }).constraint ??
           '';
-        if (
-          input.roleSlug === HOSPITAL_ADMIN_ROLE ||
-          constraint.includes('one_hospital_admin')
-        ) {
+        if (constraint.includes('one_hospital_admin')) {
           throw new ConflictException(HOSPITAL_ADMIN_SLOT_TAKEN_MESSAGE);
         }
         throw new ConflictException(
@@ -401,8 +457,7 @@ export class StaffService {
       targetIsHospitalAdmin &&
       input.roleSlug !== undefined &&
       input.roleSlug !== HOSPITAL_ADMIN_ROLE;
-    const deactivatingAdmin =
-      targetIsHospitalAdmin && input.isActive === false;
+    const deactivatingAdmin = targetIsHospitalAdmin && input.isActive === false;
     if (demotingAdmin || deactivatingAdmin) {
       await this.assertNotLastActiveHospitalAdmin(staff);
     }
@@ -588,8 +643,9 @@ export class StaffService {
     authId: string,
     email: string,
   ): Promise<StaffProfile> {
-    const staffId = await this.invitesRepo.manager.transaction(
-      async (manager) => {
+    let staffId: string;
+    try {
+      staffId = await this.invitesRepo.manager.transaction(async (manager) => {
         const invitesRepo = manager.getRepository(StaffInvite);
         const usersRepo = manager.getRepository(User);
         const staffRepo = manager.getRepository(StaffProfile);
@@ -638,6 +694,14 @@ export class StaffService {
           );
         }
 
+        if (invite.roleSlug === HOSPITAL_ADMIN_ROLE) {
+          await this.transferHospitalAdminRole(
+            manager,
+            invite.hospitalId,
+            staff.userId,
+          );
+        }
+
         await usersRepo.update(staff.userId, {
           authId,
           onboardingCompleted: true,
@@ -648,8 +712,13 @@ export class StaffService {
         invite.acceptedAt = new Date();
         await invitesRepo.save(invite);
         return staff.id;
-      },
-    );
+      });
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new ConflictException(HOSPITAL_ADMIN_SLOT_TAKEN_MESSAGE);
+      }
+      throw error;
+    }
 
     return (await this.findById(staffId))!;
   }

--- a/apps/web/src/components/staff/staff-form.tsx
+++ b/apps/web/src/components/staff/staff-form.tsx
@@ -20,6 +20,7 @@ const roleOptions = [
   ROLES.PHARMACIST,
   ROLES.ACCOUNTANT,
   ROLES.HOSPITAL_MANAGER,
+  ROLES.HOSPITAL_ADMIN,
 ];
 
 export function StaffForm({

--- a/apps/web/src/components/staff/staff-form.tsx
+++ b/apps/web/src/components/staff/staff-form.tsx
@@ -32,6 +32,7 @@ export function StaffForm({
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<StaffInput>({
     resolver: zodResolver(staffSchema),
@@ -40,6 +41,8 @@ export function StaffForm({
       ...defaultValues,
     },
   });
+
+  const selectedRole = watch('roleSlug');
 
   return (
     <ClayCard className="max-w-2xl">
@@ -64,6 +67,11 @@ export function StaffForm({
                 </option>
               ))}
             </select>
+            {selectedRole === ROLES.HOSPITAL_ADMIN ? (
+              <p className="text-sm text-clay-text-muted">
+                Invite a successor. The hospital_admin role transfers when they accept.
+              </p>
+            ) : null}
           </div>
           <ClayInput label="Department" error={errors.department?.message} {...register('department')} />
           <ClayInput

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,7 +30,7 @@ Hospital-scoped data is filtered by the authenticated user's `hospitalId` unless
 |--------|---------|
 | `auth` / `users` | JWT validation, `me`, onboarding / patient onboarding |
 | `hospitals` | Hospital profile and settings |
-| `staff` | Staff CRUD, invite URLs, RBAC assignment |
+| `staff` | Staff CRUD, invite URLs, RBAC assignment. `hospital_admin` invite is a pending successor; the unique role transfers on accept. |
 | `patients` | Patient CRUD, bulk import, documents, soft delete, account linking |
 | `appointments` | Scheduling and status updates |
 | `admissions` | Admissions and bed occupancy |


### PR DESCRIPTION
## Summary
- Prevents deactivating, deleting, or demoting the last **active** `hospital_admin` (`#273`). The hospital must keep at least one active admin; invite a replacement first.
- Allows inviting `hospital_admin` only when the hospital currently has **zero** active hospital admins (`#283` recovery). Existing hospital_admin / super_admin can invite; hospital_manager cannot. Platform `super_admin` is not counted as filling the hospital admin slot.
- Unique index still covers all `hospital_admin` rows, including inactive leftovers. Replacement invite and bootstrap delete inactive leftover roles so the slot can be reused, and bootstrap now counts only active admins.

Closes #273
Closes #283

## Test plan
- [ ] Try to deactivate/delete the last active hospital_admin — expect BadRequest telling you to invite a replacement first
- [ ] Deactivate a hospital_admin when another active one remains — succeeds
- [ ] With an active hospital_admin present, invite another `hospital_admin` — rejected
- [ ] As hospital_manager, invite `hospital_admin` — rejected
- [ ] With zero active hospital_admins (inactive leftover only), invite `hospital_admin` as super_admin — succeeds
- [ ] Unit tests: `pnpm --filter api test -- staff.service.spec.ts auth.service.spec.ts`