### PR TITLE
fix(api): refuse GraphQL tenant ops on inactive hospitals (#284)

### DIFF
--- a/apps/api/src/admissions/admissions.resolver.ts
+++ b/apps/api/src/admissions/admissions.resolver.ts
@@ -8,6 +8,7 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { AdmissionsService } from './admissions.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   AdmissionType,
   AdmitPatientInput,
@@ -29,7 +30,10 @@ const CHART_READ_ROLES = [
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class AdmissionsResolver {
-  constructor(private readonly admissionsService: AdmissionsService) {}
+  constructor(
+    private readonly admissionsService: AdmissionsService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [AdmissionType])
   @Roles(...CHART_READ_ROLES)
@@ -38,9 +42,10 @@ export class AdmissionsResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<AdmissionType[]> {
-    const resolvedHospitalId = this.admissionsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.admissionsService.activeAdmissions(resolvedHospitalId);
   }
@@ -52,9 +57,10 @@ export class AdmissionsResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<WardOccupancyType[]> {
-    const resolvedHospitalId = this.admissionsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.admissionsService.wardOccupancy(resolvedHospitalId);
   }
@@ -74,9 +80,10 @@ export class AdmissionsResolver {
     @Args('input') input: AdmitPatientInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<AdmissionType> {
-    const resolvedHospitalId = this.admissionsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.admissionsService.admitPatient(resolvedHospitalId, input, user);
   }
@@ -95,9 +102,10 @@ export class AdmissionsResolver {
     @Args('input') input: DischargeAdmissionInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<AdmissionType> {
-    const resolvedHospitalId = this.admissionsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.admissionsService.dischargeAdmission(
       resolvedHospitalId,
@@ -121,9 +129,10 @@ export class AdmissionsResolver {
     @Args('input') input: TransferAdmissionInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<AdmissionType> {
-    const resolvedHospitalId = this.admissionsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.admissionsService.transferAdmission(
       resolvedHospitalId,
@@ -146,9 +155,10 @@ export class AdmissionsResolver {
     @Args('input') input: TransferOutAdmissionInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<AdmissionType> {
-    const resolvedHospitalId = this.admissionsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.admissionsService.transferOutAdmission(
       resolvedHospitalId,

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { graphqlQueryComplexityPlugin } from './common/graphql-query-complexity.
 import { validateEnv } from './config/env.validation';
 import { AuthModule } from './auth/auth.module';
 import { AppThrottlerGuard } from './common/app-throttler.guard';
+import { CommonModule } from './common/common.module';
 import {
   Hospital,
   Patient,
@@ -170,6 +171,7 @@ import { UploadsModule } from './uploads/uploads.module';
       },
     }),
     AuthModule,
+    CommonModule,
     RbacModule,
     ClerkModule,
     AuditModule,

--- a/apps/api/src/appointments/appointments.resolver.ts
+++ b/apps/api/src/appointments/appointments.resolver.ts
@@ -9,6 +9,7 @@ import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { STAFF_ROLES } from '../rbac/staff-roles';
 import { AppointmentsService } from './appointments.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   AppointmentType,
   CancelAppointmentInput,
@@ -18,7 +19,10 @@ import {
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class AppointmentsResolver {
-  constructor(private readonly appointmentsService: AppointmentsService) {}
+  constructor(
+    private readonly appointmentsService: AppointmentsService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [AppointmentType])
   @Roles(...STAFF_ROLES)
@@ -30,9 +34,10 @@ export class AppointmentsResolver {
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
     @Args('status', { nullable: true }) status?: string,
   ): Promise<AppointmentType[]> {
-    const resolvedHospitalId = this.appointmentsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.appointmentsService.findAll(
       resolvedHospitalId,
@@ -51,9 +56,10 @@ export class AppointmentsResolver {
     @Args('input') input: CreateAppointmentInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<AppointmentType> {
-    const resolvedHospitalId = this.appointmentsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.appointmentsService.create(resolvedHospitalId, input, user);
   }
@@ -67,9 +73,10 @@ export class AppointmentsResolver {
     @Args('status') status: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<AppointmentType> {
-    const resolvedHospitalId = this.appointmentsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.appointmentsService.updateStatus(
       id,
@@ -87,9 +94,10 @@ export class AppointmentsResolver {
     @Args('input') input: CancelAppointmentInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<AppointmentType> {
-    const resolvedHospitalId = this.appointmentsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.appointmentsService.cancel(resolvedHospitalId, input, user);
   }

--- a/apps/api/src/audit/audit.resolver.ts
+++ b/apps/api/src/audit/audit.resolver.ts
@@ -9,11 +9,15 @@ import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { AuditService } from './audit.service';
 import { AuditLogsPageType } from './audit.types';
+import { HospitalContextService } from '../common/hospital-context.service';
 
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class AuditResolver {
-  constructor(private readonly auditService: AuditService) {}
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => AuditLogsPageType)
   @Permissions(PERMISSIONS.REPORTS_READ)
@@ -24,9 +28,10 @@ export class AuditResolver {
     @Args('resource', { nullable: true }) resource?: string,
     @Args('limit', { type: () => Int, nullable: true }) limit?: number,
   ): Promise<AuditLogsPageType> {
-    const resolvedHospitalId = this.auditService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.auditService.listHospitalLogs(resolvedHospitalId, {
       resource,

--- a/apps/api/src/billing/billing.resolver.ts
+++ b/apps/api/src/billing/billing.resolver.ts
@@ -8,6 +8,7 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { BillingService } from './billing.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   CreateInvoiceInput,
   InvoiceType,
@@ -31,7 +32,10 @@ const BILLING_ROLES = [
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class BillingResolver {
-  constructor(private readonly billingService: BillingService) {}
+  constructor(
+    private readonly billingService: BillingService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [InvoiceType])
   @Roles(...BILLING_ROLES)
@@ -40,9 +44,10 @@ export class BillingResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<InvoiceType[]> {
-    const resolvedHospitalId = this.billingService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.billingService.listInvoices(resolvedHospitalId);
   }
@@ -56,9 +61,10 @@ export class BillingResolver {
     @Args('limit', { type: () => Int, nullable: true }) limit?: number,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<BillingPatientLookupType[]> {
-    const resolvedHospitalId = this.billingService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.billingService.searchPatientsForBilling(
       resolvedHospitalId,
@@ -75,9 +81,10 @@ export class BillingResolver {
     @Args('id') id: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<InvoiceType> {
-    const resolvedHospitalId = this.billingService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.billingService.getInvoice(resolvedHospitalId, id);
   }
@@ -90,9 +97,10 @@ export class BillingResolver {
     @Args('input') input: CreateInvoiceInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<InvoiceType> {
-    const resolvedHospitalId = this.billingService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.billingService.createInvoice(resolvedHospitalId, input, user);
   }
@@ -105,9 +113,10 @@ export class BillingResolver {
     @Args('input') input: RecordPaymentInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<InvoiceType> {
-    const resolvedHospitalId = this.billingService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.billingService.recordPayment(resolvedHospitalId, input, user);
   }
@@ -120,9 +129,10 @@ export class BillingResolver {
     @Args('id') id: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<InvoiceType> {
-    const resolvedHospitalId = this.billingService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.billingService.voidInvoice(resolvedHospitalId, id, user);
   }

--- a/apps/api/src/clinical/clinical.resolver.ts
+++ b/apps/api/src/clinical/clinical.resolver.ts
@@ -7,6 +7,7 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { ClinicalService } from './clinical.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   ClinicalNoteType,
   CompleteLabResultInput,
@@ -62,7 +63,10 @@ const LAB_ORDER_READ_ROLES = [
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class ClinicalResolver {
-  constructor(private readonly clinicalService: ClinicalService) {}
+  constructor(
+    private readonly clinicalService: ClinicalService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [LabOrderType])
   @Roles(...LAB_ORDER_READ_ROLES)
@@ -72,9 +76,10 @@ export class ClinicalResolver {
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
     @Args('status', { nullable: true }) status?: string,
   ): Promise<LabOrderType[]> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.clinicalService.listLabOrders(resolvedHospitalId, status);
   }
@@ -87,9 +92,10 @@ export class ClinicalResolver {
     @Args('patientId') patientId: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<VitalSignType[]> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.clinicalService.listVitalSigns(resolvedHospitalId, patientId);
   }
@@ -102,9 +108,10 @@ export class ClinicalResolver {
     @Args('patientId') patientId: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<ClinicalNoteType[]> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.clinicalService.listClinicalNotes(
       resolvedHospitalId,
@@ -120,9 +127,10 @@ export class ClinicalResolver {
     @Args('patientId') patientId: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<DiagnosisType[]> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.clinicalService.listDiagnoses(resolvedHospitalId, patientId);
   }
@@ -135,9 +143,10 @@ export class ClinicalResolver {
     @Args('patientId') patientId: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PrescriptionType[]> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.clinicalService.listPrescriptions(
       resolvedHospitalId,
@@ -153,9 +162,10 @@ export class ClinicalResolver {
     @Args('input') input: CreateVitalInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<VitalSignType> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.clinicalService.createVital(resolvedHospitalId, input, user);
   }
@@ -168,9 +178,10 @@ export class ClinicalResolver {
     @Args('input') input: CreateDiagnosisInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<DiagnosisType> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.clinicalService.createDiagnosis(
       resolvedHospitalId,
@@ -187,9 +198,10 @@ export class ClinicalResolver {
     @Args('input') input: CreateClinicalNoteInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<ClinicalNoteType> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.clinicalService.createClinicalNote(
       resolvedHospitalId,
@@ -206,9 +218,10 @@ export class ClinicalResolver {
     @Args('input') input: CreatePrescriptionInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PrescriptionType> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.clinicalService.createPrescription(
       resolvedHospitalId,
@@ -225,9 +238,10 @@ export class ClinicalResolver {
     @Args('input') input: CreateLabOrderInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<LabOrderType> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.clinicalService.createLabOrder(resolvedHospitalId, input, user);
   }
@@ -239,9 +253,10 @@ export class ClinicalResolver {
     @Args('input') input: CompleteLabResultInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<LabResultType> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.clinicalService.completeLabResult(
       resolvedHospitalId,
@@ -257,9 +272,10 @@ export class ClinicalResolver {
     @Args('input') input: UpdateLabOrderStatusInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<LabOrderType> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.clinicalService.updateLabOrderStatus(
       resolvedHospitalId,
@@ -276,9 +292,10 @@ export class ClinicalResolver {
     @Args('input') input: CancelPrescriptionInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PrescriptionType> {
-    const resolvedHospitalId = this.clinicalService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.clinicalService.cancelPrescription(
       resolvedHospitalId,

--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -1,11 +1,13 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { StaffProfile } from '../database/entities';
+import { Hospital, StaffProfile } from '../database/entities';
+import { HospitalContextService } from './hospital-context.service';
 import { HospitalDoctorValidator } from './hospital-doctor.validator';
 
+@Global()
 @Module({
-  imports: [TypeOrmModule.forFeature([StaffProfile])],
-  providers: [HospitalDoctorValidator],
-  exports: [HospitalDoctorValidator],
+  imports: [TypeOrmModule.forFeature([StaffProfile, Hospital])],
+  providers: [HospitalDoctorValidator, HospitalContextService],
+  exports: [HospitalDoctorValidator, HospitalContextService],
 })
 export class CommonModule {}

--- a/apps/api/src/common/hospital-context.service.spec.ts
+++ b/apps/api/src/common/hospital-context.service.spec.ts
@@ -1,0 +1,137 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { Hospital } from '../database/entities';
+import { HospitalContextService } from './hospital-context.service';
+
+describe('HospitalContextService', () => {
+  let service: HospitalContextService;
+  const hospitalsRepo = { findOne: jest.fn() };
+
+  const hospitalAdmin: AuthenticatedUser = {
+    id: 'user-1',
+    authId: 'auth-1',
+    email: 'admin@hospital.com',
+    fullName: 'Admin',
+    hospitalId: 'hospital-a',
+    hospitalActive: true,
+    roles: ['hospital_admin'],
+    permissions: ['patients:write'],
+    onboardingCompleted: true,
+  };
+
+  const superAdmin: AuthenticatedUser = {
+    ...hospitalAdmin,
+    id: 'super-1',
+    roles: ['super_admin'],
+    hospitalId: undefined,
+    hospitalActive: true,
+    permissions: [],
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HospitalContextService,
+        { provide: getRepositoryToken(Hospital), useValue: hospitalsRepo },
+      ],
+    }).compile();
+    service = module.get(HospitalContextService);
+  });
+
+  describe('resolveHospitalId', () => {
+    it('returns the caller hospital when it is active', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: true,
+      });
+
+      await expect(service.resolveHospitalId(hospitalAdmin)).resolves.toBe(
+        'hospital-a',
+      );
+    });
+
+    it('throws when hospital context is missing', async () => {
+      await expect(
+        service.resolveHospitalId({ ...hospitalAdmin, hospitalId: undefined }),
+      ).rejects.toThrow(NotFoundException);
+      expect(hospitalsRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('rejects tenant writes when the hospital exists and is inactive', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: false,
+      });
+
+      await expect(service.resolveHospitalId(hospitalAdmin)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('rejects tenant reads when the hospital is inactive', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: false,
+      });
+
+      await expect(
+        service.resolveHospitalId(hospitalAdmin, undefined, { write: false }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('does not throw when the hospital row is missing', async () => {
+      hospitalsRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.resolveHospitalId(hospitalAdmin)).resolves.toBe(
+        'hospital-a',
+      );
+    });
+
+    it('rejects super_admin writes to an inactive hospital', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-b',
+        isActive: false,
+      });
+
+      await expect(
+        service.resolveHospitalId(superAdmin, 'hospital-b', { write: true }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('allows super_admin to read an inactive hospital', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-b',
+        isActive: false,
+      });
+
+      await expect(
+        service.resolveHospitalId(superAdmin, 'hospital-b', { write: false }),
+      ).resolves.toBe('hospital-b');
+    });
+
+    it('allows super_admin writes to an active hospital', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-b',
+        isActive: true,
+      });
+
+      await expect(
+        service.resolveHospitalId(superAdmin, 'hospital-b', { write: true }),
+      ).resolves.toBe('hospital-b');
+    });
+
+    it('defaults to write and blocks super_admin when write is omitted', async () => {
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-b',
+        isActive: false,
+      });
+
+      await expect(
+        service.resolveHospitalId(superAdmin, 'hospital-b'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+});

--- a/apps/api/src/common/hospital-context.service.ts
+++ b/apps/api/src/common/hospital-context.service.ts
@@ -1,0 +1,67 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { Hospital } from '../database/entities';
+
+export type ResolveHospitalOptions = {
+  /**
+   * Tenant writes (including super_admin targeting a hospital) must not
+   * mutate an inactive hospital. Reads may still let super_admin view
+   * across hospitals after tenant lockout.
+   */
+  write?: boolean;
+};
+
+@Injectable()
+export class HospitalContextService {
+  constructor(
+    @InjectRepository(Hospital)
+    private readonly hospitalsRepo: Repository<Hospital>,
+  ) {}
+
+  /**
+   * Resolve hospital scope, then refuse inactive hospitals (#284).
+   * Missing hospital rows are left to the caller (typically 404).
+   */
+  async resolveHospitalId(
+    user: AuthenticatedUser,
+    hospitalId?: string,
+    options?: ResolveHospitalOptions,
+  ): Promise<string> {
+    const id = this.resolveTenantHospitalId(user, hospitalId);
+    const hospital = await this.hospitalsRepo.findOne({ where: { id } });
+    if (hospital && hospital.isActive === false) {
+      const isSuperAdmin = user.roles.includes('super_admin');
+      if (options?.write === false && isSuperAdmin) {
+        return id;
+      }
+      throw new ForbiddenException(
+        'This hospital is currently inactive; tenant access is unavailable',
+      );
+    }
+    return id;
+  }
+
+  resolveTenantHospitalId(
+    user: AuthenticatedUser,
+    hospitalId?: string,
+  ): string {
+    if (user.roles.includes('super_admin') && hospitalId) return hospitalId;
+    const id = hospitalId ?? user.hospitalId;
+    if (!id) throw new NotFoundException('Hospital context required');
+    this.assertHospitalAccess(user, id);
+    return id;
+  }
+
+  assertHospitalAccess(user: AuthenticatedUser, hospitalId: string) {
+    if (user.roles.includes('super_admin')) return;
+    if (!user.hospitalId || user.hospitalId !== hospitalId) {
+      throw new ForbiddenException('Access denied for this hospital');
+    }
+  }
+}

--- a/apps/api/src/dashboard/dashboard.resolver.ts
+++ b/apps/api/src/dashboard/dashboard.resolver.ts
@@ -8,11 +8,15 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { DashboardService } from './dashboard.service';
 import { DashboardStatsType } from './dashboard.types';
+import { HospitalContextService } from '../common/hospital-context.service';
 
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class DashboardResolver {
-  constructor(private readonly dashboardService: DashboardService) {}
+  constructor(
+    private readonly dashboardService: DashboardService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => DashboardStatsType)
   @Permissions(PERMISSIONS.REPORTS_READ)
@@ -20,9 +24,10 @@ export class DashboardResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<DashboardStatsType> {
-    const resolvedHospitalId = this.dashboardService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.dashboardService.getStats(resolvedHospitalId);
   }

--- a/apps/api/src/discharge/discharge.resolver.ts
+++ b/apps/api/src/discharge/discharge.resolver.ts
@@ -8,6 +8,7 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { DischargeService } from './discharge.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   CreateDischargeInput,
   CreateFollowUpInput,
@@ -29,7 +30,10 @@ const CHART_READ_ROLES = [
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class DischargeResolver {
-  constructor(private readonly dischargeService: DischargeService) {}
+  constructor(
+    private readonly dischargeService: DischargeService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [FollowUpType])
   @Roles(...CHART_READ_ROLES)
@@ -39,9 +43,10 @@ export class DischargeResolver {
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
     @Args('status', { nullable: true }) status?: string,
   ): Promise<FollowUpType[]> {
-    const resolvedHospitalId = this.dischargeService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.dischargeService.followUps(resolvedHospitalId, status);
   }
@@ -54,9 +59,10 @@ export class DischargeResolver {
     @Args('patientId') patientId: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<DischargeType[]> {
-    const resolvedHospitalId = this.dischargeService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.dischargeService.dischargesForPatient(
       resolvedHospitalId,
@@ -78,9 +84,10 @@ export class DischargeResolver {
     @Args('input') input: CreateDischargeInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<DischargeType> {
-    const resolvedHospitalId = this.dischargeService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.dischargeService.createDischarge(
       resolvedHospitalId,
@@ -104,9 +111,10 @@ export class DischargeResolver {
     @Args('input') input: CreateFollowUpInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<FollowUpType> {
-    const resolvedHospitalId = this.dischargeService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.dischargeService.createFollowUp(
       resolvedHospitalId,
@@ -130,9 +138,10 @@ export class DischargeResolver {
     @Args('input') input: UpdateFollowUpStatusInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<FollowUpType> {
-    const resolvedHospitalId = this.dischargeService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.dischargeService.updateFollowUpStatus(
       resolvedHospitalId,

--- a/apps/api/src/facility/facility.resolver.ts
+++ b/apps/api/src/facility/facility.resolver.ts
@@ -7,6 +7,7 @@ import type { AuthenticatedUser } from '../auth/auth.types';
 import { Permissions } from '../rbac/permissions.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { FacilityService } from './facility.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   BedType,
   CreateBedInput,
@@ -20,7 +21,10 @@ import {
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class FacilityResolver {
-  constructor(private readonly facilityService: FacilityService) {}
+  constructor(
+    private readonly facilityService: FacilityService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [DepartmentType])
   @Permissions(PERMISSIONS.HOSPITALS_READ)
@@ -28,9 +32,10 @@ export class FacilityResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<DepartmentType[]> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.facilityService.listDepartments(resolvedHospitalId);
   }
@@ -42,9 +47,10 @@ export class FacilityResolver {
     @Args('departmentId', { nullable: true }) departmentId?: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<WardType[]> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.facilityService.listWards(resolvedHospitalId, departmentId);
   }
@@ -56,9 +62,10 @@ export class FacilityResolver {
     @Args('wardId', { nullable: true }) wardId?: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<BedType[]> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.facilityService.listBeds(resolvedHospitalId, wardId);
   }
@@ -70,9 +77,10 @@ export class FacilityResolver {
     @Args('input') input: CreateDepartmentInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<DepartmentType> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.facilityService.createDepartment(
       resolvedHospitalId,
@@ -88,9 +96,10 @@ export class FacilityResolver {
     @Args('input') input: CreateWardInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<WardType> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.facilityService.createWard(resolvedHospitalId, input, user);
   }
@@ -102,9 +111,10 @@ export class FacilityResolver {
     @Args('input') input: CreateBedInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<BedType> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.facilityService.createBed(resolvedHospitalId, input, user);
   }
@@ -116,9 +126,10 @@ export class FacilityResolver {
     @Args('id') id: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<boolean> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.facilityService.deleteDepartment(resolvedHospitalId, id, user);
   }
@@ -130,9 +141,10 @@ export class FacilityResolver {
     @Args('id') id: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<boolean> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.facilityService.deleteWard(resolvedHospitalId, id, user);
   }
@@ -144,9 +156,10 @@ export class FacilityResolver {
     @Args('id') id: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<boolean> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.facilityService.deleteBed(resolvedHospitalId, id, user);
   }
@@ -158,9 +171,10 @@ export class FacilityResolver {
     @Args('input') input: UpdateBedStatusInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<BedType> {
-    const resolvedHospitalId = this.facilityService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.facilityService.updateBedStatus(
       resolvedHospitalId,

--- a/apps/api/src/inventory/inventory.resolver.ts
+++ b/apps/api/src/inventory/inventory.resolver.ts
@@ -8,6 +8,7 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { InventoryService } from './inventory.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   CreateInventoryItemInput,
   InventoryItemType,
@@ -23,7 +24,10 @@ const INVENTORY_ROLES = [
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class InventoryResolver {
-  constructor(private readonly inventoryService: InventoryService) {}
+  constructor(
+    private readonly inventoryService: InventoryService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [InventoryItemType])
   @Roles(...INVENTORY_ROLES)
@@ -32,9 +36,10 @@ export class InventoryResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<InventoryItemType[]> {
-    const resolvedHospitalId = this.inventoryService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.inventoryService.listInventoryItems(resolvedHospitalId);
   }
@@ -47,9 +52,10 @@ export class InventoryResolver {
     @Args('input') input: CreateInventoryItemInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<InventoryItemType> {
-    const resolvedHospitalId = this.inventoryService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.inventoryService.createInventoryItem(
       resolvedHospitalId,
@@ -66,9 +72,10 @@ export class InventoryResolver {
     @Args('input') input: UpdateInventoryQuantityInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<InventoryItemType> {
-    const resolvedHospitalId = this.inventoryService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.inventoryService.updateInventoryQuantity(
       resolvedHospitalId,

--- a/apps/api/src/patients/patients.resolver.ts
+++ b/apps/api/src/patients/patients.resolver.ts
@@ -8,6 +8,7 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { PatientsService } from './patients.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   BulkImportResultType,
   BulkPatientRowInput,
@@ -33,7 +34,10 @@ const CHART_READ_ROLES = [
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class PatientsResolver {
-  constructor(private readonly patientsService: PatientsService) {}
+  constructor(
+    private readonly patientsService: PatientsService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => PatientsPageType)
   @Roles(...CHART_READ_ROLES)
@@ -45,9 +49,10 @@ export class PatientsResolver {
     @Args('search', { nullable: true }) search?: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PatientsPageType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.patientsService.findAll(
       resolvedHospitalId,
@@ -65,9 +70,10 @@ export class PatientsResolver {
     @Args('id') id: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PatientDetailType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.patientsService.findById(id, resolvedHospitalId);
   }
@@ -87,9 +93,10 @@ export class PatientsResolver {
     @Args('input') input: CreatePatientInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PatientType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.patientsService.create(resolvedHospitalId, input, user);
   }
@@ -110,9 +117,10 @@ export class PatientsResolver {
     @Args('input') input: UpdatePatientInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PatientType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.patientsService.updatePatient(
       id,
@@ -130,9 +138,10 @@ export class PatientsResolver {
     @Args('id') id: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<boolean> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.patientsService.deletePatient(id, resolvedHospitalId, user);
   }
@@ -153,9 +162,10 @@ export class PatientsResolver {
     @Args('status') status: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PatientType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.patientsService.updatePatientStatus(
       id,
@@ -182,9 +192,10 @@ export class PatientsResolver {
     @Args('dryRun', { defaultValue: true }) dryRun: boolean,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<BulkImportResultType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.patientsService.bulkImport(
       resolvedHospitalId,
@@ -210,9 +221,10 @@ export class PatientsResolver {
     @Args('input') input: PatientDocumentInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PatientDocumentType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     const doc = await this.patientsService.addDocument(
       patientId,
@@ -246,9 +258,10 @@ export class PatientsResolver {
     @Args('patientId') patientId: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<boolean> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.patientsService.deletePatientDocument(
       id,
@@ -268,9 +281,10 @@ export class PatientsResolver {
     @Args('email', { nullable: true }) email?: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PatientType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.patientsService.linkPatientAccount(
       patientId,
@@ -289,9 +303,10 @@ export class PatientsResolver {
     @Args('patientId') patientId: string,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PatientType> {
-    const resolvedHospitalId = this.patientsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.patientsService.unlinkPatientAccount(
       patientId,

--- a/apps/api/src/pharmacy/pharmacy.resolver.ts
+++ b/apps/api/src/pharmacy/pharmacy.resolver.ts
@@ -8,6 +8,7 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { Roles } from '../rbac/roles.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { PharmacyService } from './pharmacy.service';
+import { HospitalContextService } from '../common/hospital-context.service';
 import {
   DispensePrescriptionInput,
   PendingPrescriptionType,
@@ -24,7 +25,10 @@ const PHARMACY_ROLES = [
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class PharmacyResolver {
-  constructor(private readonly pharmacyService: PharmacyService) {}
+  constructor(
+    private readonly pharmacyService: PharmacyService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [PharmacyStockType])
   @Roles(...PHARMACY_ROLES)
@@ -33,9 +37,10 @@ export class PharmacyResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PharmacyStockType[]> {
-    const resolvedHospitalId = this.pharmacyService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.pharmacyService.listPharmacyStock(resolvedHospitalId);
   }
@@ -47,9 +52,10 @@ export class PharmacyResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PendingPrescriptionType[]> {
-    const resolvedHospitalId = this.pharmacyService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.pharmacyService.listPendingPrescriptions(resolvedHospitalId);
   }
@@ -62,9 +68,10 @@ export class PharmacyResolver {
     @Args('input') input: UpsertPharmacyStockInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PharmacyStockType> {
-    const resolvedHospitalId = this.pharmacyService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.pharmacyService.upsertPharmacyStock(
       resolvedHospitalId,
@@ -81,9 +88,10 @@ export class PharmacyResolver {
     @Args('input') input: DispensePrescriptionInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<PendingPrescriptionType> {
-    const resolvedHospitalId = this.pharmacyService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     return this.pharmacyService.dispensePrescription(
       resolvedHospitalId,

--- a/apps/api/src/reports/reports.resolver.ts
+++ b/apps/api/src/reports/reports.resolver.ts
@@ -8,11 +8,15 @@ import { Permissions } from '../rbac/permissions.decorator';
 import { RolesGuard } from '../rbac/roles.guard';
 import { ReportsService } from './reports.service';
 import { HospitalReportsType } from './reports.types';
+import { HospitalContextService } from '../common/hospital-context.service';
 
 @Resolver()
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class ReportsResolver {
-  constructor(private readonly reportsService: ReportsService) {}
+  constructor(
+    private readonly reportsService: ReportsService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => HospitalReportsType)
   @Permissions(PERMISSIONS.REPORTS_READ)
@@ -20,9 +24,10 @@ export class ReportsResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<HospitalReportsType> {
-    const resolvedHospitalId = this.reportsService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     return this.reportsService.getHospitalReports(resolvedHospitalId);
   }

--- a/apps/api/src/staff/staff.resolver.ts
+++ b/apps/api/src/staff/staff.resolver.ts
@@ -1,4 +1,4 @@
-import { UseGuards } from '@nestjs/common';
+import { NotFoundException, UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { PERMISSIONS, ROLES } from '@careconnect/types';
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
@@ -76,6 +76,11 @@ export class StaffResolver {
     @Args('id') id: string,
     @Args('input') input: UpdateStaffInput,
   ): Promise<StaffType> {
+    const existing = await this.staffService.findByIdForUser(id, user);
+    if (!existing) throw new NotFoundException('Staff member not found');
+    await this.hospitalContext.resolveHospitalId(user, existing.hospitalId, {
+      write: true,
+    });
     const member = await this.staffService.update(id, input, user);
     const full = await this.staffService.findById(member.id);
     return this.staffService.toStaffType(full!);
@@ -88,6 +93,11 @@ export class StaffResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('id') id: string,
   ): Promise<StaffType> {
+    const existing = await this.staffService.findByIdForUser(id, user);
+    if (!existing) throw new NotFoundException('Staff member not found');
+    await this.hospitalContext.resolveHospitalId(user, existing.hospitalId, {
+      write: true,
+    });
     const member = await this.staffService.resendStaffInvite(id, user);
     const inviteToken = member.inviteToken;
     const full = await this.staffService.findById(member.id);
@@ -101,6 +111,11 @@ export class StaffResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('id') id: string,
   ): Promise<boolean> {
+    const existing = await this.staffService.findByIdForUser(id, user);
+    if (!existing) throw new NotFoundException('Staff member not found');
+    await this.hospitalContext.resolveHospitalId(user, existing.hospitalId, {
+      write: true,
+    });
     return this.staffService.remove(id, user);
   }
 

--- a/apps/api/src/staff/staff.resolver.ts
+++ b/apps/api/src/staff/staff.resolver.ts
@@ -10,11 +10,15 @@ import { RolesGuard } from '../rbac/roles.guard';
 import { AllowAuthenticated } from '../rbac/allow-authenticated.decorator';
 import { StaffService } from './staff.service';
 import { CreateStaffInput, StaffType, UpdateStaffInput } from './staff.types';
+import { HospitalContextService } from '../common/hospital-context.service';
 
 @Resolver(() => StaffType)
 @UseGuards(GqlAuthGuard, RolesGuard)
 export class StaffResolver {
-  constructor(private readonly staffService: StaffService) {}
+  constructor(
+    private readonly staffService: StaffService,
+    private readonly hospitalContext: HospitalContextService,
+  ) {}
 
   @Query(() => [StaffType])
   @Permissions(PERMISSIONS.STAFF_READ)
@@ -22,9 +26,10 @@ export class StaffResolver {
     @CurrentUser() user: AuthenticatedUser,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<StaffType[]> {
-    const resolvedHospitalId = this.staffService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: false },
     );
     const members = await this.staffService.findByHospital(resolvedHospitalId);
     return members.map((m) => this.staffService.toStaffType(m));
@@ -48,9 +53,10 @@ export class StaffResolver {
     @Args('input') input: CreateStaffInput,
     @Args('hospitalId', { nullable: true }) hospitalId?: string,
   ): Promise<StaffType> {
-    const resolvedHospitalId = this.staffService.resolveHospitalId(
+    const resolvedHospitalId = await this.hospitalContext.resolveHospitalId(
       user,
       hospitalId,
+      { write: true },
     );
     const member = await this.staffService.create(
       resolvedHospitalId,

--- a/apps/api/src/users/users.resolver.spec.ts
+++ b/apps/api/src/users/users.resolver.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from '../auth/auth.service';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { UsersResolver } from './users.resolver';
+
+describe('UsersResolver', () => {
+  let resolver: UsersResolver;
+  const authService = {
+    completeOnboarding: jest.fn(),
+    completePatientOnboarding: jest.fn(),
+    syncAndGetUser: jest.fn(),
+  };
+
+  const user: AuthenticatedUser = {
+    id: 'user-1',
+    authId: 'auth-1',
+    email: 'admin@hospital.com',
+    fullName: 'Admin',
+    hospitalId: 'hospital-a',
+    hospitalActive: true,
+    roles: ['hospital_admin'],
+    permissions: ['patients:read'],
+    onboardingCompleted: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersResolver,
+        { provide: AuthService, useValue: authService },
+      ],
+    }).compile();
+    resolver = module.get(UsersResolver);
+  });
+
+  it('reports hospitalActive from AuthService without fail-open default', () => {
+    expect(resolver.me(user).hospitalActive).toBe(true);
+    expect(resolver.me({ ...user, hospitalActive: false }).hospitalActive).toBe(
+      false,
+    );
+  });
+
+  it('treats missing hospitalActive as inactive', () => {
+    expect(
+      resolver.me({ ...user, hospitalActive: undefined }).hospitalActive,
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/users/users.resolver.ts
+++ b/apps/api/src/users/users.resolver.ts
@@ -21,7 +21,9 @@ export class UsersResolver {
       email: user.email,
       fullName: user.fullName,
       hospitalId: user.hospitalId,
-      hospitalActive: user.hospitalActive ?? true,
+      // Fail closed: AuthService.toAuthenticatedUser always sets this flag.
+      // Missing/undefined must not look active (#284).
+      hospitalActive: user.hospitalActive === true,
       roles: user.roles,
       permissions: user.permissions,
       onboardingCompleted: user.onboardingCompleted,
@@ -52,7 +54,7 @@ export class UsersResolver {
       email: refreshed!.email,
       fullName: refreshed!.fullName,
       hospitalId: refreshed!.hospitalId,
-      hospitalActive: refreshed!.hospitalActive ?? true,
+      hospitalActive: refreshed!.hospitalActive === true,
       roles: refreshed!.roles,
       permissions: refreshed!.permissions,
       onboardingCompleted: true,
@@ -75,7 +77,7 @@ export class UsersResolver {
       email: refreshed!.email,
       fullName: refreshed!.fullName,
       hospitalId: refreshed!.hospitalId,
-      hospitalActive: refreshed!.hospitalActive ?? true,
+      hospitalActive: refreshed!.hospitalActive === true,
       roles: refreshed!.roles,
       permissions: refreshed!.permissions,
       onboardingCompleted: true,


### PR DESCRIPTION
## Summary
- GraphQL tenant resolvers now go through `HospitalContextService.resolveHospitalId`, which looks up the hospital and throws Forbidden when `isActive === false`. Super_admin may still **read** across inactive hospitals; **writes** are refused.
- `me.hospitalActive` (and onboarding refresh) fails closed with `hospitalActive === true`. `AuthService.toAuthenticatedUser` always sets the flag (`true` when unbound, `!!hospital.isActive` when bound), so active hospitals are not locked out.

Closes #284

## Test plan
- [ ] Unit: `HospitalContextService` inactive write/read cases (tenant + super_admin)
- [ ] Unit: `UsersResolver.me` missing `hospitalActive` reports `false`
- [ ] Super_admin `createPatient` (or similar mutation) against an inactive `hospitalId` is Forbidden
- [ ] Super_admin `patients` query against an inactive hospital still succeeds
- [ ] Hospital staff on an inactive tenant still see the dashboard lock (`me.hospitalActive === false`)
- [ ] Super_admin can still `updateHospital` to reactivate (path does not use resolveHospitalId)
- [ ] Unbound onboarding user (`hospitalId` unset) still gets `hospitalActive: true` from auth sync


Made with [Cursor](https://cursor.com)