### PR TITLE
fix(web): parse quoted multiline CSV fields

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node --experimental-strip-types --test src/lib/csv-parser.spec.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:install": "playwright install chromium"

--- a/apps/web/src/lib/csv-parser.spec.ts
+++ b/apps/web/src/lib/csv-parser.spec.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseCsvRecords, parsePatientCsv } from './csv-parser.ts';
+
+describe('parseCsvRecords', () => {
+  it('parses a simple unquoted CSV', () => {
+    const records = parseCsvRecords('a,b,c\n1,2,3\n');
+    assert.deepEqual(records, [
+      ['a', 'b', 'c'],
+      ['1', '2', '3'],
+    ]);
+  });
+
+  it('keeps commas inside quoted fields', () => {
+    const records = parseCsvRecords('name,city\n"Doe, Jane",Springfield');
+    assert.deepEqual(records, [
+      ['name', 'city'],
+      ['Doe, Jane', 'Springfield'],
+    ]);
+  });
+
+  it('unescapes doubled quotes inside quoted fields', () => {
+    const records = parseCsvRecords('name\n"Jane ""JJ"" Doe"');
+    assert.deepEqual(records, [['name'], ['Jane "JJ" Doe']]);
+  });
+
+  it('keeps newlines inside quoted fields as a single record', () => {
+    const csv = 'full_name,address\n"Jane Doe","123 Main St\nApt 4"\nBob,Oak Ave';
+    const records = parseCsvRecords(csv);
+    assert.deepEqual(records, [
+      ['full_name', 'address'],
+      ['Jane Doe', '123 Main St\nApt 4'],
+      ['Bob', 'Oak Ave'],
+    ]);
+  });
+
+  it('supports CRLF record separators and CR inside quoted fields', () => {
+    const csv = 'full_name,notes\r\n"Jane Doe","line1\r\nline2"\r\nBob,ok';
+    const records = parseCsvRecords(csv);
+    assert.deepEqual(records, [
+      ['full_name', 'notes'],
+      ['Jane Doe', 'line1\r\nline2'],
+      ['Bob', 'ok'],
+    ]);
+  });
+});
+
+describe('parsePatientCsv', () => {
+  it('maps a standard unquoted patient row', () => {
+    const csv = [
+      'full_name,email,phone,dob,gender',
+      'John Doe,john@email.com,555-0100,1990-01-15,male',
+    ].join('\n');
+
+    const rows = parsePatientCsv(csv);
+    assert.equal(rows.length, 1);
+    assert.deepEqual(rows[0], {
+      fullName: 'John Doe',
+      email: 'john@email.com',
+      phone: '555-0100',
+      dateOfBirth: '1990-01-15',
+      gender: 'male',
+      bloodGroup: undefined,
+      address: undefined,
+      city: undefined,
+      emergencyContactName: undefined,
+      emergencyContactPhone: undefined,
+      insuranceProvider: undefined,
+      insurancePolicyNumber: undefined,
+      allergies: undefined,
+      identificationType: undefined,
+      identificationNumber: undefined,
+    });
+  });
+
+  it('maps a quoted multiline address onto a single patient row', () => {
+    const csv = [
+      'full_name,address,city',
+      '"Jane Doe","123 Main St\nApt 4B",Springfield',
+    ].join('\n');
+
+    const rows = parsePatientCsv(csv);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]?.fullName, 'Jane Doe');
+    assert.equal(rows[0]?.address, '123 Main St\nApt 4B');
+    assert.equal(rows[0]?.city, 'Springfield');
+  });
+});

--- a/apps/web/src/lib/csv-parser.ts
+++ b/apps/web/src/lib/csv-parser.ts
@@ -18,14 +18,33 @@ const EXPECTED_HEADERS = [
   'identification_number',
 ];
 
-function parseCsvLine(line: string): string[] {
-  const values: string[] = [];
+/**
+ * RFC 4180-ish CSV record parser: quoted fields may contain commas, quotes
+ * (`""` escapes), and newlines. Unquoted newlines still start a new record.
+ */
+export function parseCsvRecords(text: string): string[][] {
+  const records: string[][] = [];
+  let row: string[] = [];
   let current = '';
   let inQuotes = false;
 
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-    const next = line[i + 1];
+  const pushField = () => {
+    row.push(current.trim());
+    current = '';
+  };
+
+  const pushRow = () => {
+    if (row.length === 1 && row[0] === '') {
+      row = [];
+      return;
+    }
+    records.push(row);
+    row = [];
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const next = text[i + 1];
 
     if (inQuotes) {
       if (char === '"') {
@@ -41,26 +60,39 @@ function parseCsvLine(line: string): string[] {
     } else if (char === '"') {
       inQuotes = true;
     } else if (char === ',') {
-      values.push(current.trim());
-      current = '';
+      pushField();
+    } else if (char === '\n') {
+      pushField();
+      pushRow();
+    } else if (char === '\r') {
+      if (next === '\n') continue;
+      pushField();
+      pushRow();
     } else {
       current += char;
     }
   }
 
-  values.push(current.trim());
-  return values;
+  if (current.length > 0 || row.length > 0) {
+    pushField();
+    pushRow();
+  }
+
+  return records;
 }
 
 export function parsePatientCsv(text: string): BulkPatientRow[] {
-  const lines = text.trim().split(/\r?\n/).filter(Boolean);
-  if (lines.length < 2) return [];
+  const records = parseCsvRecords(text.trim());
+  if (records.length < 2) return [];
 
-  const headers = parseCsvLine(lines[0]).map((h) => h.toLowerCase().replace(/\s+/g, '_'));
+  const headerRow = records[0];
+  if (!headerRow) return [];
+
+  const headers = headerRow.map((h) => h.toLowerCase().replace(/\s+/g, '_'));
   const rows: BulkPatientRow[] = [];
 
-  for (let i = 1; i < lines.length; i++) {
-    const values = parseCsvLine(lines[i]);
+  for (let i = 1; i < records.length; i++) {
+    const values = records[i] ?? [];
     const row: Record<string, string> = {};
     headers.forEach((h, idx) => {
       row[h] = values[idx] ?? '';


### PR DESCRIPTION
## Summary
- Patient CSV parsing now handles RFC 4180 quoted fields, including commas, escaped quotes, and embedded newlines.
- Simple unquoted CSVs keep working; empty lines are still skipped.
- Adds `csv-parser.spec.ts` next to the parser (`pnpm --filter web test`).

Closes #276.

## Test plan
- [ ] Import an unquoted patient CSV and confirm rows map as before
- [ ] Import a quoted address that contains a newline and confirm it lands on one patient row
- [ ] Import a quoted name with doubled quotes (`""`) and confirm a single `"` is stored
- [ ] `pnpm --filter web test`


Made with [Cursor](https://cursor.com)