### PR TITLE
fix(auth): require verified email before binding pending staff

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -23,11 +23,39 @@ describe('AuthService', () => {
     create: jest.fn(),
     save: jest.fn(),
     update: jest.fn(),
+    createQueryBuilder: jest.fn(),
     manager: {
       transaction: jest.fn((cb: (m: typeof manager) => unknown) =>
         Promise.resolve(cb(manager)),
       ),
     },
+  };
+
+  function stubEmailLookup(user: Record<string, unknown> | null) {
+    usersRepo.createQueryBuilder.mockReturnValue({
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(user),
+    });
+  }
+
+  const pendingStaff = {
+    id: 'pending-user-1',
+    authId: 'pending_abc123',
+    email: 'invited@hospital.com',
+    fullName: 'Invited Staff',
+    hospitalId: 'hospital-a',
+    isActive: true,
+    onboardingCompleted: false,
+    userRoles: [
+      {
+        hospitalId: 'hospital-a',
+        role: {
+          slug: 'nurse',
+          permissions: [{ slug: 'patients:read' }],
+        },
+      },
+    ],
   };
 
   const userRolesRepo = {
@@ -136,6 +164,60 @@ describe('AuthService', () => {
         permissions: ['patients:read'],
         onboardingCompleted: true,
       });
+    });
+
+    it('does not bind pending_* staff when email is unverified', async () => {
+      usersRepo.findOne.mockResolvedValue(null);
+      stubEmailLookup(pendingStaff);
+
+      await expect(
+        service.syncAndGetUser('user_attacker', 'invited@hospital.com', false),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.syncAndGetUser('user_attacker', 'invited@hospital.com', false),
+      ).rejects.toThrow('Email address is not verified');
+      expect(usersRepo.update).not.toHaveBeenCalled();
+      expect(usersRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('does not bind pending_* staff when email_verified claim is missing', async () => {
+      usersRepo.findOne.mockResolvedValue(null);
+      stubEmailLookup(pendingStaff);
+
+      await expect(
+        service.syncAndGetUser('user_attacker', 'invited@hospital.com'),
+      ).rejects.toThrow('Email address is not verified');
+      expect(usersRepo.update).not.toHaveBeenCalled();
+      expect(usersRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('binds pending_* staff when email is verified', async () => {
+      usersRepo.findOne.mockResolvedValue(null);
+      stubEmailLookup({ ...pendingStaff });
+      hospitalsRepo.findOne.mockResolvedValue({
+        id: 'hospital-a',
+        isActive: true,
+      });
+
+      const result = await service.syncAndGetUser(
+        'user_clerk_invited',
+        'invited@hospital.com',
+        true,
+      );
+
+      expect(usersRepo.update).toHaveBeenCalledWith('pending-user-1', {
+        authId: 'user_clerk_invited',
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'pending-user-1',
+          authId: 'user_clerk_invited',
+          email: 'invited@hospital.com',
+          hospitalId: 'hospital-a',
+          roles: ['nurse'],
+        }),
+      );
+      expect(usersRepo.save).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -45,13 +45,15 @@ export class AuthService {
   async syncAndGetUser(
     authId: string,
     email?: string,
+    emailVerified = false,
   ): Promise<AuthenticatedUser | null> {
     let user = await this.usersRepo.findOne({
       where: { authId },
       relations: ['userRoles', 'userRoles.role', 'userRoles.role.permissions'],
     });
 
-    // Link invited staff who were created with a different auth_id placeholder
+    // Link invited staff who were created with a different auth_id placeholder.
+    // Email uniqueness is global, so this never binds a row from another hospital.
     if (!user && email) {
       user = await this.usersRepo
         .createQueryBuilder('user')
@@ -63,9 +65,15 @@ export class AuthService {
       if (user) {
         // Only reclaim pending invite placeholders — never steal an active Clerk-linked account
         const isPending = user.authId.startsWith('pending_');
-        if (isPending || user.authId === authId) {
+        if (isPending) {
+          if (!emailVerified) {
+            // Fail closed: missing or false email_verified must not claim an invite slot
+            throw new UnauthorizedException('Email address is not verified');
+          }
           await this.usersRepo.update(user.id, { authId });
           user.authId = authId;
+        } else if (user.authId === authId) {
+          await this.usersRepo.update(user.id, { authId });
         } else {
           // Fail closed: do not create a duplicate users row for the same email
           throw new UnauthorizedException(

--- a/apps/api/src/auth/clerk-jwt.payload.spec.ts
+++ b/apps/api/src/auth/clerk-jwt.payload.spec.ts
@@ -1,0 +1,79 @@
+import { extractEmail, isEmailVerified } from './clerk-jwt.payload';
+
+describe('Clerk JWT payload helpers', () => {
+  describe('extractEmail', () => {
+    it('prefers top-level email', () => {
+      expect(
+        extractEmail({
+          sub: 'user_1',
+          email: 'primary@hospital.com',
+          email_address: 'other@hospital.com',
+        }),
+      ).toBe('primary@hospital.com');
+    });
+  });
+
+  describe('isEmailVerified', () => {
+    it('returns true when email_verified is boolean true', () => {
+      expect(
+        isEmailVerified({
+          sub: 'user_1',
+          email: 'staff@hospital.com',
+          email_verified: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when email_verified is boolean false', () => {
+      expect(
+        isEmailVerified({
+          sub: 'user_1',
+          email: 'staff@hospital.com',
+          email_verified: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when email_verified claim is missing', () => {
+      expect(
+        isEmailVerified({
+          sub: 'user_1',
+          email: 'staff@hospital.com',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns true when nested email_addresses verification is verified', () => {
+      expect(
+        isEmailVerified({
+          sub: 'user_1',
+          email_addresses: [
+            {
+              email_address: 'staff@hospital.com',
+              verification: { status: 'verified' },
+            },
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it('does not treat a different nested address as verified for the bind email', () => {
+      expect(
+        isEmailVerified({
+          sub: 'user_1',
+          email: 'attacker@hospital.com',
+          email_addresses: [
+            {
+              email_address: 'attacker@hospital.com',
+              verification: { status: 'unverified' },
+            },
+            {
+              email_address: 'victim@hospital.com',
+              verification: { status: 'verified' },
+            },
+          ],
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/auth/clerk-jwt.payload.ts
+++ b/apps/api/src/auth/clerk-jwt.payload.ts
@@ -1,0 +1,59 @@
+import type { JwtPayload } from './auth.types';
+
+export interface ClerkJwtPayload extends JwtPayload {
+  email?: string;
+  email_address?: string;
+  primary_email_address?: string;
+  primary_email_address_id?: string;
+  email_verified?: boolean | string;
+  email_addresses?: Array<{
+    id?: string;
+    email_address?: string;
+    verification?: { status?: string };
+  }>;
+  first_name?: string;
+  last_name?: string;
+  full_name?: string;
+  username?: string;
+  org_id?: string;
+  org_slug?: string;
+  org_role?: string;
+}
+
+export function extractEmail(payload: ClerkJwtPayload): string | undefined {
+  if (payload.email) return payload.email;
+  if (payload.email_address) return payload.email_address;
+  if (payload.primary_email_address) return payload.primary_email_address;
+
+  const list = payload.email_addresses;
+  if (Array.isArray(list) && list.length > 0) {
+    const primaryId = payload.primary_email_address_id;
+    const primary =
+      (primaryId ? list.find((entry) => entry?.id === primaryId) : undefined) ??
+      list[0];
+    if (primary?.email_address) return primary.email_address;
+  }
+
+  return undefined;
+}
+
+/** Fail closed: missing or unrecognized claims are unverified. */
+export function isEmailVerified(payload: ClerkJwtPayload): boolean {
+  if (payload.email_verified === true || payload.email_verified === 'true') {
+    return true;
+  }
+  if (payload.email_verified === false || payload.email_verified === 'false') {
+    return false;
+  }
+
+  const email = extractEmail(payload);
+  const list = payload.email_addresses;
+  if (!email || !Array.isArray(list)) return false;
+
+  const matched = list.find(
+    (entry) =>
+      typeof entry?.email_address === 'string' &&
+      entry.email_address.toLowerCase() === email.toLowerCase(),
+  );
+  return matched?.verification?.status === 'verified';
+}

--- a/apps/api/src/auth/clerk-jwt.strategy.ts
+++ b/apps/api/src/auth/clerk-jwt.strategy.ts
@@ -4,7 +4,12 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import jwksRsa from 'jwks-rsa';
 import { AuthService } from './auth.service';
-import type { AuthenticatedUser, JwtPayload } from './auth.types';
+import type { AuthenticatedUser } from './auth.types';
+import {
+  extractEmail,
+  isEmailVerified,
+  type ClerkJwtPayload,
+} from './clerk-jwt.payload';
 
 /**
  * Clerk session tokens are RS256-signed JWTs. Public keys are published at
@@ -70,7 +75,11 @@ export class ClerkJwtStrategy extends PassportStrategy(Strategy, 'clerk-jwt') {
     }
 
     const email = extractEmail(payload);
-    const user = await this.authService.syncAndGetUser(payload.sub, email);
+    const user = await this.authService.syncAndGetUser(
+      payload.sub,
+      email,
+      isEmailVerified(payload),
+    );
 
     if (!user) {
       throw new UnauthorizedException('User not found');
@@ -78,36 +87,4 @@ export class ClerkJwtStrategy extends PassportStrategy(Strategy, 'clerk-jwt') {
 
     return user;
   }
-}
-
-export interface ClerkJwtPayload extends JwtPayload {
-  email?: string;
-  email_address?: string;
-  primary_email_address?: string;
-  primary_email_address_id?: string;
-  email_addresses?: Array<{ id?: string; email_address?: string }>;
-  first_name?: string;
-  last_name?: string;
-  full_name?: string;
-  username?: string;
-  org_id?: string;
-  org_slug?: string;
-  org_role?: string;
-}
-
-function extractEmail(payload: ClerkJwtPayload): string | undefined {
-  if (payload.email) return payload.email;
-  if (payload.email_address) return payload.email_address;
-  if (payload.primary_email_address) return payload.primary_email_address;
-
-  const list = payload.email_addresses;
-  if (Array.isArray(list) && list.length > 0) {
-    const primaryId = payload.primary_email_address_id;
-    const primary =
-      (primaryId ? list.find((entry) => entry?.id === primaryId) : undefined) ??
-      list[0];
-    if (primary?.email_address) return primary.email_address;
-  }
-
-  return undefined;
 }


### PR DESCRIPTION
## Summary
- Fail closed on `pending_*` staff email-bind unless the Clerk JWT proves the email is verified (`email_verified` true, or nested `email_addresses[].verification.status === 'verified'` for the bind email).
- Missing `email_verified` is treated as unverified, so an attacker cannot take over an invited staff slot with an unverified claim. Invite → login still works when Clerk issues a verified email after invite acceptance.
- Bind remains on the existing unique-email user row (one hospital); no cross-hospital takeover.

Closes #280

## Test plan
- [x] `pnpm --filter api test -- src/auth/auth.service.spec.ts src/auth/clerk-jwt.payload.spec.ts`
- [ ] Unverified JWT email matching a `pending_*` staff row is rejected and does not update `authId`
- [ ] Verified JWT email binds the pending staff row on first login after Clerk invite
- [ ] JWT with no `email_verified` claim does not bind pending staff
- [ ] Existing patient/staff login by Clerk `sub` is unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for securely extracting email addresses and verification status from authentication tokens.
  * Verified email addresses can now reclaim pending invitations and link to existing accounts.
* **Bug Fixes**
  * Prevented unverified or missing-verification email claims from binding pending accounts.
  * Improved handling of existing accounts already linked to the same authentication identity.
* **Tests**
  * Added coverage for email extraction, verification scenarios, pending-account binding, and security failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->